### PR TITLE
Fix Windows unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ mypy-host:
 mypy-container:
 	mypy $(MYPY_ARGS) container
 
-mypy: mypy-host  mypy-container ## check type hints with mypy
+mypy-tests:
+	mypy $(MYPY_ARGS) tests
+
+mypy: mypy-host  mypy-container mypy-tests ## check type hints with mypy
 
 .PHONY: lint
 lint: lint-black lint-isort mypy ## check the code with various linters

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-sys.dangerzone_dev = True
+sys.dangerzone_dev = True  # type: ignore[attr-defined]
 
 SAMPLE_DIRECTORY = "test_docs"
 BASIC_SAMPLE = "sample.pdf"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import copy
 import os
 import shutil
+import sys
 import tempfile
+import traceback
+from typing import Sequence
 
 import pytest
 from click.testing import CliRunner, Result
@@ -24,21 +28,113 @@ from . import TestBase, for_each_doc
 # FIXME "/" path separator is platform-dependent, use pathlib instead
 
 
+class CLIResult(Result):
+    """Wrapper class for Click results.
+
+    This class wraps Click results and provides the following extras:
+    * Assertion statements for success/failure.
+    * Printing the result details, when an assertion fails.
+    * The arguments of the invocation, which are not provided by the stock
+    `Result` class.
+    """
+
+    @classmethod
+    def reclass_click_result(cls, result: Result, args: Sequence[str]) -> CLIResult:
+        result.__class__ = cls
+        result.args = copy.deepcopy(args)  # type: ignore[attr-defined]
+        return result  # type: ignore[return-value]
+
+    def assert_success(self) -> None:
+        """Assert that the command succeeded."""
+        try:
+            assert self.exit_code == 0
+            assert self.exception is None
+        except AssertionError:
+            self.print_info()
+            raise
+
+    def assert_failure(self, exit_code: int = None, message: str = None) -> None:
+        """Assert that the command failed.
+
+        By default, check that the command has returned with an exit code
+        other than 0. Alternatively, the caller can check for a specific exit
+        code. Also, the caller can check if the output contains an error
+        message.
+        """
+        try:
+            if exit_code is None:
+                assert self.exit_code != 0
+            else:
+                assert self.exit_code == exit_code
+            if message is not None:
+                assert message in self.output
+        except AssertionError:
+            self.print_info()
+            raise
+
+    def print_info(self) -> None:
+        """Print all the info we have for a CLI result.
+
+        Print the string representation of the result, as well as:
+        1. Command output (if any).
+        2. Exception traceback (if any).
+        """
+        print(self)
+        num_lines = len(self.output.splitlines())
+        if num_lines > 0:
+            print(f"Output ({num_lines} lines follow):")
+            print(self.output)
+        else:
+            print("Output (0 lines).")
+
+        if self.exc_info:
+            print("The original traceback follows:")
+            traceback.print_exception(*self.exc_info, file=sys.stdout)
+
+    def __str__(self) -> str:
+        """Return a string representation of a CLI result.
+
+        Include the arguments of the command invocation, as well as the exit
+        code and exception message.
+        """
+        desc = (
+            f"<CLIResult args: {self.args},"  # type: ignore[attr-defined]
+            f" exit code: {self.exit_code}"
+        )
+        if self.exception:
+            desc += f", exception: {self.exception}"
+        return desc
+
+
 class TestCli(TestBase):
-    def run_cli(self, *args, **kwargs) -> Result:
-        return CliRunner().invoke(cli_main, *args, **kwargs)
+    def run_cli(self, args: Sequence[str] | str = ()) -> CLIResult:
+        """Run the CLI with the provided arguments.
+
+        Callers can either provide a list of arguments (iterable), or a single
+        argument (str). Note that in both cases, we don't tokenize the input
+        (i.e., perform `shlex.split()`), as this is prone to errors in Windows
+        environments [1]. The user must perform the tokenizaton themselves.
+
+        [1]: https://stackoverflow.com/a/35900070c
+        """
+        if isinstance(args, str):
+            # Convert the single argument to a tuple, else Click will attempt
+            # to tokenize it.
+            args = (args,)
+        result = CliRunner().invoke(cli_main, args)
+        return CLIResult.reclass_click_result(result, args)
 
 
 class TestCliBasic(TestCli):
     def test_no_args(self):
         """``$ dangerzone-cli``"""
         result = self.run_cli()
