### PR TITLE
Reinstate support for Ubuntu Focal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,14 @@
 version: 2.1
 
 aliases:
+  - &provide-podman
+    name: Provide Podman in Ubuntu Focal
+    command: ./install/linux/install-podman-ubuntu-focal.sh --repo-only
+
+  - &install-podman
+    name: Install Podman in Ubuntu Focal
+    command: ./install/linux/install-podman-ubuntu-focal.sh
+
   - &install-dependencies-deb
     name: Install dependencies (deb)
     command: |
@@ -121,18 +129,8 @@ jobs:
     machine:
       image: ubuntu-2004:202111-01
     steps:
-      # https://www.atlantic.net/dedicated-server-hosting/how-to-install-and-use-podman-on-ubuntu-20-04/
-      - run:
-          name: Install podman on Ubuntu 20.04
-          command: |
-            export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
-            source /etc/os-release
-            sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-            wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
-            sudo apt-get update -qq -y
-            sudo apt-get -qq --yes install podman
-            podman --version
       - checkout
+      - run: *install-podman
       - run:
           name: Install poetry dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,18 @@ jobs:
       - run: *copy-image
       - run: *build-deb
 
+  build-ubuntu-focal:
+    docker:
+      - image: ubuntu:20.04
+    resource_class: medium+
+    steps:
+      - checkout
+      - run: *provide-podman
+      - run: *install-dependencies-deb
+      - restore_cache: *restore-cache
+      - run: *copy-image
+      - run: *build-deb
+
   build-debian-bookworm:
     docker:
       - image: debian:bookworm
@@ -301,6 +313,12 @@ jobs:
             PACKAGE_TYPE: "deb"
             PACKAGECLOUD_DISTRO: "ubuntu/jammy"
           <<: *deploy-packagecloud
+      - run:
+          name: Deploy ubuntu/focal
+          environment:
+            PACKAGE_TYPE: "deb"
+            PACKAGECLOUD_DISTRO: "ubuntu/focal"
+          <<: *deploy-packagecloud
 
 workflows:
   version: 2
@@ -313,6 +331,9 @@ workflows:
           requires:
             - build-container-image
       - build-ubuntu-jammy:
+          requires:
+            - build-container-image
+      - build-ubuntu-focal:
           requires:
             - build-container-image
       - build-debian-bullseye:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bug fix: Fix unit tests on Windows
 - Feature: Re-add Fedora 37 support
 - Feature: Add Debian Bookworm (12) support
