### PR TITLE
Add linting to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,28 @@ aliases:
       fi
 
 jobs:
+  run-lint:
+    docker:
+      - image: debian:bullseye
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Install dev. dependencies
+          command: |
+            export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+            apt-get update
+            apt-get install -y make python3 python3-pip python3-venv
+            python3 -m venv .venv
+            source .venv/bin/activate
+            pip install poetry
+            poetry install  # FIXME --dev-only once poetry 1.2.0 is out https://github.com/python-poetry/poetry/issues/2572
+      - run:
+          name: Run linters to enforce code style
+          command: |
+            source .venv/bin/activate
+            make lint
+
   build-container-image:
     working_directory: /app
     docker:
@@ -291,6 +313,7 @@ workflows:
 
   build:
     jobs:
+      - run-lint
       - build-container-image
       - convert-test-docs:
           requires:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: lint-black
+lint-black: ## check python source code formatting issues, with black
+	black --check --diff ./
+
+.PHONY: lint-black-apply
+lint-black-apply: ## apply black's source code formatting suggestions
+	black ./
+
+.PHONY: lint-isort
+lint-isort: ## check imports are organized, with isort
+	isort --check-only ./
+
+.PHONY: lint-isort-apply
+lint-isort-apply: ## apply isort's imports organization suggestions
+	isort ./
+
+.PHONY: lint
+lint: lint-black lint-isort ## check the code with various linters
+
+.PHONY: lint-apply
+lint-apply: lint-black-apply lint-isort-apply ## apply all the linter's suggestions
+
+# Makefile self-help borrowed from the securedrop-client project
+# Explaination of the below shell command should it ever break.
+# 1. Set the field separator to ": ##" and any make targets that might appear between : and ##
+# 2. Use sed-like syntax to remove the make targets
+# 3. Format the split fields into $$1) the target name (in blue) and $$2) the target descrption
+# 4. Pass this file as an arg to awk
+# 5. Sort it alphabetically
+# 6. Format columns with colon as delimiter.
+.PHONY: help
+help: ## Print this message and exit.
+	@printf "Makefile for developing and testing dangerzone.\n"
+	@printf "Subcommands:\n\n"
+	@awk 'BEGIN {FS = ":.*?## "} /^[0-9a-zA-Z_-]+:.*?## / {printf "\033[36m%s\033[0m : %s\n", $$1, $$2}' $(MAKEFILE_LIST) \
+		| sort \
+		| column -s ':' -t

