### PR TITLE
fix windows build failure due to package autodiscovery

### DIFF
--- a/setup-windows.py
+++ b/setup-windows.py
@@ -5,14 +5,16 @@ from cx_Freeze import setup, Executable
 with open("share/version.txt") as f:
     version = f.read().strip()
 
+packages = ["dangerzone", "dangerzone.gui"]
 
 setup(
     name="dangerzone",
     version=version,
     description="Take potentially dangerous PDFs, office documents, or images and convert them to a safe PDF",
+    packages=packages,
     options={
         "build_exe": {
-            "packages": ["dangerzone", "dangerzone.gui"],
+            "packages": packages,
             "excludes": ["test", "tkinter"],
             "include_files": [("share", "share"), ("LICENSE", "LICENSE")],
             "include_msvcr": True,


### PR DESCRIPTION
Setuptools was trying to autodiscover packages with an error
described in #178 [1]. Adding the packages arg to setup() solves
it. In the future we may want to centralize the package list in
a pyproject.toml, once it goes out of beta in setuptools [2].

Fixes #178

[1]: https://github.com/freedomofpress/dangerzone/issues/178
[2]: https://setuptools.pypa.io/en/latest/userguide/package_discovery.html?highlight=package%20discovery#package-discovery-and-namespace-packages