### PR TITLE
Various fixes for Windows 0.4.0

### DIFF
--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -95,9 +95,9 @@ def cli_main(
         print_header("Failed to convert document(s)")
         for document in documents_failed:
             click.echo(document.input_filename)
-        exit(1)
+        sys.exit(1)
     else:
-        exit(0)
+        sys.exit(0)
 
 
 args.override_parser_and_check_suspicious_options(cli_main)

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -485,18 +485,17 @@ class SettingsWidget(QtWidgets.QWidget):
         if index != -1:
             self.ocr_combobox.setCurrentIndex(index)
 
-        if platform.system() == "Darwin" or platform.system() == "Linux":
-            if self.dangerzone.settings.get("open"):
-                self.open_checkbox.setCheckState(QtCore.Qt.Checked)
-            else:
-                self.open_checkbox.setCheckState(QtCore.Qt.Unchecked)
+        if self.dangerzone.settings.get("open"):
+            self.open_checkbox.setCheckState(QtCore.Qt.Checked)
+        else:
+            self.open_checkbox.setCheckState(QtCore.Qt.Unchecked)
 
-            if platform.system() == "Linux":
-                index = self.open_combobox.findText(
-                    self.dangerzone.settings.get("open_app")
-                )
-                if index != -1:
-                    self.open_combobox.setCurrentIndex(index)
+        if platform.system() == "Linux":
+            index = self.open_combobox.findText(
+                self.dangerzone.settings.get("open_app")
+            )
+            if index != -1:
+                self.open_combobox.setCurrentIndex(index)
 
     def check_safe_extension_is_valid(self) -> bool:
         if self.save_checkbox.checkState() == QtCore.Qt.Unchecked:
@@ -606,14 +605,11 @@ class SettingsWidget(QtWidgets.QWidget):
             "ocr", self.ocr_checkbox.checkState() == QtCore.Qt.Checked
         )
         self.dangerzone.settings.set("ocr_language", self.ocr_combobox.currentText())
-        if platform.system() == "Darwin" or platform.system() == "Linux":
-            self.dangerzone.settings.set(
-                "open", self.open_checkbox.checkState() == QtCore.Qt.Checked
-            )
-            if platform.system() == "Linux":
-                self.dangerzone.settings.set(
-                    "open_app", self.open_combobox.currentText()
-                )
+        self.dangerzone.settings.set(
+            "open", self.open_checkbox.checkState() == QtCore.Qt.Checked
+        )
+        if platform.system() == "Linux":
+            self.dangerzone.settings.set("open_app", self.open_combobox.currentText())
         self.dangerzone.settings.save()
 
         # Start!


### PR DESCRIPTION
Fixes two things that were misbehaving while doing QA on windows for Dangerzone 0.4.0
-  replace `exit()` with `sys.exit()` to work on Windows
-  save / load 'open after conversion' setting
