### PR TITLE
Support Ubuntu 22.10 "Kinetic Kudu"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,17 @@ jobs:
           command: |
             poetry run make test
 
+  build-ubuntu-kudu:
+    docker:
+      - image: ubuntu:22.10
+    resource_class: medium+
+    steps:
+      - run: *install-dependencies-deb
+      - checkout
+      - restore_cache: *restore-cache
+      - run: *copy-image
+      - run: *build-deb
+
   build-ubuntu-jammy:
     docker:
       - image: ubuntu:22.04
@@ -308,6 +319,12 @@ jobs:
             gem install -N rake
             gem install -N package_cloud
       - run:
+          name: Deploy ubuntu/kudu
+          environment:
+            PACKAGE_TYPE: "deb"
+            PACKAGECLOUD_DISTRO: "ubuntu/kudu"
+          <<: *deploy-packagecloud
+      - run:
           name: Deploy ubuntu/jammy
           environment:
             PACKAGE_TYPE: "deb"
@@ -328,6 +345,9 @@ workflows:
       - run-lint
       - build-container-image
       - convert-test-docs:
+          requires:
+            - build-container-image
+      - build-ubuntu-kudu:
           requires:
             - build-container-image
       - build-ubuntu-jammy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Platform support: Re-add Fedora 37 support
 - Platform support: Add Debian Bookworm (12) support ([issue #172](https://github.com/freedomofpress/dangerzone/issues/172))
 - Platform support: Reinstate Ubuntu Focal support ([issue #206](https://github.com/freedomofpress/dangerzone/issues/206))
+- Platform support: Add Ubuntu 22.10 "Kinetic Kudu" support ([issue #265](https://github.com/freedomofpress/dangerzone/issues/265))
 - Feature: Support bulk conversion to safe PDFs ([issue #77](https://github.com/freedomofpress/dangerzone/issues/77))
 - Feature: Option to archive unsafe directories ([issue #255](https://github.com/freedomofpress/dangerzone/pull/255))
 - Feature: Support python 3.10

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,6 @@
 Dangerzone is available for:
 
+- Ubuntu 22.10 (kinetic)
 - Ubuntu 22.04 (jammy)
 - Ubuntu 20.04 (focal)
 - Debian 12 (bookworm)


### PR DESCRIPTION
Add support for the newly released Ubuntu 22.10 "Kinetic Kudu".

Closes #265