-        assert result.exit_code != 0
+        result.assert_failure()
 
     def test_help(self):
         """``$ dangerzone-cli --help``"""
         result = self.run_cli("--help")
-        assert result.exit_code == 0
+        result.assert_success()
 
     def test_display_banner(self, capfd):
         display_banner()  # call the test subject
@@ -55,33 +151,33 @@ class TestCliBasic(TestCli):
 class TestCliConversion(TestCliBasic):
     def test_invalid_lang(self):
         result = self.run_cli(f"{self.sample_doc} --ocr-lang piglatin")
-        assert result.exit_code != 0
+        result.assert_failure()
 
     @for_each_doc
     def test_formats(self, doc):
         result = self.run_cli(f'"{doc}"')
-        assert result.exit_code == 0
+        result.assert_success()
 
     def test_output_filename(self):
         temp_dir = tempfile.mkdtemp(prefix="dangerzone-")
         result = self.run_cli(
             f"{self.sample_doc} --output-filename {temp_dir}/safe.pdf"
         )
-        assert result.exit_code == 0
+        result.assert_success()
 
     def test_output_filename_new_dir(self):
         result = self.run_cli(
             f"{self.sample_doc} --output-filename fake-directory/my-output.pdf"
         )
-        assert result.exit_code != 0
+        result.assert_failure()
 
     def test_sample_not_found(self):
         result = self.run_cli("fake-directory/fake-file.pdf")
-        assert result.exit_code != 0
+        result.assert_failure()
 
     def test_lang_eng(self):
         result = self.run_cli(f'"{self.sample_doc}" --ocr-lang eng')
-        assert result.exit_code == 0
+        result.assert_success()
 
     @pytest.mark.parametrize(
         "filename,",
@@ -96,4 +192,4 @@ class TestCliConversion(TestCliBasic):
         shutil.copyfile(self.sample_doc, doc_path)
         result = self.run_cli(doc_path)
         shutil.rmtree(tempdir)
-        assert result.exit_code == 0
+        result.assert_success()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from typing import Sequence
 
 import pytest
 from click.testing import CliRunner, Result
-from strip_ansi import strip_ansi  # type: ignore
+from strip_ansi import strip_ansi
 
 from dangerzone.cli import cli_main, display_banner
 
@@ -125,17 +125,17 @@ class TestCli(TestBase):
 
 
 class TestCliBasic(TestCli):
-    def test_no_args(self):
+    def test_no_args(self) -> None:
         """``$ dangerzone-cli``"""
         result = self.run_cli()
         result.assert_failure()
 
-    def test_help(self):
+    def test_help(self) -> None:
         """``$ dangerzone-cli --help``"""
         result = self.run_cli("--help")
         result.assert_success()
 
-    def test_display_banner(self, capfd):
+    def test_display_banner(self, capfd) -> None:  # type: ignore[no-untyped-def]
         display_banner()  # call the test subject
         (out, err) = capfd.readouterr()
         plain_lines = [strip_ansi(line) for line in out.splitlines()]
@@ -148,38 +148,38 @@ class TestCliBasic(TestCli):
 
 
 class TestCliConversion(TestCliBasic):
-    def test_invalid_lang(self):
+    def test_invalid_lang(self) -> None:
         result = self.run_cli([self.sample_doc, "--ocr-lang", "piglatin"])
         result.assert_failure()
 
     @for_each_doc
-    def test_formats(self, doc):
+    def test_formats(self, doc: Path) -> None:
         result = self.run_cli(str(doc))
         result.assert_success()
 
-    def test_output_filename(self):
+    def test_output_filename(self) -> None:
         temp_dir = tempfile.mkdtemp(prefix="dangerzone-")
         output_filename = str(Path(temp_dir) / "safe.pdf")
         result = self.run_cli([self.sample_doc, "--output-filename", output_filename])
         result.assert_success()
 
-    def test_output_filename_spaces(self):
+    def test_output_filename_spaces(self) -> None:
         temp_dir = tempfile.mkdtemp(prefix="dangerzone-")
         output_filename = str(Path(temp_dir) / "safe space.pdf")
         result = self.run_cli([self.sample_doc, "--output-filename", output_filename])
         result.assert_success()
 
-    def test_output_filename_new_dir(self):
+    def test_output_filename_new_dir(self) -> None:
         output_filename = str(Path("fake-directory") / "my-output.pdf")
         result = self.run_cli([self.sample_doc, "--output-filename", output_filename])
         result.assert_failure()
 
-    def test_sample_not_found(self):
+    def test_sample_not_found(self) -> None:
         input_filename = str(Path("fake-directory") / "fake-file.pdf")
         result = self.run_cli(input_filename)
         result.assert_failure()
 
-    def test_lang_eng(self):
+    def test_lang_eng(self) -> None:
         result = self.run_cli([self.sample_doc, "--ocr-lang", "eng"])
         result.assert_success()
 
@@ -191,7 +191,7 @@ class TestCliConversion(TestCliBasic):
             "spaces test.pdf",
         ],
     )
