### PR TITLE
Fix 'open with Dangerzone' on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Bug fix: Fix unit tests on Windows
 - Bug fix: Do not hardcode "docker" in help messages, now that Podman is also used ([issue #122](https://github.com/freedomofpress/dangerzone/issues/122))
 - Bug fix: Failed execution no longer produces an empty "safe" documents ([issue #214](https://github.com/freedomofpress/dangerzone/issues/214))
-- Bug fix: Malfunctioning "New window" logic was replaced with multi-doc support (([issue #204](https://github.com/freedomofpress/dangerzone/issues/204)))
+- Bug fix: Malfunctioning "New window" logic was replaced with multi-doc support ([issue #204](https://github.com/freedomofpress/dangerzone/issues/204))
+- Bug fix: re-adds support for 'open with Dangerzone' from finder on macOS ([issue #268](https://github.com/freedomofpress/dangerzone/issues/268))
 - Bug fix: (macOS) quit Dangerzone when main window is closed ([issue #271](https://github.com/freedomofpress/dangerzone/issues/271))
 
 

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -195,3 +195,8 @@ class Document:
     def mark_as_safe(self) -> None:
         log.debug(f"Marking doc {self.id} as 'safe'")
         self.state = Document.STATE_SAFE
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Document):
+            return False
+        return self.input_filename == other.input_filename

--- a/dangerzone/errors.py
+++ b/dangerzone/errors.py
@@ -14,6 +14,13 @@ class DocumentFilenameException(Exception):
     """Exception for document-related filename errors."""
 
 
+class AddedDuplicateDocumentException(DocumentFilenameException):
+    """Exception for a document is added twice."""
+
+    def __init__(self) -> None:
+        super().__init__("A document was added twice")
+
+
 class InputFileNotFoundException(DocumentFilenameException):
     """Exception for when an input file does not exist."""
 

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -114,6 +114,7 @@ class Alert(QtWidgets.QDialog):
         dangerzone: DangerzoneGui,
         message: str,
         ok_text: str = "Ok",
+        has_cancel: bool = True,
         extra_button_text: str = None,
     ) -> None:
         super(Alert, self).__init__()
@@ -151,15 +152,16 @@ class Alert(QtWidgets.QDialog):
         if extra_button_text:
             extra_button = QtWidgets.QPushButton(extra_button_text)
             extra_button.clicked.connect(self.clicked_extra)
-        cancel_button = QtWidgets.QPushButton("Cancel")
-        cancel_button.clicked.connect(self.clicked_cancel)
 
         buttons_layout = QtWidgets.QHBoxLayout()
         buttons_layout.addStretch()
         buttons_layout.addWidget(ok_button)
         if extra_button_text:
             buttons_layout.addWidget(extra_button)
-        buttons_layout.addWidget(cancel_button)
+        if has_cancel:
+            cancel_button = QtWidgets.QPushButton("Cancel")
+            cancel_button.clicked.connect(self.clicked_cancel)
+            buttons_layout.addWidget(cancel_button)
 
         layout = QtWidgets.QVBoxLayout()
         layout.addLayout(message_layout)

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -31,6 +31,9 @@ class DangerzoneGui(DangerzoneCore):
         # Qt app
         self.app = app
 
+        # Only one output dir is supported in the GUI
+        self.output_dir: str = ""
+
         # Preload font
         self.fixed_font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
 

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -240,12 +240,22 @@ class ContentWidget(QtWidgets.QWidget):
 
     def documents_selected(self, new_docs: List[Document]) -> None:
         if not self.conversion_started:
-            for doc in new_docs:
-                self.dangerzone.add_document(doc)
+            for doc in new_docs.copy():
+                try:
+                    self.dangerzone.add_document(doc)
+                except errors.AddedDuplicateDocumentException:
+                    new_docs.remove(doc)
+                    Alert(
+                        self.dangerzone,
+                        message=f"Document '{doc.input_filename}' has already been added for conversion.",
+                        has_cancel=False,
+                    ).exec_()
 
             self.doc_selection_widget.hide()
             self.settings_widget.show()
-            self.documents_added.emit(new_docs)
+
+            if len(new_docs) > 0:
+                self.documents_added.emit(new_docs)
 
         else:
             Alert(

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -12,7 +12,7 @@ from typing import Callable, List, Optional
 import appdirs
 import colorama
 
-from . import container
+from . import container, errors
 from .document import Document
 from .settings import Settings
 from .util import get_resource_path
@@ -51,6 +51,8 @@ class DangerzoneCore(object):
         self.add_document(doc)
 
     def add_document(self, doc: Document) -> None:
+        if doc in self.documents:
+            raise errors.AddedDuplicateDocumentException()
         self.documents.append(doc)
 
     def convert_documents(


### PR DESCRIPTION
(Fixes #268) This PR adds again the support for 'open with Dangerzone', specifically on macOS (may work on other systems). 

Without the 'open with Dangerzone', the user could only really add documents once. But with this functionality, it opens up many other possibilities. So this PR handing extra edge-cases.

### 1. Prevent adding duplicate documents

![image(4)](https://user-images.githubusercontent.com/47065258/204523741-2c4e5635-abe6-42b4-bb5a-95510133328f.png)

### 2. Prevent adding documents after the conversion has started
![image(5)](https://user-images.githubusercontent.com/47065258/204524146-d62ce243-b059-43d9-870c-0e132118318f.png)

### 3. Update settings page after more documents are added
Scenario:
1. User starts Dangerzone with one document
2. [Dangerzone open in settings saying '1 document selected']
3. User right-clicks another file and 'open with... Dangerzone'
4. [Dangerzone adds the doc and settings now show '2 documents selected']


## Side-effects

### Adding files from different directories
With the 'open with Dangerzone', it would now possible for someone to add files from multiple directories. This would lead to complexity in regards to the options of where the file is saved. To make things simple, I have disabled this option for now in the GUI:

![image(6)](https://user-images.githubusercontent.com/47065258/204544060-6751f4d2-eb07-47e2-9b82-a535eb6fd4f2.png)
