### PR TITLE
rename "common" to  "document" & simplify "new window" window logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint: lint-black lint-isort mypy ## check the code with various linters
 .PHONY: lint-apply
 lint-apply: lint-black-apply lint-isort-apply ## apply all the linter's suggestions
 
-.PHONT: test
+.PHONY: test
 test:  ## run tests in parallel
 	pytest -v -n 4 --cov
 

--- a/dangerzone/args.py
+++ b/dangerzone/args.py
@@ -12,8 +12,9 @@ def validate_input_filename(
 ) -> Optional[str]:
     if value is None:
         return None
-    Document.validate_input_filename(value)
-    return value
+    filename = Document.normalize_filename(value)
+    Document.validate_input_filename(filename)
+    return filename
 
 
 @errors.handle_document_errors
@@ -22,5 +23,6 @@ def validate_output_filename(
 ) -> Optional[str]:
     if value is None:
         return None
-    Document.validate_output_filename(value)
-    return value
+    filename = Document.normalize_filename(value)
+    Document.validate_output_filename(filename)
+    return filename

--- a/dangerzone/args.py
+++ b/dangerzone/args.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+import click
+
+from . import errors
+from .document import Document
+
+
+@errors.handle_document_errors
+def validate_input_filename(
+    ctx: click.Context, param: str, value: Optional[str]
+) -> Optional[str]:
+    if value is None:
+        return None
+    Document.validate_input_filename(value)
+    return value
+
+
+@errors.handle_document_errors
+def validate_output_filename(
+    ctx: click.Context, param: str, value: Optional[str]
+) -> Optional[str]:
+    if value is None:
+        return None
+    Document.validate_output_filename(value)
+    return value

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -28,7 +28,6 @@ def cli_main(
 ) -> None:
     setup_logging()
     global_common = GlobalCommon()
-    document = Document()
 
     display_banner()
 
