### PR TITLE
Fix 0.4.0 windows builder

### DIFF
--- a/install/windows/build-app.bat
+++ b/install/windows/build-app.bat
@@ -6,8 +6,8 @@ REM build the exe
 python .\setup-windows.py build
 
 REM code sign dangerzone.exe
-signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.9\dangerzone.exe
-signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.9\dangerzone-cli.exe
+signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.10\dangerzone.exe
+signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.10\dangerzone-cli.exe
 
 REM build the wix file
 python install\windows\build-wxs.py > build\Dangerzone.wxs

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -23,7 +23,7 @@ def build_data(dirname, dir_prefix, id_, name):
                 id_prefix = id_
 
             # Skip lib/Pyside2/Examples folder
-            if "\\build\\exe.win-amd64-3.9\\lib\\PySide2\\examples" in dirname:
+            if "\\build\\exe.win-amd64-3.10\\lib\\PySide2\\examples" in dirname:
                 continue
 
             id_value = f"{id_prefix}{basename.capitalize().replace('-', '_')}"
@@ -121,7 +121,7 @@ def main():
     dist_dir = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
         "build",
-        "exe.win-amd64-3.9",
+        "exe.win-amd64-3.10",
     )
     if not os.path.exists(dist_dir):
         print("You must build the dangerzone binary before running this")
