### PR TITLE
Option to move untrusted files into subdirectory after conversion 

### DIFF
--- a/dangerzone/container.py
+++ b/dangerzone/container.py
@@ -282,6 +282,9 @@ def convert(
             )
             shutil.move(container_output_filename, document.output_filename)
 
+            if document.archive_after_conversion:
+                document.archive()
+
             # We did it
             success = True
 

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -77,6 +77,11 @@ class Document:
             # in unwriteable directory
             raise errors.UnwriteableOutputDirException()
 
+    def validate_default_archive_dir(self) -> None:
+        """Checks if archive dir can be created"""
+        if not os.access(self.default_archive_dir.parent, os.W_OK):
+            raise errors.UnwriteableArchiveDirException()
+
     @property
     def input_filename(self) -> str:
         if self._input_filename is None:
@@ -125,6 +130,7 @@ class Document:
     @archive_after_conversion.setter
     def archive_after_conversion(self, enabled: bool) -> None:
         if enabled:
+            self.validate_default_archive_dir()
             self._archive = True
         else:
             self._archive = False

--- a/dangerzone/errors.py
+++ b/dangerzone/errors.py
@@ -71,6 +71,15 @@ class OutputDirIsNotDirException(DocumentFilenameException):
         super().__init__("Specified output directory is actually not a directory")
 
 
