### PR TITLE
Replace prints with logging

### DIFF
--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import click
+import logging
 from colorama import Fore, Style
 
 from .global_common import GlobalCommon
@@ -19,6 +20,7 @@ def print_header(s):
 @click.option("--ocr-lang", help="Language to OCR, defaults to none")
 @click.argument("filename", required=True)
 def cli_main(output_filename, ocr_lang, filename):
+    setup_logging()
     global_common = GlobalCommon()
     common = Common()
 
@@ -113,3 +115,11 @@ def cli_main(output_filename, ocr_lang, filename):
     else:
         print_header("Failed to convert document")
         sys.exit(-1)
+
+
+def setup_logging() -> None:
+    if getattr(sys, "dangerzone_dev", True):
+        fmt = "%(message)s"
+        logging.basicConfig(level=logging.DEBUG, format=fmt)
+    else:
+        logging.basicConfig(level=logging.ERROR, format=fmt)

--- a/dangerzone/container.py
+++ b/dangerzone/container.py
@@ -2,6 +2,7 @@ import platform
 import subprocess
 import pipes
 import shutil
+import logging
 import os
 import tempfile
 import appdirs
@@ -20,6 +21,7 @@ if platform.system() == "Windows":
 else:
     startupinfo = None
 
+log = logging.getLogger(__name__)
 
 # Name of the dangerzone container
 container_name = "dangerzone.rocks/dangerzone"
@@ -27,7 +29,7 @@ container_name = "dangerzone.rocks/dangerzone"
 
 def exec(args, stdout_callback=None):
     args_str = " ".join(pipes.quote(s) for s in args)
-    print("> " + args_str)
+    log.info("> " + args_str)
 
     with subprocess.Popen(
         args,
@@ -95,7 +97,7 @@ def convert(input_filename, output_filename, ocr_lang, stdout_callback):
     )
     ret = exec_container(args, stdout_callback)
     if ret != 0:
-        print("documents-to-pixels failed")
+        log.error("documents-to-pixels failed")
     else:
         # TODO: validate convert to pixels output
 
@@ -120,7 +122,7 @@ def convert(input_filename, output_filename, ocr_lang, stdout_callback):
         )
         ret = exec_container(args, stdout_callback)
         if ret != 0:
-            print("pixels-to-pdf failed")
+            log.error("pixels-to-pdf failed")
         else:
             # Move the final file to the right place
             if os.path.exists(output_filename):

--- a/dangerzone/global_common.py
+++ b/dangerzone/global_common.py
@@ -227,8 +227,8 @@ class GlobalCommon(object):
         ╰──────────────────────────╯
         """
 
-        log.info(Back.BLACK + Fore.YELLOW + Style.DIM + "╭──────────────────────────╮")
-        log.info(
+        print(Back.BLACK + Fore.YELLOW + Style.DIM + "╭──────────────────────────╮")
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -240,7 +240,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -252,7 +252,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -264,7 +264,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -276,7 +276,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -288,7 +288,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -300,7 +300,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -312,7 +312,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -324,7 +324,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -336,7 +336,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -348,12 +348,12 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(Back.BLACK + Fore.YELLOW + Style.DIM + "│                          │")
+        print(Back.BLACK + Fore.YELLOW + Style.DIM + "│                          │")
         left_spaces = (15 - len(self.version) - 1) // 2
         right_spaces = left_spaces
         if left_spaces + len(self.version) + 1 + right_spaces < 15:
             right_spaces += 1
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -367,7 +367,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(
+        print(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -380,7 +380,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        log.info(Back.BLACK + Fore.YELLOW + Style.DIM + "╰──────────────────────────╯")
+        print(Back.BLACK + Fore.YELLOW + Style.DIM + "╰──────────────────────────╯")
 
     def get_container_runtime(self):
         if platform.system() == "Linux":

--- a/dangerzone/global_common.py
+++ b/dangerzone/global_common.py
@@ -8,9 +8,12 @@ import json
 import gzip
 import colorama
 from colorama import Fore, Back, Style
+import logging
 
 from .settings import Settings
 from .container import convert
+
+log = logging.getLogger(__name__)
 
 
 class GlobalCommon(object):
@@ -224,8 +227,8 @@ class GlobalCommon(object):
         ╰──────────────────────────╯
         """
 