@@ -145,7 +145,7 @@ def main():
     data["dirs"][0]["dirs"].append(
         build_data(
             dist_dir,
-            "exe.win-amd64-3.9",
+            "exe.win-amd64-3.10",
             "INSTALLDIR",
             "Dangerzone",
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -87,7 +87,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "cx-freeze"
-version = "6.13.0"
+version = "6.13.1"
 description = "Create standalone executables from Python scripts"
 category = "main"
 optional = false
@@ -502,7 +502,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"
-content-hash = "098fe8820fcf719b946a0b92b29a64e93e68107e9fe0340b1d8503e53b2802fd"
+content-hash = "aa98d53c3d49f0d013cea71047b304643ebe7e89fb74b26618af2ef31011287d"
 
 [metadata.files]
 altgraph = [
@@ -601,41 +601,41 @@ coverage = [
     {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
 ]
 cx-freeze = [
-    {file = "cx_Freeze-6.13.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8069f1976a6f3c50af8efe0d40361cfbc172643b4dde069be7dce89f6c2a05e3"},
-    {file = "cx_Freeze-6.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1fb0b4e39f0c4c5bc65a07d3ce498433ef9cfa378a8dd7104c8e6e9f640e89dd"},
-    {file = "cx_Freeze-6.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7846f215f2bf2a4e9aec2845ca9dcf56b5277ba1161a7671c6dd186679848025"},
-    {file = "cx_Freeze-6.13.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4683ebb1ba68897c75f6bc0d592980c9e02b6f2f31033e4f8aff3b0fd23eaed4"},
-    {file = "cx_Freeze-6.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e0f2465b69d35b80728158046a41ef1b98caead8e6f791a88b3bd1f9cf740c4"},
-    {file = "cx_Freeze-6.13.0-cp310-cp310-win32.whl", hash = "sha256:64720a9dfbfa18d92f67e63f236936fa6c7406b2bdcc8830afbfc1ed38b91c7b"},
-    {file = "cx_Freeze-6.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:a9ca9801c1216d6cabd36dce8c037487257b0aa5859922d29f2bdbced1182edf"},
-    {file = "cx_Freeze-6.13.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5f4aeb550d2ae0df15911240f016bc7fe7cb5535daf102f3d5bf3dc3169b29bb"},
-    {file = "cx_Freeze-6.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:10cf2d330fcf76618af0195b37ea7f075035015f9021ee61e83398b282a0ed7d"},
-    {file = "cx_Freeze-6.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3623840826c703aabcadca1077db86abc6cd6422cc80e738c8b6d4c7fdb0ca5"},
-    {file = "cx_Freeze-6.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fe5cdb0fa2d80cb2460a5faacb670188fa933d951847140df55cb10d4298bb6"},
-    {file = "cx_Freeze-6.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba95c8c002e38cfa28b96d3d35142204472a67cdc5422442e70a0fef437f06f6"},
-    {file = "cx_Freeze-6.13.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a2f44172ab06be78ad13a2cd10834c45c7b376c365bcd8a57963369ceea753a9"},
-    {file = "cx_Freeze-6.13.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1a2a57ee6060c2590a7a18ed5120500cc3136bf3e6800df5b10233c3bfd39c9"},
-    {file = "cx_Freeze-6.13.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cce31f8c6d72cb918e197b74d822cb1199632780a5f9f06a174a114f061eba7e"},
-    {file = "cx_Freeze-6.13.0-cp36-cp36m-win32.whl", hash = "sha256:345b95591bc045bf088519c680d55831f29c135d7b0a56aae3ed068a4de9cbea"},
-    {file = "cx_Freeze-6.13.0-cp36-cp36m-win_amd64.whl", hash = "sha256:c509a5b6bc3509ba921cf092171d06530da250cc9ce198b0cf2f3fbe5750b1d3"},
-    {file = "cx_Freeze-6.13.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:de6ccbc0cff29c95a2ce6ee4d50b170b1cd98a14f88755e4f77354d1d7a545e0"},
-    {file = "cx_Freeze-6.13.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:625b4a137d4351a5d6d3fbe56353a0ddfe95c2c53ec952f25e2bace35b1667da"},
-    {file = "cx_Freeze-6.13.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d9093da8f04d4724b02589c1faf6096b4f208773ff2a7555eca10f89d6d3c0a"},
-    {file = "cx_Freeze-6.13.0-cp37-cp37m-win32.whl", hash = "sha256:d37520e9fb8a3ada044ec3ef5cd360407042909111c03b75947ffff587b8d5ed"},
-    {file = "cx_Freeze-6.13.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e49ad4cb2ce17c29b264204000e00e6aabc5193aeabd82670bb5564918e93023"},
-    {file = "cx_Freeze-6.13.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:11cc057d0a5e89ebe47105eb82ed34f467117feb4c25026b513ddf82c3a81c7d"},
-    {file = "cx_Freeze-6.13.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0429ab053de45caa9fb8ac15caee27cfb86afd27cd4fde27778ceb3f1155841"},
-    {file = "cx_Freeze-6.13.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:342222de1692969cd619951c1ac634ba0c125e0bedc0b2b065015e58159b84f3"},
-    {file = "cx_Freeze-6.13.0-cp38-cp38-win32.whl", hash = "sha256:db7c7c9c6aa0f66b6e8adfe10d18fb60a5a2f8c6c7706b56d1211050da829c06"},
-    {file = "cx_Freeze-6.13.0-cp38-cp38-win_amd64.whl", hash = "sha256:e67f9e0e1d7e7fc37b9f3e0ee3e405cfe0dd442e26da4766a2efe4f7862649a9"},
-    {file = "cx_Freeze-6.13.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3c9e88681db25597f8308a094663722a9de36382fd4832b5a63f7dc82e2d4776"},
-    {file = "cx_Freeze-6.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:71725f136bc285bea40b2304e777b3e69b432957e7ac578fa6b20fe9c0dbd2c2"},
-    {file = "cx_Freeze-6.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7125e2d96602793757d8c54db6a2984b5c19bb19484da1ee9face8cb224ad1f4"},
-    {file = "cx_Freeze-6.13.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b62f8786d205387f2c4dda5616a19a48bd5a0bd31870d7aa66f062acd57ac9b"},
-    {file = "cx_Freeze-6.13.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5eb818f281d07b5e186bf49ccc2068b5d538bf272385ced063d219c089fc7b44"},
-    {file = "cx_Freeze-6.13.0-cp39-cp39-win32.whl", hash = "sha256:17ceeed36acbc84119483bc1862ac9dcb1bf9294eda5a8f1b61c9c6a5f0b4d29"},
-    {file = "cx_Freeze-6.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:bcf8c9dbb05d77ff438c2fbd3841c7ba992275e093b19c861d062ea3b7359337"},
-    {file = "cx_Freeze-6.13.0.tar.gz", hash = "sha256:543f08fb89e02797c9224002f250607820b8cbff3ccf13d9ff9cbd9e238e481d"},
+    {file = "cx_Freeze-6.13.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d6abf729e796e9d6d8eba7192ef6d98c5cd9764fa9ce767dff49533e84472def"},
+    {file = "cx_Freeze-6.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:83a684991c3c37d38a75f7804be62d831719ee0cb60b304e12dd5ace2ea939ef"},
+    {file = "cx_Freeze-6.13.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:515b3bd89d964c66fb74c5a9caabddb4e53571dbe931ee50cbb9509a3900de89"},
+    {file = "cx_Freeze-6.13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8cb5f2271a680272c9861e551913acbaca145693740529e0d0fc4f13809536d6"},
+    {file = "cx_Freeze-6.13.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:954faf882887734c0fc69b7d9db25c2e70c9ce44dc078289379a39fbd2053aa9"},
+    {file = "cx_Freeze-6.13.1-cp310-cp310-win32.whl", hash = "sha256:4bb8af2a76455fe8446df3b7f33fd83502536c4195c7452055fc8bfb31b42598"},
+    {file = "cx_Freeze-6.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:42a036796711906e79380b469f36f2f88ddc0cc965a55369f92f77ff0999db0c"},
+    {file = "cx_Freeze-6.13.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cd90887ec7a0d3f2384170fbaf2fbe4ff49e0b838473ae6a0932f64974bd3c33"},
+    {file = "cx_Freeze-6.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:22750aa871be2ab5f82d53df0a96f122eee2f46f22e36fbbb298dcfef77affe9"},
+    {file = "cx_Freeze-6.13.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:09e872bffaccc1829a3d4815103ece5bb7896ccaf5b5191d62fe758a359d0def"},
+    {file = "cx_Freeze-6.13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2a61f9e76a2c3f724790ae6e786f3efc7c3d5936d031958ea5c2ef05b884d91"},
+    {file = "cx_Freeze-6.13.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41fbe545c1249a05771352e5689e492af2b265c4f43f95faab9dd8e570f2d2e5"},
+    {file = "cx_Freeze-6.13.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:64f08a0cb43fdbe3282bd2810e0b3835e90c568574d720cba79ab7ecaabc935c"},
+    {file = "cx_Freeze-6.13.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a087e3f02acd00219cab0207e5fd9af8980fde6c7e672c3a27c58f8e1cab6d05"},
+    {file = "cx_Freeze-6.13.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b802cd5d6959fe5c9283c0a769e9b818fcd6b40aab0599755f1cb27d1378ad03"},
+    {file = "cx_Freeze-6.13.1-cp36-cp36m-win32.whl", hash = "sha256:5cd143d6c7a9d4e7c6a9338856e3c8f0fc4fae6ef00e30d3fd4e49fe054ca5f5"},
+    {file = "cx_Freeze-6.13.1-cp36-cp36m-win_amd64.whl", hash = "sha256:93ae97072b31adfab51eb35f6e3c2e46654eff5bdfe8203538dbe93237ef6bc5"},
+    {file = "cx_Freeze-6.13.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2b311a52b6db09acf30cdeb6bf158db07049b95629d2c2d8a37055d6a99fa8a0"},
+    {file = "cx_Freeze-6.13.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82154171b5c9f89b406723f378c469f3e9af367565d25d8185d5c51532dd5b17"},
+    {file = "cx_Freeze-6.13.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c65ded67f7e4f842ddf20260496fbc98192352ea1ae6e16827e3f25f0a9c53d"},
+    {file = "cx_Freeze-6.13.1-cp37-cp37m-win32.whl", hash = "sha256:5aa4926be340d8aafaa82ba13c62340308f4df5c4d1220118f43c9b3ff46e585"},
+    {file = "cx_Freeze-6.13.1-cp37-cp37m-win_amd64.whl", hash = "sha256:be9d8acec8104eea794550d4fb61940d68d80936e4aad3d33310ed2e5f2bbac3"},
+    {file = "cx_Freeze-6.13.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0228a18acaf65543da51fbc98a1eaac5025b388af4f5f82c4dc209390b59a8da"},
+    {file = "cx_Freeze-6.13.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:198624947984becd5a815008cdbacbdfe89a5b053f282e494bd6449a2094e42d"},
+    {file = "cx_Freeze-6.13.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:002e453164cc3b5a467ff0975955d761c9dc9dcdf8b521ea2bd51e01e29d66cf"},
+    {file = "cx_Freeze-6.13.1-cp38-cp38-win32.whl", hash = "sha256:042967f5a6ab5dfb21f633264f1d9211a8db5b2acfa13d0f906bbc693f5e9c61"},
+    {file = "cx_Freeze-6.13.1-cp38-cp38-win_amd64.whl", hash = "sha256:9ec94b8c9fdb262449c64de1fad0bfc41c41140836421a56991d33179ef2bb69"},
+    {file = "cx_Freeze-6.13.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f515cadd90d03ac860b8ec6d7e347bb383d5573f4aa9b8b13c17f368ae980e46"},
+    {file = "cx_Freeze-6.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5faae7ee72649553ed180a7f48500a85d4aa1ffe015fbc2fc9fee13f360efad3"},
+    {file = "cx_Freeze-6.13.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8cd336f82d21f582092b45c0c88d05a571de9109ad62c381b797b7093374b1d8"},
+    {file = "cx_Freeze-6.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9c1a423c877e42f17aa318577b7c82a4f90802bba27d645fd06bdf08f64392a"},
+    {file = "cx_Freeze-6.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0daf25c745dcd95c05c657279557156890a3f8ca92add1b596d1d82bdc324b79"},
+    {file = "cx_Freeze-6.13.1-cp39-cp39-win32.whl", hash = "sha256:62a4a84e89fe8b1aa3bfec28f19fe4badebd299883d96e8c1dbcbc4319d0ef80"},
+    {file = "cx_Freeze-6.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:65dc8f29a18a2a420483356e86d460b10fd7126072e6fc44d4c4da41bbb8d7ae"},
+    {file = "cx_Freeze-6.13.1.tar.gz", hash = "sha256:f694f54daf292e973d92b14df0a2e9ddbd74206caf32389a5370a7e1e54089a4"},
 ]
 cx-logging = [
     {file = "cx_Logging-3.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:9fcd297e5c51470521c47eff0f86ba844aeca6be97e13c3e2114ebdf03fa3c96"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ click = "*"
 appdirs = "*"
 PySide2 = "5.15.2.1"
 colorama = "*"
-cx_freeze = {version = "*", platform = "win32"}
+cx_freeze = {version = "^6.13.1", platform = "win32"}
 pywin32 = {version = "*", platform = "win32"}
 pyxdg = {version = "*", platform = "linux"}
 pyinstaller = {version = "*", platform = "darwin"}


### PR DESCRIPTION
The windows builder was not working. This fixes it.

In the future we can make more permanent fixes like changing the build [directory name](https://cx-freeze.readthedocs.io/en/latest/setup_script.html#cmdoption-arg-build_exe) to something independent of the python version.