-    def test_filenames(self, filename):
+    def test_filenames(self, filename: str) -> None:
         tempdir = tempfile.mkdtemp(prefix="dangerzone-")
         doc_path = os.path.join(filename)
         shutil.copyfile(self.sample_doc, doc_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,6 @@ from dangerzone.cli import cli_main, display_banner
 
 from . import TestBase, for_each_doc
 
-# TODO --output-filename with spaces
 # TODO explore any symlink edge cases
 # TODO simulate ctrl-c, ctrl-d, SIGINT/SIGKILL/SIGTERM... (man 7 signal), etc?
 # TODO validate output PDFs https://github.com/pdfminer/pdfminer.six
@@ -165,6 +164,13 @@ class TestCliConversion(TestCliBasic):
         )
         result.assert_success()
 
+    def test_output_filename_spaces(self):
+        temp_dir = tempfile.mkdtemp(prefix="dangerzone-")
+        result = self.run_cli(
+            [self.sample_doc, "--output-filename", f"{temp_dir}/safe space.pdf"]
+        )
+        result.assert_success()
+
     def test_output_filename_new_dir(self):
         result = self.run_cli(
             [self.sample_doc, "--output-filename", "fake-directory/my-output.pdf"]
@@ -184,6 +190,7 @@ class TestCliConversion(TestCliBasic):
         [
             "“Curly_Quotes”.pdf",  # issue 144
             "Оригинал.pdf",
+            "spaces test.pdf",
         ],
     )
     def test_filenames(self, filename):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,24 +150,24 @@ class TestCliBasic(TestCli):
 
 class TestCliConversion(TestCliBasic):
     def test_invalid_lang(self):
-        result = self.run_cli(f"{self.sample_doc} --ocr-lang piglatin")
+        result = self.run_cli([self.sample_doc, "--ocr-lang", "piglatin"])
         result.assert_failure()
 
     @for_each_doc
     def test_formats(self, doc):
-        result = self.run_cli(f'"{doc}"')
+        result = self.run_cli(str(doc))
         result.assert_success()
 
     def test_output_filename(self):
         temp_dir = tempfile.mkdtemp(prefix="dangerzone-")
         result = self.run_cli(
-            f"{self.sample_doc} --output-filename {temp_dir}/safe.pdf"
+            [self.sample_doc, "--output-filename", f"{temp_dir}/safe.pdf"]
         )
         result.assert_success()
 
     def test_output_filename_new_dir(self):
         result = self.run_cli(
-            f"{self.sample_doc} --output-filename fake-directory/my-output.pdf"
+            [self.sample_doc, "--output-filename", "fake-directory/my-output.pdf"]
         )
         result.assert_failure()
 