+- Reinstate Ubuntu Focal support ([issue #206](https://github.com/freedomofpress/dangerzone/issues/206))
 
 ## Dangerzone 0.3.2
 - Bug fix: some non-ascii characters like “ would prevent Dangerzone from working  ([issue #144](https://github.com/freedomofpress/dangerzone/issues/144))

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,9 @@
-Dangerzone 0.3 is available for:
+Dangerzone is available for:
 
 - Ubuntu 22.04 (jammy)
+- Debian 12 (bookworm)
 - Debian 11 (bullseye)
+- Fedora 37
 - Fedora 36
 - Fedora 35
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,7 @@
 Dangerzone is available for:
 
 - Ubuntu 22.04 (jammy)
+- Ubuntu 20.04 (focal)
 - Debian 12 (bookworm)
 - Debian 11 (bullseye)
 - Fedora 37
@@ -8,6 +9,27 @@ Dangerzone is available for:
 - Fedora 35
 
 ### Ubuntu, Debian
+
+<details>
+  <summary><i>:memo: Expand this section if you are on Ubuntu 20.04 (Focal).</i></summary>
+  </br>
+
+  Dangerzone requires [Podman](https://podman.io/), which is not available
+  through the official Ubuntu Focal repos. To proceed with the Dangerzone
+  installation, you need to add an extra OpenSUSE repo that provides Podman to
+  Ubuntu Focal users. You can follow the instructions below, which have been
+  copied from the [official Podman blog](https://podman.io/new/2021/06/16/new.html):
+
+  ```bash
+  sudo apt-get install curl wget gnupg2 -y
+  source /etc/os-release
+  sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' \
+    > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+  wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- \
+    | sudo apt-key add -
+  sudo apt update
+  ```
+</details>
 
 Add our repository following [these instructions](https://packagecloud.io/firstlookmedia/code/install#manual-deb), or by running this script:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,39 @@
+Dangerzone 0.3 is available for:
+
+- Ubuntu 22.04 (jammy)
+- Debian 11 (bullseye)
+- Fedora 36
+- Fedora 35
+
+### Ubuntu, Debian
+
+Add our repository following [these instructions](https://packagecloud.io/firstlookmedia/code/install#manual-deb), or by running this script:
+
+```
+curl -s https://packagecloud.io/install/repositories/firstlookmedia/code/script.deb.sh | sudo bash
+```
+
+Install Dangerzone:
+
+```
+sudo apt update
+sudo apt install -y dangerzone
+```
+
+### Fedora
+
+Add our repository following [these instructions](https://packagecloud.io/firstlookmedia/code/install#manual-rpm), or by running this script:
+
+```
+curl -s https://packagecloud.io/install/repositories/firstlookmedia/code/script.rpm.sh | sudo bash
+```
+
+Install Dangerzone:
+
+```
+sudo dnf install -y dangerzone
+```
+
+## Build from source
+
+If you'd like to build from source, follow the [build instructions](https://github.com/firstlookmedia/dangerzone/blob/master/BUILD.md).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Read more about Dangerzone in the blog post [Dangerzone: Working With Suspiciou
 
 - Download [Dangerzone 0.3.2 for Mac](https://github.com/firstlookmedia/dangerzone/releases/download/v0.3.2/Dangerzone-0.3.2.dmg)
 - Download [Dangerzone 0.3.2 for Windows](https://github.com/firstlookmedia/dangerzone/releases/download/v0.3.2/Dangerzone-0.3.2.msi)
-- See [installing Dangerzone](https://github.com/firstlookmedia/dangerzone/wiki/Installing-Dangerzone) on the wiki for Linux repositories
+- See [installing Dangerzone](INSTALL.md) for Linux repositories
 
 You can also install Dangerzone for Mac using [Homebrew](https://brew.sh/): `brew install --cask dangerzone`
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -85,6 +85,6 @@ Linux binaries are automatically built and deployed to repositories when a new t
 To publish the release:
 
 - Create a new release on GitHub, put the changelog in the description of the release, and upload the macOS and Windows installers
-- Update the [Installing Dangerzone](https://github.com/firstlookmedia/dangerzone/wiki/Installing-Dangerzone) wiki page
+- Update the [Installing Dangerzone](INSTALL.md) page
 - Update the [Dangerzone website](https://github.com/firstlookmedia/dangerzone.rocks) to link to the new installers
 - Update the brew cask release of Dangerzone with a [PR like this one](https://github.com/Homebrew/homebrew-cask/pull/116319)

--- a/dangerzone/args.py
+++ b/dangerzone/args.py
@@ -7,7 +7,7 @@ from .document import Document
 
 
 @errors.handle_document_errors
-def validate_input_filename(
+def _validate_input_filename(
     ctx: click.Context, param: str, value: Optional[str]
 ) -> Optional[str]:
     if value is None:
@@ -18,7 +18,7 @@ def validate_input_filename(
 
 
 @errors.handle_document_errors
-def validate_output_filename(
+def _validate_output_filename(
     ctx: click.Context, param: str, value: Optional[str]
 ) -> Optional[str]:
     if value is None:
@@ -26,3 +26,23 @@ def validate_output_filename(
     filename = Document.normalize_filename(value)
     Document.validate_output_filename(filename)
     return filename
+
+
+# XXX: Click versions 7.x and below inspect the number of arguments that the
+# callback handler supports. Unfortunately, common Python decorators (such as
+# `handle_document_errors()`) mask this number, so we need to reinstate it
+# somehow [1]. The simplest way to do so is using a wrapper function.
+#
+# Once we stop supporting Click 7.x, we can remove the wrappers below.
+#
+# [1]: https://github.com/freedomofpress/dangerzone/issues/206#issuecomment-1297336863
+def validate_input_filename(
+    ctx: click.Context, param: str, value: Optional[str]
+) -> Optional[str]:
+    return _validate_input_filename(ctx, param, value)
+
+
+def validate_output_filename(
+    ctx: click.Context, param: str, value: Optional[str]
+) -> Optional[str]:
+    return _validate_output_filename(ctx, param, value)

--- a/install/linux/install-podman-ubuntu-focal.sh
+++ b/install/linux/install-podman-ubuntu-focal.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Development script for installing Podman on Ubuntu Focal. Mainly to be used as
+# part of our CI pipelines, where we may install Podman on environments that
+# don't have sudo.
+
+set -e
+
+if [[ "$EUID" -ne 0 ]]; then
+    SUDO=sudo
+else
+    SUDO=
+fi
+
+provide() {
+    $SUDO apt-get update
+    $SUDO apt-get install curl wget gnupg2 -y
+    source /etc/os-release
+    $SUDO sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' \
+      > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- \
+      | $SUDO apt-key add -
+    $SUDO apt-get update -qq -y
+}
+
+install() {
+    $SUDO apt-get -qq --yes install podman
+    podman --version
+}
+
+if [[ "$1" == "--repo-only" ]]; then
+    provide
+elif [[ "$1" == "" ]]; then
+    provide
+    install
+else
+    echo "Unexpected argument: $1"
+    echo "Usage: $0 [--repo-only]"
+    exit 1
+fi


### PR DESCRIPTION
Reinstate support for Ubuntu Focal, by creating packages for it in our CI and providing some extra installation instructions to users.

Closes #206
Refs #240 