-        print(Back.BLACK + Fore.YELLOW + Style.DIM + "╭──────────────────────────╮")
-        print(
+        log.info(Back.BLACK + Fore.YELLOW + Style.DIM + "╭──────────────────────────╮")
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -237,7 +240,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -249,7 +252,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -261,7 +264,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -273,7 +276,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -285,7 +288,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -297,7 +300,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -309,7 +312,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -321,7 +324,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -333,7 +336,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -345,12 +348,12 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(Back.BLACK + Fore.YELLOW + Style.DIM + "│                          │")
+        log.info(Back.BLACK + Fore.YELLOW + Style.DIM + "│                          │")
         left_spaces = (15 - len(self.version) - 1) // 2
         right_spaces = left_spaces
         if left_spaces + len(self.version) + 1 + right_spaces < 15:
             right_spaces += 1
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -364,7 +367,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(
+        log.info(
             Back.BLACK
             + Fore.YELLOW
             + Style.DIM
@@ -377,7 +380,7 @@ class GlobalCommon(object):
             + Style.DIM
             + "│"
         )
-        print(Back.BLACK + Fore.YELLOW + Style.DIM + "╰──────────────────────────╯")
+        log.info(Back.BLACK + Fore.YELLOW + Style.DIM + "╰──────────────────────────╯")
 
     def get_container_runtime(self):
         if platform.system() == "Linux":
@@ -423,7 +426,7 @@ class GlobalCommon(object):
             return
 
         # Load the container into podman
-        print("Installing Dangerzone container image...")
+        log.info("Installing Dangerzone container image...")
 
         p = subprocess.Popen(
             [self.get_container_runtime(), "load"],
@@ -443,10 +446,10 @@ class GlobalCommon(object):
         p.communicate()
 
         if not self.is_container_installed():
-            print("Failed to install the container image")
+            log.error("Failed to install the container image")
             return False
 
-        print("Container image installed")
+        log.info("Container image installed")
         return True
 
     def is_container_installed(self):
@@ -478,7 +481,7 @@ class GlobalCommon(object):
         elif found_image_id == "":
             pass
         else:
-            print("Deleting old dangerzone container image")
+            log.info("Deleting old dangerzone container image")
 
             try:
                 subprocess.check_output(
@@ -486,6 +489,6 @@ class GlobalCommon(object):
                     startupinfo=self.get_subprocess_startupinfo(),
                 )
             except:
-                print("Couldn't delete old container image, so leaving it there")
+                log.warning("Couldn't delete old container image, so leaving it there")
 
         return installed

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -4,6 +4,7 @@ import signal
 import platform
 import click
 import uuid
+import logging
 from PySide2 import QtCore, QtWidgets
 
 from .common import GuiCommon
@@ -45,6 +46,8 @@ class ApplicationWrapper(QtCore.QObject):
 @click.command()
 @click.argument("filename", required=False)
 def gui_main(filename):
+    setup_logging()
+
     if platform.system() == "Darwin":
         # Required for macOS Big Sur: https://stackoverflow.com/a/64878899
         os.environ["QT_MAC_WANTS_LAYER"] = "1"
@@ -146,3 +149,7 @@ def gui_main(filename):
     ret = app.exec_()
 
     sys.exit(ret)
+
+
+def setup_logging() -> None:
+    logging.basicConfig(level=logging.DEBUG, format="[%(levelname)s] %(message)s")

--- a/dangerzone/gui/common.py
+++ b/dangerzone/gui/common.py
@@ -5,6 +5,7 @@ import shlex
 import pipes
 from PySide2 import QtCore, QtGui, QtWidgets
 from colorama import Fore
+import logging
 
 if platform.system() == "Darwin":
     import plistlib
@@ -15,6 +16,8 @@ elif platform.system() == "Linux":
     from xdg.DesktopEntry import DesktopEntry
 
 from ..settings import Settings
+
+log = logging.getLogger(__name__)
 
 
 class GuiCommon(object):
@@ -52,7 +55,7 @@ class GuiCommon(object):
 
             # Run
             args_str = " ".join(pipes.quote(s) for s in args)
-            print(Fore.YELLOW + "> " + Fore.CYAN + args_str)
+            log.info(Fore.YELLOW + "> " + Fore.CYAN + args_str)
             subprocess.run(args)
 
         elif platform.system() == "Linux":
@@ -72,7 +75,7 @@ class GuiCommon(object):
 
             # Open as a background process
             args_str = " ".join(pipes.quote(s) for s in args)
-            print(Fore.YELLOW + "> " + Fore.CYAN + args_str)
+            log.info(Fore.YELLOW + "> " + Fore.CYAN + args_str)
             subprocess.Popen(args)
 
     def _find_pdf_viewers(self):

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -4,11 +4,14 @@ import tempfile
 import subprocess
 import json
 import shutil
+import logging
 from PySide2 import QtCore, QtGui, QtWidgets
 from colorama import Style, Fore
 
 from ..common import Common
 from ..container import convert
+
+log = logging.getLogger(__name__)
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -154,7 +157,7 @@ class WaitingWidget(QtWidgets.QWidget):
             container_runtime = shutil.which("docker")
 
         if container_runtime is None:
-            print("Docker is not installed")
+            log.error("Docker is not installed")
             state = "not_installed"
 
         else:
@@ -167,7 +170,7 @@ class WaitingWidget(QtWidgets.QWidget):
             ) as p:
                 p.communicate()
                 if p.returncode != 0:
-                    print("Docker is not running")
+                    log.error("Docker is not running")
                     state = "not_running"
                 else:
                     # Always try installing the container
@@ -515,7 +518,7 @@ class ConvertThread(QtCore.QThread):
         try:
             status = json.loads(line)
         except:
-            print(f"Invalid JSON returned from container: {line}")
+            log.error(f"Invalid JSON returned from container: {line}")
             self.error = True
             self.update.emit(
                 True, f"Invalid JSON returned from container:\n\n{line}", 0
@@ -526,9 +529,10 @@ class ConvertThread(QtCore.QThread):
         if status["error"]:
             self.error = True
             s += Style.RESET_ALL + Fore.RED + status["text"]
+            log.error(s)
         else:
             s += Style.RESET_ALL + status["text"]
-        print(s)
+            log.info(s)
 
         self.update.emit(status["error"], status["text"], status["percentage"])
 

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -1,6 +1,9 @@
 import os
 import json
 import appdirs
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class Settings:
@@ -36,12 +39,12 @@ class Settings:
                         self.settings[key] = self.default_settings[key]
 
             except:
-                print("Error loading settings, falling back to default")
+                log.error("Error loading settings, falling back to default")
                 self.settings = self.default_settings
 
         else:
             # Save with default settings
-            print("Settings file doesn't exist, starting with default")
+            log.info("Settings file doesn't exist, starting with default")
             self.settings = self.default_settings
 
         self.save()


### PR DESCRIPTION
fixes #144: printing non-ascii characters in a macOS application
opened directly from finder would sometimes lead to an error
message in /var/log/system.log similar to this:

  Failed to execute script 'dangerzone' due to unhandled exception:
  'ascii' codec can't encode character '\u201c' in position 1:
  ordinal not in range(128)