--- a/container/dangerzone.py
+++ b/container/dangerzone.py
@@ -12,12 +12,12 @@ pixels_to_pdf:
 - 95%-100%: Compress the final PDF
 """
 
-import sys
-import subprocess
 import glob
-import os
 import json
+import os
 import shutil
+import subprocess
+import sys
 
 import magic
 from PIL import Image

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -1,13 +1,14 @@
+import json
+import logging
 import os
 import sys
-import json
+
 import click
-import logging
 from colorama import Fore, Style
 
-from .global_common import GlobalCommon
 from .common import Common
 from .container import convert
+from .global_common import GlobalCommon
 
 
 def print_header(s):

--- a/dangerzone/common.py
+++ b/dangerzone/common.py
@@ -1,7 +1,8 @@
 import os
-import stat
 import platform
+import stat
 import tempfile
+
 import appdirs
 
 

--- a/dangerzone/container.py
+++ b/dangerzone/container.py
@@ -1,10 +1,11 @@
-import platform
-import subprocess
-import pipes
-import shutil
 import logging
 import os
+import pipes
+import platform
+import shutil
+import subprocess
 import tempfile
+
 import appdirs
 
 # What container tech is used for this platform?

--- a/dangerzone/global_common.py
+++ b/dangerzone/global_common.py
@@ -398,16 +398,15 @@ class GlobalCommon(object):
             prefix = project_root.joinpath("share")
         else:
             if platform.system() == "Darwin":
-                bin_path = pathlib.Path(sys.executable)           # /path/to/Dangerzone.app/Contents/MacOS/dangerzone[-cli]
-                app_path = bin_path.parent.parent                 # /path/to/Dangerzone.app/Contents
-                prefix = app_path.joinpath("Resources", "share")  # /path/to/Dangerzone.app/Contents/Resources/share
+                bin_path = pathlib.Path(sys.executable)
+                app_path = bin_path.parent.parent
+                prefix = app_path.joinpath("Resources", "share")
             elif platform.system() == "Linux":
-                prefix = pathlib.Path(sys.prefix)\
-                                .joinpath("share", "dangerzone")  # /usr/share/dangerzone
+                prefix = pathlib.Path(sys.prefix).joinpath("share", "dangerzone")
             elif platform.system() == "Windows":
-                exe_path = pathlib.Path(sys.executable)           # c:\Program Files (x86)\Dangerzone\dangerzone.exe
-                dz_install_path = exe_path.parent                 # c:\Program Files (x86)\Dangerzone\
-                prefix = dz_install_path.joinpath("share")        # c:\Program Files (x86)\Dangerzone\share
+                exe_path = pathlib.Path(sys.executable)
+                dz_install_path = exe_path.parent
+                prefix = dz_install_path.joinpath("share")
             else:
                 raise NotImplementedError(f"Unsupported system {platform.system()}")
         resource_path = prefix.joinpath(filename)

--- a/dangerzone/global_common.py
+++ b/dangerzone/global_common.py
@@ -1,17 +1,20 @@
-import sys
-import appdirs
+import gzip
+import inspect
+import json
+import logging
+import os
 import pathlib
 import platform
-import subprocess
 import shutil
-import json
-import gzip
-import colorama
-from colorama import Fore, Back, Style
-import logging
+import subprocess
+import sys
 
-from .settings import Settings
+import appdirs
+import colorama
+from colorama import Back, Fore, Style
+
 from .container import convert
+from .settings import Settings
 
 log = logging.getLogger(__name__)
 

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -1,16 +1,17 @@
-import os
-import sys
-import signal
-import platform
-import click
-import uuid
 import logging
+import os
+import platform
+import signal
+import sys
+import uuid
+
+import click
 from PySide2 import QtCore, QtWidgets
 
+from ..global_common import GlobalCommon
 from .common import GuiCommon
 from .main_window import MainWindow
 from .systray import SysTray
-from ..global_common import GlobalCommon
 
 
 # For some reason, Dangerzone segfaults if I inherit from QApplication directly, so instead

--- a/dangerzone/gui/common.py
+++ b/dangerzone/gui/common.py
@@ -1,11 +1,12 @@
-import os
-import platform
-import subprocess
-import shlex
-import pipes
-from PySide2 import QtCore, QtGui, QtWidgets
-from colorama import Fore
 import logging
+import os
+import pipes
+import platform
+import shlex
+import subprocess
+
+from colorama import Fore
+from PySide2 import QtCore, QtGui, QtWidgets
 
 if platform.system() == "Darwin":
     import plistlib

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -1,12 +1,13 @@
+import json
+import logging
 import os
 import platform
-import tempfile
-import subprocess
-import json
 import shutil
-import logging
+import subprocess
+import tempfile
+
+from colorama import Fore, Style
 from PySide2 import QtCore, QtGui, QtWidgets
-from colorama import Style, Fore
 
 from ..common import Common
 from ..container import convert

--- a/dangerzone/gui/systray.py
+++ b/dangerzone/gui/systray.py
@@ -1,4 +1,5 @@
 import platform
+
 from PySide2 import QtWidgets
 
 

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -1,7 +1,6 @@
-import os
 import json
-import appdirs
 import logging
+import os
 
 log = logging.getLogger(__name__)
 

--- a/dev_scripts/dangerzone
+++ b/dev_scripts/dangerzone
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 
 # Load dangerzone module and resources from the source code tree
-import os, sys
+import os
+import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.dangerzone_dev = True

--- a/install/linux/build-deb.py
+++ b/install/linux/build-deb.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import os
-import sys
 import inspect
-import subprocess
+import os
 import shutil
+import subprocess
+import sys
 
 root = os.path.dirname(
     os.path.dirname(

--- a/install/linux/build-rpm.py
+++ b/install/linux/build-rpm.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import os
-import sys
 import inspect
-import subprocess
+import os
 import shutil
-
+import subprocess
+import sys
 
 root = os.path.dirname(
     os.path.dirname(

--- a/install/macos/build-app.py
+++ b/install/macos/build-app.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import os
-import inspect
-import subprocess
-import shutil
 import argparse
 import glob
+import inspect
 import itertools
+import os
+import shutil
+import subprocess
 
 root = os.path.dirname(
     os.path.dirname(

--- a/install/pyinstaller/dangerzone
+++ b/install/pyinstaller/dangerzone
@@ -5,7 +5,9 @@
 # to open in macOS when double-clicking, not just when running from the terminal or opening
 # with a file.
 import os
+
 os.environ["LANG"] = "en_US.UTF-8"
 
 import dangerzone
+
 dangerzone.main()

--- a/install/windows/build-image.py
+++ b/install/windows/build-image.py
@@ -1,6 +1,6 @@
-import subprocess
 import gzip
 import os
+import subprocess
 
 
 def main():

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,6 +70,7 @@ cx-logging = {version = ">=3.0", markers = "sys_platform == \"win32\" and python
 importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
 lief = {version = ">=0.11.5", markers = "sys_platform == \"win32\" and python_version <= \"3.10\""}
 packaging = ">=21.0"
+patchelf = {version = ">=0.12", markers = "sys_platform == \"linux\""}
 
 [package.extras]
 dev = ["bump2version (>=1.0.1)", "pre-commit (>=2.17.0)", "pylint (>=2.13.0)", "cibuildwheel (==2.6.1)"]
@@ -83,6 +84,14 @@ description = "Python and C interfaces for logging"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "future"
+version = "0.18.2"
+description = "Clean single-source support for Python 3 and 2"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "importlib-metadata"
@@ -100,6 +109,20 @@ zipp = ">=0.5"
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "lief"
@@ -140,12 +163,34 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
+name = "patchelf"
+version = "0.15.0.0"
+description = "A small utility to modify the dynamic linker and RPATH of ELF executables."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+test = ["pytest", "importlib-metadata"]
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "pefile"
+version = "2022.5.30"
+description = "Python PE parsing module"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+future = "*"
 
 [[package]]
 name = "platformdirs"
@@ -171,7 +216,9 @@ python-versions = "<3.11,>=3.7"
 altgraph = "*"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 macholib = {version = ">=1.8", markers = "sys_platform == \"darwin\""}
+pefile = {version = ">=2022.5.30", markers = "sys_platform == \"win32\""}
 pyinstaller-hooks-contrib = ">=2021.4"
+pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 encryption = ["tinyaes (>=1.0.0)"]
@@ -211,6 +258,14 @@ shiboken2 = "5.15.2"
 name = "pywin32"
 version = "304"
 description = "Python for Window Extensions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.0"
+description = ""
 category = "main"
 optional = false
 python-versions = "*"
@@ -278,7 +333,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "19acb0aca534fde07bfdd373a503f3d07076cb27d78f38a1c9b0f2c8d7f0f39c"
+content-hash = "dcf636b215ddf8e260a66d6761365c6a5c8b3e0277f92c56894818913f609046"
 
 [metadata.files]
 altgraph = [
@@ -289,13 +344,66 @@ appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
-black = []
+black = [
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
+    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
+    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
+    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
+    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
+    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
+    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
+    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
+    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
+    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
+    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
+    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
+    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
+    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
+    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
+    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
+    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
+    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
+]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
-colorama = []
-cx-freeze = []
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+cx-freeze = [
+    {file = "cx_Freeze-6.11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e372b9e72ac0e2207ee65a9d404e2669da1134dc37f5ace9a2a779099d3aa868"},
+    {file = "cx_Freeze-6.11.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dd293382e1ad270dddf5a2707db5dbb8600a1e0b0c9b0da7af9d61326eb1b325"},
+    {file = "cx_Freeze-6.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:feec2f36bce042da6a0d92690bc592b0dcec29218adc2278535cd13b28ec3485"},
+    {file = "cx_Freeze-6.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5aafcc6337856d5921b20f41acdcc8d0fe770388f3a072eb25163f8825f6c5d"},
+    {file = "cx_Freeze-6.11.1-cp310-cp310-win32.whl", hash = "sha256:b99cc0b6d6c1ba51bd9fe11dbfae9aabcf089ba779ea86d83d280e2e40f484e7"},
+    {file = "cx_Freeze-6.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:f0dfe6acf25eb096faba7d4b4b001bcd0f818e372ea1f05d900665b0ad82b0b9"},
+    {file = "cx_Freeze-6.11.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:3a68e70dcb27b0720b131a35c5fdd096012fe00119a8e51d935f3fb3cd251c39"},
+    {file = "cx_Freeze-6.11.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f7bde925042d8843af9b6242a1bf3865dbbae088f3183a89a575124ec2e14a4"},
+    {file = "cx_Freeze-6.11.1-cp36-cp36m-win32.whl", hash = "sha256:7698fb82b6f84b3426774b5f3bee770601f26b612306319664a02f1ec5160861"},
+    {file = "cx_Freeze-6.11.1-cp36-cp36m-win_amd64.whl", hash = "sha256:9848c975401b21a98aa896baabfed067c3e981afd5b5b0a8a5eabe5c9f23d3c5"},
+    {file = "cx_Freeze-6.11.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:87dcf5ceb78dc6af910c45238128fda2394b7c430d3fa469e87e1efdeeb5d4cc"},
+    {file = "cx_Freeze-6.11.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb74d8cc1f8c658986acc19ea6875b985a979421f9bb9c310b43cd2ff5d90c44"},
+    {file = "cx_Freeze-6.11.1-cp37-cp37m-win32.whl", hash = "sha256:971c0a8356ef0ee09a3097f9c9d5b52cde6d08d1ef80e997eb4a6e22fe0eff2f"},
+    {file = "cx_Freeze-6.11.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7c1cb44379b2093cbdde77e302a376f29aa61999c73be6e8a559463db84b85c4"},
+    {file = "cx_Freeze-6.11.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bc90d6dbde66e8ddfe6b26f63fb2ea7d6d0e4568205f40660a63b8b200dcabcf"},
+    {file = "cx_Freeze-6.11.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f56f618a23d86bdcfff22b29ec993117effd32a401060013105517301c0bf32"},
+    {file = "cx_Freeze-6.11.1-cp38-cp38-win32.whl", hash = "sha256:4edfb5d65afb11eb9f0326d40d15445366481585705b3096f2cd090e30a36247"},
+    {file = "cx_Freeze-6.11.1-cp38-cp38-win_amd64.whl", hash = "sha256:cfb5a8032bf424c04814c9426425fa1db4cf8c280da948969eead9f616c0fd92"},
+    {file = "cx_Freeze-6.11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0a3e32980269cfabc2e814978bfdf4382fe3cbc9ac64f9f1bdb1cd2ddf3a40d0"},
+    {file = "cx_Freeze-6.11.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:798bb7ca037c3c885efd3eda6756c84c7927c712b730b22a7f256440faa36d38"},
+    {file = "cx_Freeze-6.11.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5aa1759098ca4853200a79138b626a9caa2ccf829d662b28c82ec7e71ea97cde"},
+    {file = "cx_Freeze-6.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7962680ae04ee3afda1012026b5394a534e2526b68681d591158b7d8bc733bcf"},
+    {file = "cx_Freeze-6.11.1-cp39-cp39-win32.whl", hash = "sha256:da4f82fe27e71571c0ab9d700b5e6c6c631ae39133d9b6d7157939f1e9f37312"},
+    {file = "cx_Freeze-6.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:aaf399b6ed5d54b7271980ae354605620bedcd52d722f57ad527bd989c56a875"},
+    {file = "cx_Freeze-6.11.1.tar.gz", hash = "sha256:8f3a30c9e3394f290655e346d3b460910656b30ac6347a87499bb5ad365c6e7c"},
+]
 cx-logging = [
     {file = "cx_Logging-3.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:9fcd297e5c51470521c47eff0f86ba844aeca6be97e13c3e2114ebdf03fa3c96"},
     {file = "cx_Logging-3.0-cp36-cp36m-win32.whl", hash = "sha256:0df4be47c5022cc54316949e283403214568ef599817ced0c0972183d6d4fabb"},
@@ -311,7 +419,17 @@ cx-logging = [
     {file = "cx_Logging-3.0-cp39-cp39-win_amd64.whl", hash = "sha256:302e9c4f65a936c288a4fa59a90e7e142d9ef994aa29676731acafdcccdbb3f5"},
     {file = "cx_Logging-3.0.tar.gz", hash = "sha256:ba8a7465facf7b98d8f494030fb481a2e8aeee29dc191e10383bb54ed42bdb34"},
 ]
-importlib-metadata = []
+future = [
+    {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
+    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
 lief = [
     {file = "lief-0.12.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:4fbbc9d520de87ac22210c62d22a9b088e5460f9a028741311e6f68ef8877ddd"},
     {file = "lief-0.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:443e4494df448ea1a021976258c7a6aca27d81b0612783fa3a84fab196fb9fcb"},
@@ -350,16 +468,42 @@ packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
+patchelf = [
+    {file = "patchelf-0.15.0.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:08e5e30a9415a8628de47726fbf15bfcd89be35df51c8a0a12372aebd0c5b4f6"},
+    {file = "patchelf-0.15.0.0-py2.py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:4ce9d08119816bc4316c8ecc5f33da42384934fc0fc9cfbdded53a4930705466"},
+    {file = "patchelf-0.15.0.0-py2.py3-none-manylinux_2_17_s390x.manylinux2014_s390x.musllinux_1_1_s390x.whl", hash = "sha256:ae19b0f91aabc9af2608a4ca0395533f1df9122e6abc11ef2c8db6e4db0f98c2"},
+    {file = "patchelf-0.15.0.0-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.musllinux_1_1_i686.whl", hash = "sha256:f3f87aee44d1d1b2209e38c4227b0316bb03538df68d20b3d96205aa87868d95"},
+    {file = "patchelf-0.15.0.0-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:52e48c08110f2988a9761a5a383f7ae35b1e8e06a140e320d18386d3510697ed"},
+    {file = "patchelf-0.15.0.0.tar.gz", hash = "sha256:0f8dcf0df0ba919ce37e8aef67a08bde5326897098451df94ab3a5eedc9e08d9"},
+]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+pefile = [
+    {file = "pefile-2022.5.30.tar.gz", hash = "sha256:a5488a3dd1fd021ce33f969780b88fe0f7eebb76eb20996d7318f307612a045b"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
-pyinstaller = []
-pyinstaller-hooks-contrib = []
+pyinstaller = [
+    {file = "pyinstaller-5.3-py3-none-macosx_10_13_universal2.whl", hash = "sha256:7591a9e1e2a481f99eb99036d6786e20717bc10f8f0a8ef519958cb3172fac7a"},
+    {file = "pyinstaller-5.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d4123992556951ed24e11cf2eec9a4e18e94ee8bd63ca49d9b7fc37387097eb9"},
+    {file = "pyinstaller-5.3-py3-none-manylinux2014_i686.whl", hash = "sha256:066b83a0eae89ad418749e9e29429c152f1ff096230df11a093bbded8344ade0"},
+    {file = "pyinstaller-5.3-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4c658a762cbbee5c5997c364578804d4c1e91d688de8ed018710c2705bf1474b"},
+    {file = "pyinstaller-5.3-py3-none-manylinux2014_s390x.whl", hash = "sha256:a0e7a80fe04204add3f743101958a3cf62b79e7ccda838388784b1a35bb5b27f"},
+    {file = "pyinstaller-5.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:aa9d1b8639d2402438c179ae1c8acfd41b65366c803a5a6484a5bb7586e88647"},
+    {file = "pyinstaller-5.3-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:794e8e143ae73d1acdd2cbc52f02dd34cdfbd954ede34c7067ce68a268d8b7c2"},
+    {file = "pyinstaller-5.3-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:9efbad718fe29d425336f289871c67bfc6a1876013037fee2ef1f7613fd675a2"},
+    {file = "pyinstaller-5.3-py3-none-win32.whl", hash = "sha256:cae43e01e04f37185d23202aba8cf2837fa24ec3d0aa5ebc42e26f404e6eba95"},
+    {file = "pyinstaller-5.3-py3-none-win_amd64.whl", hash = "sha256:b38505b445cdd64279f04650e0ddfe5ac6cef61996b14f06e3c99da8aac3cfbe"},
+    {file = "pyinstaller-5.3.tar.gz", hash = "sha256:de71d4669806e4d54b23b477cc077e2e8fe9c4d57e79ed32d22b7585137fd7b7"},
+]
+pyinstaller-hooks-contrib = [
+    {file = "pyinstaller-hooks-contrib-2022.8.tar.gz", hash = "sha256:c4210fc50282c9c6a918e485e0bfae9405592390508e3be9fde19acc2213da56"},
+    {file = "pyinstaller_hooks_contrib-2022.8-py2.py3-none-any.whl", hash = "sha256:e46f099934dd4577fb1ddcf37a99fa04027c92f8f5291c8802f326345988d001"},
+]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
@@ -387,6 +531,10 @@ pywin32 = [
     {file = "pywin32-304-cp38-cp38-win_amd64.whl", hash = "sha256:ead865a2e179b30fb717831f73cf4373401fc62fbc3455a0889a7ddac848f83e"},
     {file = "pywin32-304-cp39-cp39-win32.whl", hash = "sha256:25746d841201fd9f96b648a248f731c1dec851c9a08b8e33da8b56148e4c65cc"},
     {file = "pywin32-304-cp39-cp39-win_amd64.whl", hash = "sha256:d24a3382f013b21aa24a5cfbfad5a2cd9926610c0affde3e8ab5b3d7dbcf4ac9"},
+]
+pywin32-ctypes = [
+    {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
+    {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
 ]
 pyxdg = [
     {file = "pyxdg-0.28-py2.py3-none-any.whl", hash = "sha256:bdaf595999a0178ecea4052b7f4195569c1ff4d344567bccdc12dfdf02d545ab"},
@@ -434,5 +582,11 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
 ]
-typing-extensions = []
-zipp = []
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]
+zipp = [
+    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
+    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ strip-ansi = {version = "*", platform = "darwin"}
 [tool.poetry.dev-dependencies]
 setuptools = {version = "*", platform = "win32"}
 black = "*"
+isort = "*"
 
 [tool.poetry.scripts]
 dangerzone = 'dangerzone:main'

--- a/setup-windows.py
+++ b/setup-windows.py
@@ -21,7 +21,13 @@ setup(
         }
     },
     executables=[
-        Executable("install/windows/dangerzone.py", base="Win32GUI", icon="share/dangerzone.ico"),
-        Executable("install/windows/dangerzone-cli.py", base=None, icon="share/dangerzone.ico"),
+        Executable(
+            "install/windows/dangerzone.py",
+            base="Win32GUI",
+            icon="share/dangerzone.ico",
+        ),
+        Executable(
+            "install/windows/dangerzone-cli.py", base=None, icon="share/dangerzone.ico"
+        ),
     ],
 )

--- a/setup-windows.py
+++ b/setup-windows.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
-from cx_Freeze import setup, Executable
+
+from cx_Freeze import Executable, setup
 
 with open("share/version.txt") as f:
     version = f.read().strip()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-import setuptools
 import os
 import sys
+
+import setuptools
 
 with open("share/version.txt") as f:
     version = f.read().strip()


### PR DESCRIPTION
Follows a similar approach to the securedrop-client. Adds a Makefile with commands for running lint tools and adds a new CI job for running these tools over the code.

On windows Make can be used with Cygwin64.