@@ -44,7 +43,7 @@ def cli_main(
         click.echo("Invalid filename")
         exit(1)
 
-    document.input_filename = os.path.abspath(filename)
+    document = Document(os.path.abspath(filename))
 
     # Validate safe PDF output filename
     if output_filename:

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -8,8 +8,8 @@ import click
 from colorama import Back, Fore, Style
 
 from . import container
-from .common import Common
 from .container import convert
+from .document import Document
 from .global_common import GlobalCommon
 from .util import get_version
 
@@ -28,7 +28,7 @@ def cli_main(
 ) -> None:
     setup_logging()
     global_common = GlobalCommon()
-    common = Common()
+    document = Document()
 
     display_banner()
 
@@ -44,7 +44,7 @@ def cli_main(
         click.echo("Invalid filename")
         exit(1)
 
-    common.input_filename = os.path.abspath(filename)
+    document.input_filename = os.path.abspath(filename)
 
     # Validate safe PDF output filename
     if output_filename:
@@ -63,18 +63,18 @@ def cli_main(
             click.echo("Safe PDF filename is not writable")
             exit(1)
 
-        common.output_filename = os.path.abspath(output_filename)
+        document.output_filename = os.path.abspath(output_filename)
 
     else:
-        common.output_filename = (
-            f"{os.path.splitext(common.input_filename)[0]}-safe.pdf"
+        document.output_filename = (
+            f"{os.path.splitext(document.input_filename)[0]}-safe.pdf"
         )
         try:
-            with open(common.output_filename, "wb"):
+            with open(document.output_filename, "wb"):
                 pass
         except:
             click.echo(
-                f"Output filename {common.output_filename} is not writable, use --output-filename"
+                f"Output filename {document.output_filename} is not writable, use --output-filename"
             )
             exit(1)
 
@@ -110,13 +110,13 @@ def cli_main(
             click.echo(f"Invalid JSON returned from container: {line}")
 
     if convert(
-        common.input_filename,
-        common.output_filename,
+        document.input_filename,
+        document.output_filename,
         ocr_lang,
         stdout_callback,
     ):
         print_header("Safe PDF created successfully")
-        click.echo(common.output_filename)
+        click.echo(document.output_filename)
         exit(0)
     else:
         print_header("Failed to convert document")

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -7,7 +7,7 @@ from typing import Optional
 import click
 from colorama import Back, Fore, Style
 
-from . import container, errors
+from . import args, container, errors
 from .container import convert
 from .document import Document
 from .global_common import GlobalCommon
@@ -20,9 +20,13 @@ def print_header(s: str) -> None:
 
 
 @click.command()
-@click.option("--output-filename", help="Default is filename ending with -safe.pdf")
+@click.option(
+    "--output-filename",
+    callback=args.validate_output_filename,
+    help="Default is filename ending with -safe.pdf",
+)
 @click.option("--ocr-lang", help="Language to OCR, defaults to none")
-@click.argument("filename", required=True)
+@click.argument("filename", required=True, callback=args.validate_input_filename)
 @errors.handle_document_errors
 def cli_main(
     output_filename: Optional[str], ocr_lang: Optional[str], filename: str

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -7,7 +7,7 @@ from typing import Optional
 import click
 from colorama import Back, Fore, Style
 
-from . import container
+from . import container, errors
 from .container import convert
 from .document import Document
 from .global_common import GlobalCommon
@@ -23,6 +23,7 @@ def print_header(s: str) -> None:
 @click.option("--output-filename", help="Default is filename ending with -safe.pdf")
 @click.option("--ocr-lang", help="Language to OCR, defaults to none")
 @click.argument("filename", required=True)
+@errors.handle_document_errors
 def cli_main(
     output_filename: Optional[str], ocr_lang: Optional[str], filename: str
 ) -> None:
@@ -31,51 +32,15 @@ def cli_main(
 
     display_banner()
 
-    # Validate filename
-    valid = True
-    try:
-        with open(os.path.abspath(filename), "rb") as f:
-            pass
-    except:
-        valid = False
-
-    if not valid:
-        click.echo("Invalid filename")
-        exit(1)
-
     document = Document(os.path.abspath(filename))
 
     # Validate safe PDF output filename
     if output_filename:
-        valid = True
-        if not output_filename.endswith(".pdf"):
-            click.echo("Safe PDF filename must end in '.pdf'")
-            exit(1)
-
-        try:
-            with open(os.path.abspath(output_filename), "wb"):
-                pass
-        except:
-            valid = False
-
-        if not valid:
-            click.echo("Safe PDF filename is not writable")
-            exit(1)
-
         document.output_filename = os.path.abspath(output_filename)
-
     else:
         document.output_filename = (
             f"{os.path.splitext(document.input_filename)[0]}-safe.pdf"
         )
-        try:
-            with open(document.output_filename, "wb"):
-                pass
-        except:
-            click.echo(
-                f"Output filename {document.output_filename} is not writable, use --output-filename"
-            )
-            exit(1)
 
     # Validate OCR language
     if ocr_lang:

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -10,7 +10,7 @@ from colorama import Back, Fore, Style
 from . import args, container, errors
 from .container import convert
 from .document import SAFE_EXTENSION, Document
-from .global_common import GlobalCommon
+from .logic import DangerzoneCore
 from .util import get_version
 
 
@@ -32,7 +32,7 @@ def cli_main(
     output_filename: Optional[str], ocr_lang: Optional[str], filename: str
 ) -> None:
     setup_logging()
-    global_common = GlobalCommon()
+    dangerzone = DangerzoneCore()
 
     display_banner()
 
@@ -47,14 +47,14 @@ def cli_main(
     # Validate OCR language
     if ocr_lang:
         valid = False
-        for lang in global_common.ocr_languages:
-            if global_common.ocr_languages[lang] == ocr_lang:
+        for lang in dangerzone.ocr_languages:
+            if dangerzone.ocr_languages[lang] == ocr_lang:
                 valid = True
                 break
         if not valid:
             click.echo("Invalid OCR language code. Valid language codes:")
-            for lang in global_common.ocr_languages:
-                click.echo(f"{global_common.ocr_languages[lang]}: {lang}")
+            for lang in dangerzone.ocr_languages:
+                click.echo(f"{dangerzone.ocr_languages[lang]}: {lang}")
             exit(1)
 
     # Ensure container is installed

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -9,7 +9,7 @@ from colorama import Back, Fore, Style
 
 from . import args, container, errors
 from .container import convert
-from .document import Document
+from .document import SAFE_EXTENSION, Document
 from .global_common import GlobalCommon
 from .util import get_version
 
@@ -23,7 +23,7 @@ def print_header(s: str) -> None:
 @click.option(
     "--output-filename",
     callback=args.validate_output_filename,
-    help="Default is filename ending with -safe.pdf",
+    help=f"Default is filename ending with {SAFE_EXTENSION}",
 )
 @click.option("--ocr-lang", help="Language to OCR, defaults to none")
 @click.argument("filename", required=True, callback=args.validate_input_filename)
@@ -38,13 +38,11 @@ def cli_main(
 
     document = Document(filename)
 
-    # Validate safe PDF output filename
+    # Set PDF output filename
     if output_filename:
         document.output_filename = output_filename
     else:
-        document.output_filename = (
-            f"{os.path.splitext(document.input_filename)[0]}-safe.pdf"
-        )
+        document.set_default_output_filename()
 
     # Validate OCR language
     if ocr_lang:

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -36,11 +36,11 @@ def cli_main(
 
     display_banner()
 
-    document = Document(os.path.abspath(filename))
+    document = Document(filename)
 
     # Validate safe PDF output filename
     if output_filename:
-        document.output_filename = os.path.abspath(output_filename)
+        document.output_filename = output_filename
     else:
         document.output_filename = (
             f"{os.path.splitext(document.input_filename)[0]}-safe.pdf"

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -8,6 +8,8 @@ import appdirs
 
 from .errors import DocumentFilenameException
 
+SAFE_EXTENSION = "-safe.pdf"
+
 
 class Document:
     """Track the state of a single document.
@@ -75,3 +77,8 @@ class Document:
         filename = self.normalize_filename(filename)
         self.validate_output_filename(filename)
         self._output_filename = filename
+
+    def set_default_output_filename(self) -> None:
+        self.output_filename = (
+            f"{os.path.splitext(self.input_filename)[0]}{SAFE_EXTENSION}"
+        )

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -7,9 +7,11 @@ from typing import Optional
 import appdirs
 
 
-class Common(object):
-    """
-    The Common class is a singleton of shared functionality throughout an open dangerzone window
+class Document:
+    """Track the state of a single document.
+
+    The Document class is responsible for holding the state of a single
+    document, and validating its info.
     """
 
     def __init__(self) -> None:

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import appdirs
 
+from .errors import DocumentFilenameException
+
 
 class Document:
     """Track the state of a single document.
@@ -21,24 +23,49 @@ class Document:
         if input_filename:
             self.input_filename = input_filename
 
+    @staticmethod
+    def validate_input_filename(filename: str) -> None:
+        try:
+            open(filename, "rb")
+        except FileNotFoundError as e:
+            raise DocumentFilenameException(
+                "Input file not found: make sure you typed it correctly."
+            ) from e
+        except PermissionError as e:
+            raise DocumentFilenameException(
+                "You don't have permission to open the input file."
+            ) from e
+
+    @staticmethod
+    def validate_output_filename(filename: str) -> None:
+        if not filename.endswith(".pdf"):
+            raise DocumentFilenameException("Safe PDF filename must end in '.pdf'")
+        try:
+            with open(os.path.abspath(filename), "wb"):
+                pass
+        except PermissionError as e:
+            raise DocumentFilenameException("Safe PDF filename is not writable") from e
+
     @property
     def input_filename(self) -> str:
         if self._input_filename is None:
-            raise RuntimeError("Input filename has not been set yet.")
+            raise DocumentFilenameException("Input filename has not been set yet.")
         else:
             return self._input_filename
 
     @input_filename.setter
     def input_filename(self, filename: str) -> None:
+        self.validate_input_filename(filename)
         self._input_filename = filename
 
     @property
     def output_filename(self) -> str:
         if self._output_filename is None:
-            raise RuntimeError("Output filename has not been set yet.")
+            raise DocumentFilenameException("Output filename has not been set yet.")
         else:
             return self._output_filename
 
     @output_filename.setter
     def output_filename(self, filename: str) -> None:
+        self.validate_output_filename(filename)
         self._output_filename = filename

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -14,10 +14,12 @@ class Document:
     document, and validating its info.
     """
 
-    def __init__(self) -> None:
-        # Name of input and out files
+    def __init__(self, input_filename: str = None) -> None:
         self._input_filename: Optional[str] = None
         self._output_filename: Optional[str] = None
+
+        if input_filename:
+            self.input_filename = input_filename
 
     @property
     def input_filename(self) -> str:

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -24,6 +24,10 @@ class Document:
             self.input_filename = input_filename
 
     @staticmethod
+    def normalize_filename(filename: str) -> str:
+        return os.path.abspath(filename)
+
+    @staticmethod
     def validate_input_filename(filename: str) -> None:
         try:
             open(filename, "rb")
@@ -41,7 +45,7 @@ class Document:
         if not filename.endswith(".pdf"):
             raise DocumentFilenameException("Safe PDF filename must end in '.pdf'")
         try:
-            with open(os.path.abspath(filename), "wb"):
+            with open(filename, "wb"):
                 pass
         except PermissionError as e:
             raise DocumentFilenameException("Safe PDF filename is not writable") from e
@@ -55,6 +59,7 @@ class Document:
 
     @input_filename.setter
     def input_filename(self, filename: str) -> None:
+        filename = self.normalize_filename(filename)
         self.validate_input_filename(filename)
         self._input_filename = filename
 
@@ -67,5 +72,6 @@ class Document:
 
     @output_filename.setter
     def output_filename(self, filename: str) -> None:
+        filename = self.normalize_filename(filename)
         self.validate_output_filename(filename)
         self._output_filename = filename

--- a/dangerzone/errors.py
+++ b/dangerzone/errors.py
@@ -1,8 +1,11 @@
 import functools
 import logging
 import sys
+from typing import Any, Callable, TypeVar, cast
 
 import click
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 log = logging.getLogger(__name__)
 
@@ -11,11 +14,11 @@ class DocumentFilenameException(Exception):
     """Exception for document-related filename errors."""
 
 
-def handle_document_errors(func):
+def handle_document_errors(func: F) -> F:
     """Log document-related errors and exit gracefully."""
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args, **kwargs):  # type: ignore
         try:
             return func(*args, **kwargs)
         except DocumentFilenameException as e:
@@ -26,4 +29,4 @@ def handle_document_errors(func):
             click.echo(str(e))
             exit(1)
 
-    return wrapper
+    return cast(F, wrapper)

--- a/dangerzone/errors.py
+++ b/dangerzone/errors.py
@@ -1,0 +1,29 @@
+import functools
+import logging
+import sys
+
+import click
+
+log = logging.getLogger(__name__)
+
+
+class DocumentFilenameException(Exception):
+    """Exception for document-related filename errors."""
+
+
+def handle_document_errors(func):
+    """Log document-related errors and exit gracefully."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except DocumentFilenameException as e:
+            if getattr(sys, "dangerzone_dev", False):
+                # Show the full traceback only on dev environments.
+                msg = "An exception occured while validating a document filename"
+                log.exception(msg)
+            click.echo(str(e))
+            exit(1)
+
+    return wrapper

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -88,7 +88,7 @@ def gui_main(filename: Optional[str]) -> bool:
     def select_document(filename: Optional[str] = None) -> bool:
         if (
             len(windows) == 1
-            and windows[list(windows.keys())[0]].common.input_filename == None
+            and windows[list(windows.keys())[0]].document.input_filename == None
         ):
             window = windows[list(windows.keys())[0]]
         else:
@@ -108,7 +108,7 @@ def gui_main(filename: Optional[str]) -> bool:
             except PermissionError:
                 click.echo("Permission denied")
                 return False
-            window.common.input_filename = file_path
+            window.document.input_filename = file_path
             window.content_widget.doc_selection_widget.document_selected.emit()
 
         return True

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -12,7 +12,6 @@ from PySide2 import QtCore, QtGui, QtWidgets
 
 from .. import args, errors
 from ..document import Document
-from ..logic import DangerzoneCore
 from .logic import DangerzoneGui
 from .main_window import MainWindow
 from .systray import SysTray
@@ -71,14 +70,13 @@ def gui_main(filename: Optional[str]) -> bool:
     app = app_wrapper.app
 
     # Common objects
-    dangerzone = DangerzoneCore()
-    gui_common = DangerzoneGui(app, dangerzone)
+    dangerzone = DangerzoneGui(app)
 
     # Allow Ctrl-C to smoothly quit the program instead of throwing an exception
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     # Create the system tray
-    systray = SysTray(dangerzone, gui_common, app, app_wrapper)
+    systray = SysTray(dangerzone, app, app_wrapper)
 
     closed_windows: Dict[str, MainWindow] = {}
     windows: Dict[str, MainWindow] = {}
@@ -91,7 +89,7 @@ def gui_main(filename: Optional[str]) -> bool:
     def new_window(input_filename: Optional[str] = None) -> None:
         document = Document(input_filename)
         window_id = uuid.uuid4().hex
-        window = MainWindow(dangerzone, gui_common, window_id, document)
+        window = MainWindow(dangerzone, window_id, document)
         window.delete_window.connect(delete_window)
         windows[window_id] = window
 

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -10,7 +10,7 @@ import click
 import colorama
 from PySide2 import QtCore, QtGui, QtWidgets
 
-from .. import errors
+from .. import args, errors
 from ..document import Document
 from ..global_common import GlobalCommon
 from .common import GuiCommon
@@ -50,7 +50,7 @@ class ApplicationWrapper(QtCore.QObject):
 
 
 @click.command()
-@click.argument("filename", required=False)
+@click.argument("filename", required=False, callback=args.validate_input_filename)
 @errors.handle_document_errors
 def gui_main(filename: Optional[str]) -> bool:
     setup_logging()

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -102,9 +102,7 @@ def gui_main(filename: Optional[str]) -> bool:
     if filename is None:
         new_window()
     else:
-        # If filename is passed as an argument, open it
-        input_filename: str = os.path.abspath(os.path.expanduser(filename))
-        new_window(input_filename)
+        new_window(filename)
 
     # Open a new window, if all windows are closed
     def application_activated() -> None:

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -10,6 +10,7 @@ import click
 import colorama
 from PySide2 import QtCore, QtGui, QtWidgets
 
+from ..document import Document
 from ..global_common import GlobalCommon
 from .common import GuiCommon
 from .main_window import MainWindow
@@ -86,16 +87,11 @@ def gui_main(filename: Optional[str]) -> bool:
 
     # Open a document in a window
     def select_document(filename: Optional[str] = None) -> bool:
-        if (
-            len(windows) == 1
-            and windows[list(windows.keys())[0]].document.input_filename == None
-        ):
-            window = windows[list(windows.keys())[0]]
-        else:
-            window_id = uuid.uuid4().hex
-            window = MainWindow(global_common, gui_common, window_id)
-            window.delete_window.connect(delete_window)
-            windows[window_id] = window
+        document = Document(filename)
+        window_id = uuid.uuid4().hex
+        window = MainWindow(global_common, gui_common, window_id)
+        window.delete_window.connect(delete_window)
+        windows[window_id] = window
 
         if filename:
             # Validate filename

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -13,7 +13,7 @@ from PySide2 import QtCore, QtGui, QtWidgets
 from .. import args, errors
 from ..document import Document
 from ..logic import DangerzoneCore
-from .common import GuiCommon
+from .logic import DangerzoneGui
 from .main_window import MainWindow
 from .systray import SysTray
 
@@ -72,7 +72,7 @@ def gui_main(filename: Optional[str]) -> bool:
 
     # Common objects
     dangerzone = DangerzoneCore()
-    gui_common = GuiCommon(app, dangerzone)
+    gui_common = DangerzoneGui(app, dangerzone)
 
     # Allow Ctrl-C to smoothly quit the program instead of throwing an exception
     signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -12,7 +12,7 @@ from PySide2 import QtCore, QtGui, QtWidgets
 
 from .. import args, errors
 from ..document import Document
-from ..global_common import GlobalCommon
+from ..logic import DangerzoneCore
 from .common import GuiCommon
 from .main_window import MainWindow
 from .systray import SysTray
@@ -71,14 +71,14 @@ def gui_main(filename: Optional[str]) -> bool:
     app = app_wrapper.app
 
     # Common objects
-    global_common = GlobalCommon()
-    gui_common = GuiCommon(app, global_common)
+    dangerzone = DangerzoneCore()
+    gui_common = GuiCommon(app, dangerzone)
 
     # Allow Ctrl-C to smoothly quit the program instead of throwing an exception
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     # Create the system tray
-    systray = SysTray(global_common, gui_common, app, app_wrapper)
+    systray = SysTray(dangerzone, gui_common, app, app_wrapper)
 
     closed_windows: Dict[str, MainWindow] = {}
     windows: Dict[str, MainWindow] = {}
@@ -91,7 +91,7 @@ def gui_main(filename: Optional[str]) -> bool:
     def new_window(input_filename: Optional[str] = None) -> None:
         document = Document(input_filename)
         window_id = uuid.uuid4().hex
-        window = MainWindow(global_common, gui_common, window_id, document)
+        window = MainWindow(dangerzone, gui_common, window_id, document)
         window.delete_window.connect(delete_window)
         windows[window_id] = window
 

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -86,7 +86,7 @@ def gui_main(filename: Optional[str]) -> bool:
         del windows[window_id]
 
     # Open a document in a window
-    def select_document(filename: Optional[str] = None) -> bool:
+    def new_window(filename: Optional[str] = None) -> bool:
         document = Document(filename)
         window_id = uuid.uuid4().hex
         window = MainWindow(global_common, gui_common, window_id)
@@ -111,20 +111,20 @@ def gui_main(filename: Optional[str]) -> bool:
 
     # Open a new window if not filename is passed
     if filename is None:
-        select_document()
+        new_window()
     else:
         # If filename is passed as an argument, open it
-        if not select_document(filename):
+        if not new_window(filename):
             return True
 
     # Open a new window, if all windows are closed
     def application_activated() -> None:
         if len(windows) == 0:
-            select_document()
+            new_window()
 
     # If we get a file open event, open it
-    app_wrapper.document_selected.connect(select_document)
-    app_wrapper.new_window.connect(select_document)
+    app_wrapper.document_selected.connect(new_window)
+    app_wrapper.new_window.connect(new_window)
 
     # If the application is activated and all windows are closed, open a new one
     app_wrapper.application_activated.connect(application_activated)

--- a/dangerzone/gui/common.py
+++ b/dangerzone/gui/common.py
@@ -17,7 +17,7 @@ elif platform.system() == "Linux":
     import getpass
     from xdg.DesktopEntry import DesktopEntry
 
-from ..global_common import GlobalCommon
+from ..logic import DangerzoneCore
 from ..settings import Settings
 from ..util import get_resource_path
 
@@ -29,14 +29,12 @@ class GuiCommon(object):
     The GuiCommon class is a singleton of shared functionality for the GUI
     """
 
-    def __init__(
-        self, app: QtWidgets.QApplication, global_common: GlobalCommon
-    ) -> None:
+    def __init__(self, app: QtWidgets.QApplication, dangerzone: DangerzoneCore) -> None:
         # Qt app
         self.app = app
 
         # Global common singleton
-        self.global_common = global_common
+        self.dangerzone = dangerzone
 
         # Preload font
         self.fixed_font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
@@ -67,7 +65,7 @@ class GuiCommon(object):
         elif platform.system() == "Linux":
             # Get the PDF reader command
             args = shlex.split(
-                self.pdf_viewers[self.global_common.settings.get("open_app")]
+                self.pdf_viewers[self.dangerzone.settings.get("open_app")]
             )
             # %f, %F, %u, and %U are filenames or URLS -- so replace with the file to open
             for i in range(len(args)):
@@ -118,13 +116,13 @@ class Alert(QtWidgets.QDialog):
     def __init__(
         self,
         gui_common: GuiCommon,
-        global_common: GlobalCommon,
+        dangerzone: DangerzoneCore,
         message: str,
         ok_text: str = "Ok",
         extra_button_text: str = None,
     ) -> None:
         super(Alert, self).__init__()
-        self.global_common = global_common
+        self.dangerzone = dangerzone
         self.gui_common = gui_common
 
         self.setWindowTitle("dangerzone")

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -24,17 +24,16 @@ from ..util import get_resource_path
 log = logging.getLogger(__name__)
 
 
-class DangerzoneGui(object):
+class DangerzoneGui(DangerzoneCore):
     """
-    The DangerzoneGui class is a singleton of shared functionality for the GUI
+    Singleton of shared state / functionality for the GUI and core app logic
     """
 
-    def __init__(self, app: QtWidgets.QApplication, dangerzone: DangerzoneCore) -> None:
+    def __init__(self, app: QtWidgets.QApplication) -> None:
+        super().__init__()
+
         # Qt app
         self.app = app
-
-        # Global common singleton
-        self.dangerzone = dangerzone
 
         # Preload font
         self.fixed_font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
@@ -64,9 +63,7 @@ class DangerzoneGui(object):
 
         elif platform.system() == "Linux":
             # Get the PDF reader command
-            args = shlex.split(
-                self.pdf_viewers[self.dangerzone.settings.get("open_app")]
-            )
+            args = shlex.split(self.pdf_viewers[self.settings.get("open_app")])
             # %f, %F, %u, and %U are filenames or URLS -- so replace with the file to open
             for i in range(len(args)):
                 if (
@@ -115,18 +112,16 @@ class DangerzoneGui(object):
 class Alert(QtWidgets.QDialog):
     def __init__(
         self,
-        dangerzone_gui: DangerzoneGui,
-        dangerzone: DangerzoneCore,
+        gui_common: DangerzoneGui,
         message: str,
         ok_text: str = "Ok",
         extra_button_text: str = None,
     ) -> None:
         super(Alert, self).__init__()
-        self.dangerzone = dangerzone
-        self.dangerzone_gui = dangerzone_gui
+        self.gui_common = gui_common
 
         self.setWindowTitle("dangerzone")
-        self.setWindowIcon(self.dangerzone_gui.get_window_icon())
+        self.setWindowIcon(self.gui_common.get_window_icon())
         self.setModal(True)
 
         flags = (

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -24,9 +24,9 @@ from ..util import get_resource_path
 log = logging.getLogger(__name__)
 
 
-class GuiCommon(object):
+class DangerzoneGui(object):
     """
-    The GuiCommon class is a singleton of shared functionality for the GUI
+    The DangerzoneGui class is a singleton of shared functionality for the GUI
     """
 
     def __init__(self, app: QtWidgets.QApplication, dangerzone: DangerzoneCore) -> None:
@@ -115,7 +115,7 @@ class GuiCommon(object):
 class Alert(QtWidgets.QDialog):
     def __init__(
         self,
-        gui_common: GuiCommon,
+        dangerzone_gui: DangerzoneGui,
         dangerzone: DangerzoneCore,
         message: str,
         ok_text: str = "Ok",
@@ -123,10 +123,10 @@ class Alert(QtWidgets.QDialog):
     ) -> None:
         super(Alert, self).__init__()
         self.dangerzone = dangerzone
-        self.gui_common = gui_common
+        self.dangerzone_gui = dangerzone_gui
 
         self.setWindowTitle("dangerzone")
-        self.setWindowIcon(self.gui_common.get_window_icon())
+        self.setWindowIcon(self.dangerzone_gui.get_window_icon())
         self.setModal(True)
 
         flags = (

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -24,13 +24,17 @@ class MainWindow(QtWidgets.QMainWindow):
     delete_window = QtCore.Signal(str)
 
     def __init__(
-        self, global_common: GlobalCommon, gui_common: GuiCommon, window_id: str
+        self,
+        global_common: GlobalCommon,
+        gui_common: GuiCommon,
+        window_id: str,
+        document: Document,
     ) -> None:
         super(MainWindow, self).__init__()
         self.global_common = global_common
         self.gui_common = gui_common
         self.window_id = window_id
-        self.document = Document()
+        self.document = document
 
         self.setWindowTitle("Dangerzone")
         self.setWindowIcon(self.gui_common.get_window_icon())

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -453,12 +453,9 @@ class SettingsWidget(QtWidgets.QWidget):
             f"Suspicious: {os.path.basename(self.document.input_filename)}"
         )
 
-        # Update the save location
-        output_filename = (
-            f"{os.path.splitext(self.document.input_filename)[0]}-safe.pdf"
-        )
-        self.document.output_filename = output_filename
-        self.save_lineedit.setText(os.path.basename(output_filename))
+        # Set the default save location
+        self.document.set_default_output_filename()
+        self.save_lineedit.setText(os.path.basename(self.document.output_filename))
 
     def save_browse_button_clicked(self) -> None:
         filename = QtWidgets.QFileDialog.getSaveFileName(

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -15,7 +15,7 @@ from ..container import convert
 from ..document import Document
 from ..logic import DangerzoneCore
 from ..util import get_resource_path, get_subprocess_startupinfo
-from .common import GuiCommon
+from .logic import DangerzoneGui
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def __init__(
         self,
         dangerzone: DangerzoneCore,
-        gui_common: GuiCommon,
+        gui_common: DangerzoneGui,
         window_id: str,
         document: Document,
     ) -> None:
@@ -124,7 +124,7 @@ class WaitingWidget(QtWidgets.QWidget):
     # - "install_container"
     finished = QtCore.Signal()
 
-    def __init__(self, dangerzone: DangerzoneCore, gui_common: GuiCommon) -> None:
+    def __init__(self, dangerzone: DangerzoneCore, gui_common: DangerzoneGui) -> None:
         super(WaitingWidget, self).__init__()
         self.dangerzone = dangerzone
         self.gui_common = gui_common
@@ -210,7 +210,7 @@ class ContentWidget(QtWidgets.QWidget):
     close_window = QtCore.Signal()
 
     def __init__(
-        self, dangerzone: DangerzoneCore, gui_common: GuiCommon, document: Document
+        self, dangerzone: DangerzoneCore, gui_common: DangerzoneGui, document: Document
     ) -> None:
         super(ContentWidget, self).__init__()
 
@@ -309,7 +309,7 @@ class SettingsWidget(QtWidgets.QWidget):
     close_window = QtCore.Signal()
 
     def __init__(
-        self, dangerzone: DangerzoneCore, gui_common: GuiCommon, document: Document
+        self, dangerzone: DangerzoneCore, gui_common: DangerzoneGui, document: Document
     ) -> None:
         super(SettingsWidget, self).__init__()
         self.dangerzone = dangerzone
@@ -547,7 +547,7 @@ class ConvertWidget(QtWidgets.QWidget):
     close_window = QtCore.Signal()
 
     def __init__(
-        self, dangerzone: DangerzoneCore, gui_common: GuiCommon, document: Document
+        self, dangerzone: DangerzoneCore, gui_common: DangerzoneGui, document: Document
     ) -> None:
         super(ConvertWidget, self).__init__()
         self.dangerzone = dangerzone

--- a/dangerzone/gui/systray.py
+++ b/dangerzone/gui/systray.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 from PySide2 import QtWidgets
 
-from ..logic import DangerzoneCore
 from .logic import DangerzoneGui
 
 if TYPE_CHECKING:
@@ -13,18 +12,16 @@ if TYPE_CHECKING:
 class SysTray(QtWidgets.QSystemTrayIcon):
     def __init__(
         self,
-        dangerzone: DangerzoneCore,
-        gui_common: DangerzoneGui,
+        dangerzone: DangerzoneGui,
         app: QtWidgets.QApplication,
         app_wrapper: "ApplicationWrapper",
     ) -> None:
         super(SysTray, self).__init__()
         self.dangerzone = dangerzone
-        self.gui_common = gui_common
         self.app = app
         self.app_wrapper = app_wrapper
 
-        self.setIcon(self.gui_common.get_window_icon())
+        self.setIcon(self.dangerzone.get_window_icon())
 
         menu = QtWidgets.QMenu()
 

--- a/dangerzone/gui/systray.py
+++ b/dangerzone/gui/systray.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from PySide2 import QtWidgets
 
 from ..logic import DangerzoneCore
-from .common import GuiCommon
+from .logic import DangerzoneGui
 
 if TYPE_CHECKING:
     from . import ApplicationWrapper
@@ -14,7 +14,7 @@ class SysTray(QtWidgets.QSystemTrayIcon):
     def __init__(
         self,
         dangerzone: DangerzoneCore,
-        gui_common: GuiCommon,
+        gui_common: DangerzoneGui,
         app: QtWidgets.QApplication,
         app_wrapper: "ApplicationWrapper",
     ) -> None:

--- a/dangerzone/gui/systray.py
+++ b/dangerzone/gui/systray.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from PySide2 import QtWidgets
 
-from ..global_common import GlobalCommon
+from ..logic import DangerzoneCore
 from .common import GuiCommon
 
 if TYPE_CHECKING:
@@ -13,13 +13,13 @@ if TYPE_CHECKING:
 class SysTray(QtWidgets.QSystemTrayIcon):
     def __init__(
         self,
-        global_common: GlobalCommon,
+        dangerzone: DangerzoneCore,
         gui_common: GuiCommon,
         app: QtWidgets.QApplication,
         app_wrapper: "ApplicationWrapper",
     ) -> None:
         super(SysTray, self).__init__()
-        self.global_common = global_common
+        self.dangerzone = dangerzone
         self.gui_common = gui_common
         self.app = app
         self.app_wrapper = app_wrapper

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -18,9 +18,9 @@ from .util import get_resource_path
 log = logging.getLogger(__name__)
 
 
-class GlobalCommon(object):
+class DangerzoneCore(object):
     """
-    The GlobalCommon class is a singleton of shared functionality throughout the app
+    The DangerzoneCore class is a singleton of shared functionality throughout the app
     """
 
     def __init__(self) -> None:

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 class DangerzoneCore(object):
     """
-    The DangerzoneCore class is a singleton of shared functionality throughout the app
+    Singleton of shared state / functionality throughout the app
     """
 
     def __init__(self) -> None:

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -6,16 +6,16 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from .global_common import GlobalCommon
+    from .logic import DangerzoneCore
 
 
 class Settings:
     settings: Dict[str, Any]
 
-    def __init__(self, global_common: "GlobalCommon") -> None:
-        self.global_common = global_common
+    def __init__(self, dangerzone: "DangerzoneCore") -> None:
+        self.dangerzone = dangerzone
         self.settings_filename = os.path.join(
-            self.global_common.appdata_path, "settings.json"
+            self.dangerzone.appdata_path, "settings.json"
         )
         self.default_settings: Dict[str, Any] = {
             "save": True,
@@ -59,6 +59,6 @@ class Settings:
         self.save()
 
     def save(self) -> None:
-        os.makedirs(self.global_common.appdata_path, exist_ok=True)
+        os.makedirs(self.dangerzone.appdata_path, exist_ok=True)
         with open(self.settings_filename, "w") as settings_file:
             json.dump(self.settings, settings_file, indent=4)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -20,3 +21,22 @@ for_each_doc = pytest.mark.parametrize("doc", test_docs)
 
 class TestBase:
     sample_doc = str(test_docs_dir.joinpath(BASIC_SAMPLE))
+
+
+@pytest.fixture
+def sample_doc() -> str:
+    return str(test_docs_dir.joinpath(BASIC_SAMPLE))
+
+
+@pytest.fixture
+def unwriteable_pdf(tmp_path: Path) -> str:
+    file_path = tmp_path / "document.pdf"
+    file_path.touch(mode=0o400)
+    return str(file_path)
+
+
+@pytest.fixture
+def unreadable_pdf(tmp_path: Path) -> str:
+    file_path = tmp_path / "document.pdf"
+    file_path.touch(mode=0o000)
+    return str(file_path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,13 +6,15 @@ import pytest
 
 sys.dangerzone_dev = True  # type: ignore[attr-defined]
 
+from dangerzone.document import SAFE_EXTENSION
+
 SAMPLE_DIRECTORY = "test_docs"
 BASIC_SAMPLE = "sample.pdf"
 test_docs_dir = Path(__file__).parent.joinpath(SAMPLE_DIRECTORY)
 test_docs = [
     p
     for p in test_docs_dir.rglob("*")
-    if p.is_file() and not p.name.endswith("-safe.pdf")
+    if p.is_file() and not p.name.endswith(SAFE_EXTENSION)
 ]
 
 # Pytest parameter decorators

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,10 +191,9 @@ class TestCliConversion(TestCliBasic):
             "spaces test.pdf",
         ],
     )
-    def test_filenames(self, filename: str) -> None:
-        tempdir = tempfile.mkdtemp(prefix="dangerzone-")
-        doc_path = os.path.join(filename)
+    def test_filenames(self, filename: str, tmp_path: Path) -> None:
+        doc_path = str(Path(tmp_path).joinpath(filename))
         shutil.copyfile(self.sample_doc, doc_path)
         result = self.run_cli(doc_path)
-        shutil.rmtree(tempdir)
         result.assert_success()
+        assert len(os.listdir(tmp_path)) == 2

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,0 +1,80 @@
+import os
+import platform
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from dangerzone.document import Document
+from dangerzone.errors import DocumentFilenameException
+
+from . import sample_doc, unreadable_pdf, unwriteable_pdf
+
+
+def test_input_sample_init(sample_doc: str) -> None:
+    Document(sample_doc)
+
+
+def test_input_sample_after(sample_doc: str) -> None:
+    d = Document()
+    d.input_filename = sample_doc
+
+
+def test_input_file_none() -> None:
+    """
+    Attempts to read a document's filename when no doc has been set
+    """
+    d = Document()
+    with pytest.raises(DocumentFilenameException) as e:
+        d.input_filename
+    assert "Input filename has not been set yet" in str(e.value)
+
+
+def test_input_file_non_existing() -> None:
+    with pytest.raises(DocumentFilenameException) as e:
+        Document("non-existing-file.pdf")
+    assert "Input file not found" in str(e.value)
+
+
+# XXX: This is not easy to test on Windows, as the file owner can always read it.
+# See also:
+# https://stackoverflow.com/questions/72528318/what-file-permissions-make-a-file-unreadable-by-owner-in-windows
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific")
+def test_input_file_unreadable(unreadable_pdf: str) -> None:
+    with pytest.raises(DocumentFilenameException) as e:
+        Document(unreadable_pdf)
+    assert "don't have permission to open the input file" in str(e.value)
+
+
+def test_output_file_unwriteable(unwriteable_pdf: str) -> None:
+    d = Document()
+    with pytest.raises(DocumentFilenameException) as e:
+        d.output_filename = unwriteable_pdf
+    assert "Safe PDF filename is not writable" in str(e.value)
+
+
+def test_output(tmp_path: Path) -> None:
+    pdf_file = str(tmp_path.joinpath("document.pdf"))
+    d = Document()
+    d.output_filename = pdf_file
+
+
+def test_output_file_none() -> None:
+    """
+    Attempts to read a document's filename when no doc has been set
+    """
+    d = Document()
+    with pytest.raises(DocumentFilenameException) as e:
+        d.output_filename
+    assert "Output filename has not been set yet" in str(e.value)
+
+
+def test_output_file_not_pdf(tmp_path: Path) -> None:
+    docx_file = str(tmp_path.joinpath("document.docx"))
+    d = Document()
+
+    with pytest.raises(DocumentFilenameException) as e:
+        d.output_filename = docx_file
+    assert "Safe PDF filename must end in '.pdf'" in str(e.value)
+
+    assert not os.path.exists(docx_file)


### PR DESCRIPTION
Simplify code logic for creating and handling documents through the renaming of `Common` class to `DocumentHolder` and associated simplifications.

When we support bulk document conversion we'll need to keep track of each document's state. This refactor opens way for that. A document holder does not represent a document in itself (e.g. can be instantiated without a document) but stores the input name, output name, and in the future possibly the conversion progress.

Clarification renames: some of the names were changed to better reflect the classes' or files' purpose.
- **renames:** `common.py::Common` -> `document.py::DocumentHandler`
- **renames:** `global_common.py::GlobalCommon` ->`logic.py::DangerzoneCore`
- **renames:** `gui/common.py::GuiCommon` -> `gui/common.py::DangerzoneGui`

Associated logic simplication:
- deduplicates input / output filename validation now done in `DocumentHandler`, when a new filename is added, throwing an `DocumentFilenameException` if that validation fails. (code was previously duplicated in `gui_main` and `cli_main`).
- simplifies "new window" creation logic (and associated `DocumentHandler` instantiation)
   now when the users click *new window*, it simply opens a new window without extra validation to see if any window is already open and doesn't have a document associated to it.

And lastly, it adds unit tests for `document.py` (100% coverage)