@@ -176,7 +176,7 @@ class TestCliConversion(TestCliBasic):
         result.assert_failure()
 
     def test_lang_eng(self):
-        result = self.run_cli(f'"{self.sample_doc}" --ocr-lang eng')
+        result = self.run_cli([self.sample_doc, "--ocr-lang", "eng"])
         result.assert_success()
 
     @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tempfile
 import traceback
+from pathlib import Path
 from typing import Sequence
 
 import pytest
@@ -24,7 +25,6 @@ from . import TestBase, for_each_doc
 # TODO simulate container runtime missing
 # TODO simulate container connection error
 # TODO simulate container connection loss
-# FIXME "/" path separator is platform-dependent, use pathlib instead
 
 
 class CLIResult(Result):
@@ -159,26 +159,24 @@ class TestCliConversion(TestCliBasic):
 
     def test_output_filename(self):
         temp_dir = tempfile.mkdtemp(prefix="dangerzone-")
-        result = self.run_cli(
-            [self.sample_doc, "--output-filename", f"{temp_dir}/safe.pdf"]
-        )
+        output_filename = str(Path(temp_dir) / "safe.pdf")
+        result = self.run_cli([self.sample_doc, "--output-filename", output_filename])
         result.assert_success()
 
     def test_output_filename_spaces(self):
         temp_dir = tempfile.mkdtemp(prefix="dangerzone-")
-        result = self.run_cli(
-            [self.sample_doc, "--output-filename", f"{temp_dir}/safe space.pdf"]
-        )
+        output_filename = str(Path(temp_dir) / "safe space.pdf")
+        result = self.run_cli([self.sample_doc, "--output-filename", output_filename])
         result.assert_success()
 
     def test_output_filename_new_dir(self):
-        result = self.run_cli(
-            [self.sample_doc, "--output-filename", "fake-directory/my-output.pdf"]
-        )
+        output_filename = str(Path("fake-directory") / "my-output.pdf")
+        result = self.run_cli([self.sample_doc, "--output-filename", output_filename])
         result.assert_failure()
 
     def test_sample_not_found(self):
-        result = self.run_cli("fake-directory/fake-file.pdf")
+        input_filename = str(Path("fake-directory") / "fake-file.pdf")
+        result = self.run_cli(input_filename)
         result.assert_failure()
 
     def test_lang_eng(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 import platform
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -19,4 +20,4 @@ def test_get_resource_path():
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific")
 def test_get_subprocess_startupinfo():
     startupinfo = util.get_subprocess_startupinfo()
-    self.assertIsInstance(startupinfo, subprocess.STARTUPINFO)
+    assert isinstance(startupinfo, subprocess.STARTUPINFO)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,7 +9,7 @@ import dangerzone.util as util
 VERSION_FILE_NAME = "version.txt"
 
 
-def test_get_resource_path():
+def test_get_resource_path() -> None:
     share_dir = Path("share").resolve()
     resource_path = Path(util.get_resource_path(VERSION_FILE_NAME)).parent
     assert share_dir.samefile(
@@ -18,6 +18,6 @@ def test_get_resource_path():
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific")
-def test_get_subprocess_startupinfo():
+def test_get_subprocess_startupinfo() -> None:
     startupinfo = util.get_subprocess_startupinfo()
-    assert isinstance(startupinfo, subprocess.STARTUPINFO)
+    assert isinstance(startupinfo, subprocess.STARTUPINFO)  # type: ignore[attr-defined]


### PR DESCRIPTION
Fix some failing Windows unit tests. Also, add extra functionality that will make debugging CLI tests easier:
* Capture the provided arguments to a command.
* Capture the command's output and exception, and print it in case of an assertion error.

Closes #234 