### PR TITLE
Increase App Size due to trimmed widgets on macOS

### DIFF
--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -29,7 +29,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowIcon(self.dangerzone.get_window_icon())
 
         self.setMinimumWidth(600)
-        self.setMinimumHeight(430)
+        if platform.system() == "Darwin":
+            # FIXME have a different height for macOS due to font-size inconsistencies
+            # https://github.com/freedomofpress/dangerzone/issues/270
+            self.setMinimumHeight(470)
+        else:
+            self.setMinimumHeight(430)
 
         # Header
         logo = QtWidgets.QLabel()


### PR DESCRIPTION
The save group box would get partially trimmed when running in macOS this appears to be due to differences in rendering fonts and spacings. **Should this warrant setting different window heights for different platforms?**

> **Note:** I tried expanding the `save_group_box` `minimumHeight` and then adding some spacing or a stretch. But in all situations, the group box would always be on top of other widgets. In the end the solution that worked was increasing the window's height.

## Before & After

### macOS

|<img width="400" alt="Screenshot 2022-11-25 at 10 52 38" src="https://user-images.githubusercontent.com/47065258/203968551-5ecc23ec-c49c-4d8b-941e-0f957fd2f59b.png">  |<img width="400" alt="Screenshot 2022-11-25 at 12 49 33" src="https://user-images.githubusercontent.com/47065258/203991560-0dfa6ee5-aeeb-4985-8b57-668a8f212034.png">    |
|--|--|

### Linux
Side-effects on Linux include a greater space between the "convert" button and the bottom of the window.
| ![dz-before](https://user-images.githubusercontent.com/47065258/203991881-7991ecc1-6f5d-4700-be04-71fb91d609a8.png) |![after](https://user-images.githubusercontent.com/47065258/203991879-b9b12bf5-1c19-4a07-917f-98b2749bce61.png) | 
|--|--|

### Windows

| ![image](https://user-images.githubusercontent.com/47065258/203994433-c1ee9418-8e9b-4b09-aff1-824b08f60946.png) | ![image(2)](https://user-images.githubusercontent.com/47065258/203994786-466ae855-c101-4853-b375-13fb4b94bc3d.png) |
|--|--|


