### PR TITLE
remove container after use

### DIFF
--- a/dangerzone/container.py
+++ b/dangerzone/container.py
@@ -75,11 +75,14 @@ def exec_container(
     security_args += ["--cap-drop", "all"]
     user_args = ["-u", "dangerzone"]
 
+    prevent_leakage_args = ["--rm"]
+
     args = (
         ["run", "--network", "none"]
         + platform_args
         + user_args
         + security_args
+        + prevent_leakage_args
         + extra_args
         + [container_name]
         + command


### PR DESCRIPTION
The containers and their respective volumes where not being deleted.
By adding `--rm` to the `podman run` it now removes the containers
after use along with anonymous (unnamed) volumes [1]. The same
happens in docker [2].

Fixes #196

[1]: https://docs.podman.io/en/latest/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options
[2]: https://docs.docker.com/storage/volumes/#remove-volumes