### PR TITLE
Updates to the macOS and Windows build scripts and documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -54,16 +54,14 @@ Create a .rpm:
 
 ## macOS
 
-Install Xcode from the App Store.
-
 Install [Docker Desktop](https://www.docker.com/products/docker-desktop). Make sure to choose your correct CPU, either Intel Chip or Apple Chip.
 
-Install Python 3.9.9 [from python.org](https://www.python.org/downloads/release/python-399/).
+Install the latest version of Python 3.9 [from python.org](https://www.python.org/downloads/macos/), and make sure `/Library/Frameworks/Python.framework/Versions/3.9/bin` is in your `PATH`.
 
 Install Python dependencies:
 
 ```sh
-pip3 install --user poetry
+python3 -m pip install poetry
 poetry install
 ```
 
@@ -110,12 +108,12 @@ The output is in the `dist` folder.
 
 Install [Docker Desktop](https://www.docker.com/products/docker-desktop).
 
-Install Python 3.9.9 (x86) [from python.org](https://www.python.org/downloads/release/python-399/). When installing it, make sure to check the "Add Python 3.9 to PATH" checkbox on the first page of the installer.
+Install the latest version of Python 3.9 (64-bit) [from python.org](https://www.python.org/downloads/windows/). Make sure to check the "Add Python 3.9 to PATH" checkbox on the first page of the installer.
 
-Install [poetry](https://python-poetry.org/). Open PowerShell, and run:
+Install [poetry](https://python-poetry.org/):
 
 ```
-(Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python
+python -m pip install poetry
 ```
 
 Change to the `dangerzone` folder, and install the poetry dependencies:

--- a/install/macos/build-app.py
+++ b/install/macos/build-app.py
@@ -73,9 +73,7 @@ def main():
 
     if args.with_codesign:
         print("○ Code signing app bundle")
-        identity_name_application = (
-            "Developer ID Application: FIRST LOOK PRODUCTIONS, INC. (P24U45L8P5)"
-        )
+        identity_name_application = "Developer ID Application: FIRST LOOK PRODUCTIONS, INC. (P24U45L8P5)"
         entitlements_plist_path = os.path.join(root, "install/macos/entitlements.plist")
 
         for path in itertools.chain(

--- a/install/macos/build-app.py
+++ b/install/macos/build-app.py
@@ -73,7 +73,9 @@ def main():
 
     if args.with_codesign:
         print("○ Code signing app bundle")
-        identity_name_application = "Developer ID Application: FIRST LOOK PRODUCTIONS, INC. (P24U45L8P5)"
+        identity_name_application = (
+            "Developer ID Application: FIRST LOOK PRODUCTIONS, INC. (P24U45L8P5)"
+        )
         entitlements_plist_path = os.path.join(root, "install/macos/entitlements.plist")
 
         for path in itertools.chain(

--- a/install/windows/build-app.bat
+++ b/install/windows/build-app.bat
@@ -6,8 +6,8 @@ REM build the exe
 python .\setup-windows.py build
 
 REM code sign dangerzone.exe
-signtool.exe sign /v /d "Dangerzone" /sha1 28a4af3b6ba5ed0ef307e1b96a140e1b42450c3b /tr http://timestamp.digicert.com build\exe.win32-3.9\dangerzone.exe
-signtool.exe sign /v /d "Dangerzone" /sha1 28a4af3b6ba5ed0ef307e1b96a140e1b42450c3b /tr http://timestamp.digicert.com build\exe.win32-3.9\dangerzone-cli.exe
+signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.9\dangerzone.exe
+signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.9\dangerzone-cli.exe
 
 REM build the wix file
 python install\windows\build-wxs.py > build\Dangerzone.wxs
@@ -19,7 +19,7 @@ light.exe -ext WixUIExtension Dangerzone.wixobj
 
 REM code sign dangerzone.msi
 insignia.exe -im Dangerzone.msi
-signtool.exe sign /v /d "Dangerzone" /sha1 28a4af3b6ba5ed0ef307e1b96a140e1b42450c3b /tr http://timestamp.digicert.com Dangerzone.msi
+signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com Dangerzone.msi
 
 REM moving Dangerzone.msi to dist
 cd ..

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -23,7 +23,7 @@ def build_data(dirname, dir_prefix, id_, name):
                 id_prefix = id_
 
             # Skip lib/Pyside2/Examples folder
-            if "\\build\\exe.win32-3.9\\lib\\PySide2\\examples" in dirname:
+            if "\\build\\exe.win-amd64-3.9\\lib\\PySide2\\examples" in dirname:
                 continue
 
             id_value = f"{id_prefix}{basename.capitalize().replace('-', '_')}"
@@ -121,7 +121,7 @@ def main():
     dist_dir = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
         "build",
-        "exe.win32-3.9",
+        "exe.win-amd64-3.9",
     )
     if not os.path.exists(dist_dir):
         print("You must build the dangerzone binary before running this")
@@ -145,7 +145,7 @@ def main():
     data["dirs"][0]["dirs"].append(
         build_data(
             dist_dir,
-            "exe.win32-3.9",
+            "exe.win-amd64-3.9",
             "INSTALLDIR",
             "Dangerzone",
         )
@@ -224,9 +224,8 @@ def main():
     print('<?xml version="1.0" encoding="windows-1252"?>')
     print(f'<?define ProductVersion = "{version}"?>')
     print('<?define ProductUpgradeCode = "12b9695c-965b-4be0-bc33-21274e809576"?>')
-
     ET.indent(root_el)
-    ET.dump(root_el)
+    print(ET.tostring(root_el).decode())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've made test releases from the main branch in Windows and macOS using a newly-built MacBook build laptop. I've updated the BUILD.md and RELEASE.md documentation while I did it.

Changes: 
- Switched from hardcoding the exact minor release of Python 3.9 to just using Python 3.9
- Switches from 32-bit Windows Python binaries to 64-bit
- Install poetry in Windows using pip, which is much simpler and less error-prone than the PowerShell way
- Includes instructions for making the Windows release in a Windows 11 VM, and building the container image on the host
- Updates the fingerprint of the Windows signing key
- Fixes a small bug with the .wxs file used to build the MSI package