### PR TITLE
remove unneeded imports: plistlib, grp, getpass

### DIFF
--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -9,12 +9,7 @@ from typing import Dict
 from colorama import Fore
 from PySide2 import QtCore, QtGui, QtWidgets
 
-if platform.system() == "Darwin":
-    import plistlib
-
-elif platform.system() == "Linux":
-    import grp
-    import getpass
+if platform.system() == "Linux":
     from xdg.DesktopEntry import DesktopEntry
 
 from ..logic import DangerzoneCore


### PR DESCRIPTION
plistlib:
  - originaly added in commit 3be1d6333024583aa6186035fe5b2e3921b2d145
  - no longer needed

grp, getpass:
  - originally added in commit ae7c919d8ed4bf556de8e248e9c6a61af2ac1b32
  - used for finding the 'docker' executable. No longer needed.