+class UnwriteableArchiveDirException(DocumentFilenameException):
+    """Exception for when the archive directory cannot be created."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Archive directory for storing unsafe documents cannot be created."
+        )
+
+
 class SuffixNotApplicableException(DocumentFilenameException):
     """Exception for when the suffix cannot be applied to the output filename."""
 

--- a/dangerzone/errors.py
+++ b/dangerzone/errors.py
@@ -97,7 +97,7 @@ def handle_document_errors(func: F) -> F:
         except DocumentFilenameException as e:
             if getattr(sys, "dangerzone_dev", False):
                 # Show the full traceback only on dev environments.
-                msg = "An exception occured while validating a document filename"
+                msg = "An exception occured while validating a document"
                 log.exception(msg)
             click.echo(str(e))
             exit(1)

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -303,20 +303,9 @@ class SettingsWidget(QtWidgets.QWidget):
         self.docs_selected_label.setProperty("class", "docs-selection")  # type: ignore [arg-type]
 
         # Save safe version
-        self.save_checkbox = QtWidgets.QCheckBox("Save safe PDF to")
+        self.save_checkbox = QtWidgets.QCheckBox()
         self.save_checkbox.clicked.connect(self.update_ui)
         self.output_dir = None
-
-        # Save safe to...
-        self.save_location = QtWidgets.QLineEdit()
-        self.save_location.setReadOnly(True)
-        self.save_browse_button = QtWidgets.QPushButton("Choose...")
-        self.save_browse_button.clicked.connect(self.select_output_directory)
-        self.save_location_layout = QtWidgets.QHBoxLayout()
-        self.save_location_layout.addWidget(self.save_checkbox)
-        self.save_location_layout.addWidget(self.save_location)
-        self.save_location_layout.addWidget(self.save_browse_button)
-        self.save_location_layout.addStretch()
 
         # Save safe as... [filename]-safe.pdf
         self.safe_extension_label = QtWidgets.QLabel("Save as")
@@ -339,12 +328,44 @@ class SettingsWidget(QtWidgets.QWidget):
         dot_pdf_regex = QtCore.QRegExp(r".*\.[Pp][Dd][Ff]")
         self.safe_extension.setValidator(QtGui.QRegExpValidator(dot_pdf_regex))
         self.safe_extension_layout = QtWidgets.QHBoxLayout()
-        self.safe_extension_layout.setContentsMargins(20, 0, 0, 0)
+        self.safe_extension_layout.addWidget(self.save_checkbox)
         self.safe_extension_layout.addWidget(self.safe_extension_label)
         self.safe_extension_layout.addLayout(self.safe_extension_name_layout)
         self.safe_extension_layout.addWidget(self.safe_extension_invalid)
-
         self.safe_extension_layout.addStretch()
+
+        # Save safe to...
+        self.save_label = QLabelClickable("Save safe PDFs to")
+        self.save_location = QtWidgets.QLineEdit()
+        self.save_location.setReadOnly(True)
+        self.save_browse_button = QtWidgets.QPushButton("Choose...")
+        self.save_browse_button.clicked.connect(self.select_output_directory)
+        self.save_location_layout = QtWidgets.QHBoxLayout()
+        self.save_location_layout.setContentsMargins(20, 0, 0, 0)
+        self.save_location_layout.addWidget(self.save_label)
+        self.save_location_layout.addWidget(self.save_location)
+        self.save_location_layout.addWidget(self.save_browse_button)
+        self.save_location_layout.addStretch()
+
+        # 'Save PDF to' group box
+        save_group_box_innner_layout = QtWidgets.QVBoxLayout()
+        save_group_box = QtWidgets.QGroupBox()
+        save_group_box.setLayout(save_group_box_innner_layout)
+        save_group_box_layout = QtWidgets.QHBoxLayout()
+        save_group_box_layout.setContentsMargins(20, 0, 0, 0)
+        save_group_box_layout.addWidget(save_group_box)
+        self.radio_move_untrusted = QtWidgets.QRadioButton(
+            "Move unsafe PDFs to 'unsafe' subdirectory"
+        )
+        self.radio_move_untrusted.setChecked(True)
+        save_group_box_innner_layout.addWidget(self.radio_move_untrusted)
+        self.radio_save_to = QtWidgets.QRadioButton()
+        self.save_label.clicked.connect(
+            lambda: self.radio_save_to.setChecked(True)
+        )  # select the radio button when label is clicked
+        self.radio_save_to.setMinimumHeight(30)  # make the QTextEdit fully visible
+        self.radio_save_to.setLayout(self.save_location_layout)
+        save_group_box_innner_layout.addWidget(self.radio_save_to)
 
         # Open safe document
         if platform.system() in ["Darwin", "Windows"]:
@@ -393,8 +414,8 @@ class SettingsWidget(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout()
         layout.addSpacing(20)
         layout.addWidget(self.docs_selected_label)
-        layout.addLayout(self.save_location_layout)
         layout.addLayout(self.safe_extension_layout)
+        layout.addLayout(save_group_box_layout)
         layout.addLayout(open_layout)
         layout.addLayout(ocr_layout)
         layout.addSpacing(20)
@@ -690,3 +711,12 @@ class DocumentWidget(QtWidgets.QWidget):
         # Open
         if self.dangerzone.settings.get("open"):
             self.dangerzone.open_pdf_viewer(self.document.output_filename)
+
+
+class QLabelClickable(QtWidgets.QLabel):
+    """QLabel with a 'clicked' event"""
+
+    clicked = QtCore.Signal()
+
+    def mouseReleaseEvent(self, ev: QtGui.QMouseEvent) -> None:
+        self.clicked.emit()

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -29,7 +29,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowIcon(self.dangerzone.get_window_icon())
 
         self.setMinimumWidth(600)
-        self.setMinimumHeight(400)
+        self.setMinimumHeight(430)
 
         # Header
         logo = QtWidgets.QLabel()
@@ -412,7 +412,6 @@ class SettingsWidget(QtWidgets.QWidget):
 
         # Layout
         layout = QtWidgets.QVBoxLayout()
-        layout.addSpacing(20)
         layout.addWidget(self.docs_selected_label)
         layout.addLayout(self.safe_extension_layout)
         layout.addLayout(save_group_box_layout)

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -511,7 +511,7 @@ class SettingsWidget(QtWidgets.QWidget):
                 dialog.setDirectory(os.path.dirname(unconverted_docs[0].input_filename))
         else:
             # open the directory where the user last saved it
-            dialog.setDirectory(self.output_dir)  # type: ignore [unreachable]
+            dialog.setDirectory(self.output_dir)
 
         # allow only the selection of directories
         dialog.setFileMode(QtWidgets.QFileDialog.DirectoryOnly)
@@ -520,7 +520,7 @@ class SettingsWidget(QtWidgets.QWidget):
         if dialog.exec_() == QtWidgets.QFileDialog.Accepted:
             selected_dir = dialog.selectedFiles()[0]
             if selected_dir is not None:
-                self.output_dir = str(selected_dir)  # type: ignore [assignment]
+                self.output_dir = str(selected_dir)
                 self.save_location.setText(selected_dir)
 
     def start_button_clicked(self) -> None:

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -42,9 +42,12 @@ class DangerzoneCore(object):
         self.documents: List[Document] = []
 
     def add_document_from_filename(
-        self, input_filename: str, output_filename: Optional[str] = None
+        self,
+        input_filename: str,
+        output_filename: Optional[str] = None,
+        archive: bool = False,
     ) -> None:
-        doc = Document(input_filename, output_filename)
+        doc = Document(input_filename, output_filename, archive=archive)
         self.add_document(doc)
 
     def add_document(self, doc: Document) -> None:

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -21,6 +21,7 @@ class Settings:
         )
         self.default_settings: Dict[str, Any] = {
             "save": True,
+            "archive": True,
             "ocr": True,
             "ocr_language": "English",
             "open": True,

--- a/poetry.lock
+++ b/poetry.lock
@@ -387,6 +387,20 @@ py = "*"
 pytest = ">=3.10"
 
 [[package]]
+name = "pytest-mock"
+version = "3.10.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "pytest-xdist"
 version = "2.5.0"
 description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
@@ -488,7 +502,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"
-content-hash = "5ed0423136bff7b3208bab5cc90ef6e1aa03918b9cb3e81b10d60d9a84c47de9"
+content-hash = "098fe8820fcf719b946a0b92b29a64e93e68107e9fe0340b1d8503e53b2802fd"
 
 [metadata.files]
 altgraph = [
@@ -782,6 +796,10 @@ pytest-cov = [
 pytest-forked = [
     {file = "pytest-forked-1.4.0.tar.gz", hash = "sha256:8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e"},
     {file = "pytest_forked-1.4.0-py3-none-any.whl", hash = "sha256:bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
+    {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
 ]
 pytest-xdist = [
     {file = "pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dangerzone = 'dangerzone:main'
 dangerzone-container = 'dangerzone:main'
 dangerzone-cli = 'dangerzone:main'
 
+[tool.poetry.group.dev.dependencies]
+pytest-mock = "^3.10.0"
+
 [build-system]
 requires = ["poetry>=1.1.4"]
 build-backend = "poetry.masonry.api"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from click.testing import CliRunner, Result
 from strip_ansi import strip_ansi
 
 from dangerzone.cli import cli_main, display_banner
+from dangerzone.document import ARCHIVE_SUBDIR, SAFE_EXTENSION
 
 from . import TestBase, for_each_doc
 
@@ -236,6 +237,22 @@ class TestCliConversion(TestCliBasic):
 
         result = self.run_cli(['--output-filename="output.pdf"'] + file_paths)
         result.assert_failure()
+
+    def test_archive(self, tmp_path: Path) -> None:
+        test_string = "original file"
+
+        original_doc_path = str(tmp_path / "doc.pdf")
+        safe_doc_path = str(tmp_path / f"doc{SAFE_EXTENSION}")
+        archived_doc_path = str(tmp_path / ARCHIVE_SUBDIR / "doc.pdf")
+        shutil.copyfile(self.sample_doc, original_doc_path)
+
+        result = self.run_cli(["--archive", original_doc_path])
+        result.assert_success()
+
+        # original document has been moved to unsafe/doc.pdf
+        assert not os.path.exists(original_doc_path)
+        assert os.path.exists(archived_doc_path)
+        assert os.path.exists(safe_doc_path)
 
 
 class TestSecurity(TestCli):


### PR DESCRIPTION
Follows what's been outlined in #251:
![opt3](https://user-images.githubusercontent.com/47065258/203129589-d93ab10b-be35-4298-9dd2-d9dc12059933.png)


The only thing missing would be a way to detect a case where an archive directory cannot be created where the original documents are located. This could show in the GUI by disabling the option to archive, or the CLI by giving out an error.