### PR TITLE
Adds PySide 6 Support For Windows and MacOS

### DIFF
--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -4,12 +4,21 @@ import os
 import platform
 import signal
 import sys
+import typing
 import uuid
 from typing import Dict, List, Optional
 
 import click
 import colorama
-from PySide2 import QtCore, QtGui, QtWidgets
+
+# FIXME: See https://github.com/freedomofpress/dangerzone/issues/320 for more details.
+if typing.TYPE_CHECKING:
+    from PySide2 import QtCore, QtGui, QtWidgets
+else:
+    try:
+        from PySide6 import QtCore, QtGui, QtWidgets
+    except ImportError:
+        from PySide2 import QtCore, QtGui, QtWidgets
 
 from .. import args, errors
 from ..document import Document

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -4,11 +4,20 @@ import pipes
 import platform
 import shlex
 import subprocess
+import typing
 from pathlib import Path
 from typing import Dict
 
 from colorama import Fore
-from PySide2 import QtCore, QtGui, QtWidgets
+
+# FIXME: See https://github.com/freedomofpress/dangerzone/issues/320 for more details.
+if typing.TYPE_CHECKING:
+    from PySide2 import QtCore, QtGui, QtWidgets
+else:
+    try:
+        from PySide6 import QtCore, QtGui, QtWidgets
+    except ImportError:
+        from PySide2 import QtCore, QtGui, QtWidgets
 
 if platform.system() == "Linux":
     from xdg.DesktopEntry import DesktopEntry

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -176,13 +176,13 @@ class Alert(QtWidgets.QDialog):
         self.setLayout(layout)
 
     def clicked_ok(self) -> None:
-        self.done(QtWidgets.QDialog.Accepted)
+        self.done(int(QtWidgets.QDialog.Accepted))
 
     def clicked_extra(self) -> None:
         self.done(2)
 
     def clicked_cancel(self) -> None:
-        self.done(QtWidgets.QDialog.Rejected)
+        self.done(int(QtWidgets.QDialog.Rejected))
 
     def launch(self) -> int:
         return self.exec_()

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -5,11 +5,20 @@ import platform
 import shutil
 import subprocess
 import tempfile
+import typing
 from multiprocessing.pool import ThreadPool
 from typing import List, Optional
 
 from colorama import Fore, Style
-from PySide2 import QtCore, QtGui, QtWidgets
+
+# FIXME: See https://github.com/freedomofpress/dangerzone/issues/320 for more details.
+if typing.TYPE_CHECKING:
+    from PySide2 import QtCore, QtGui, QtWidgets
+else:
+    try:
+        from PySide6 import QtCore, QtGui, QtWidgets
+    except ImportError:
+        from PySide2 import QtCore, QtGui, QtWidgets
 
 from .. import errors
 from ..document import SAFE_EXTENSION, Document
@@ -385,8 +394,10 @@ class SettingsWidget(QtWidgets.QWidget):
         self.safe_extension_name_layout.addWidget(self.safe_extension_filename)
         self.safe_extension_name_layout.addWidget(self.safe_extension)
 
-        dot_pdf_regex = QtCore.QRegExp(r".*\.[Pp][Dd][Ff]")
-        self.safe_extension.setValidator(QtGui.QRegExpValidator(dot_pdf_regex))
+        dot_pdf_regex = QtCore.QRegularExpression(r".*\.[Pp][Dd][Ff]")
+        self.safe_extension.setValidator(
+            QtGui.QRegularExpressionValidator(dot_pdf_regex)
+        )
         self.safe_extension_layout = QtWidgets.QHBoxLayout()
         self.safe_extension_layout.addWidget(self.save_checkbox)
         self.safe_extension_layout.addWidget(self.safe_extension_label)

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -46,7 +46,7 @@ class MainWindow(QtWidgets.QMainWindow):
         header_label.setFont(self.dangerzone.fixed_font)
         header_label.setStyleSheet("QLabel { font-weight: bold; font-size: 50px; }")
         header_version_label = QtWidgets.QLabel(get_version())
-        header_version_label.setProperty("class", "version")  # type: ignore [arg-type]
+        header_version_label.setProperty("class", "version")
         header_version_label.setAlignment(QtCore.Qt.AlignBottom)
 
         header_layout = QtWidgets.QHBoxLayout()
@@ -363,7 +363,7 @@ class SettingsWidget(QtWidgets.QWidget):
         self.docs_selected_label = QtWidgets.QLabel("No documents selected")
         self.docs_selected_label.setAlignment(QtCore.Qt.AlignCenter)
         self.docs_selected_label.setContentsMargins(0, 0, 0, 20)
-        self.docs_selected_label.setProperty("class", "docs-selection")  # type: ignore [arg-type]
+        self.docs_selected_label.setProperty("class", "docs-selection")
 
         # Save safe version
         self.save_checkbox = QtWidgets.QCheckBox()
@@ -373,9 +373,7 @@ class SettingsWidget(QtWidgets.QWidget):
         self.safe_extension_label = QtWidgets.QLabel("Save as")
         self.safe_extension_filename = QtWidgets.QLabel("document")
         self.safe_extension_filename.setAlignment(QtCore.Qt.AlignRight)
-        self.safe_extension_filename.setProperty(
-            "style", "safe_extension_filename"  # type: ignore
-        )
+        self.safe_extension_filename.setProperty("style", "safe_extension_filename")
         self.safe_extension = QtWidgets.QLineEdit()
         self.safe_extension.setStyleSheet("margin-left: -6px;")  # no left margin
         self.safe_extension.textChanged.connect(self.update_ui)

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -22,10 +22,6 @@ def build_data(dirname, dir_prefix, id_, name):
             else:
                 id_prefix = id_
 
-            # Skip lib/Pyside2/Examples folder
-            if "\\build\\exe.win-amd64-3.10\\lib\\PySide2\\examples" in dirname:
-                continue
-
             id_value = f"{id_prefix}{basename.capitalize().replace('-', '_')}"
             data["dirs"].append(
                 build_data(

--- a/poetry.lock
+++ b/poetry.lock
@@ -602,6 +602,66 @@ files = [
 shiboken2 = "5.15.2.1"
 
 [[package]]
+name = "pyside6"
+version = "6.4.2"
+description = "Python bindings for the Qt cross-platform application and UI framework"
+category = "main"
+optional = false
+python-versions = "<3.12,>=3.7"
+files = [
+    {file = "PySide6-6.4.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:e5f8f413743cc28b18e10b3d35a50f1410ed2874a376cd136ffa6030e5ed78fa"},
+    {file = "PySide6-6.4.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b9f132133e0681c5d1d47d533108cc9d35f96486251a9f23bdac6f3b6aa53a1c"},
+    {file = "PySide6-6.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:59dafe1f608d5363afa17d318377ac78d686907d6a1292754887b9229632f36e"},
+    {file = "PySide6-6.4.2-pp39-pypy39_pp73-macosx_10_9_universal2.whl", hash = "sha256:40830c2a5d1a19cedb33638f85b505831e172fa2630b95f11e993614187e8562"},
+    {file = "PySide6-6.4.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:74b49be890662511eb8f279cf4862f7452c1ec7dbb61839f6a9baa0efdefce66"},
+    {file = "PySide6-6.4.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0985a75aa5ff42f93e5e0a0034d2c00f4dfc9a5cda3d63a8f9c5da3096dc7e04"},
+]
+
+[package.dependencies]
+PySide6-Addons = "6.4.2"
+PySide6-Essentials = "6.4.2"
+shiboken6 = "6.4.2"
+
+[[package]]
+name = "pyside6-addons"
+version = "6.4.2"
+description = "Python bindings for the Qt cross-platform application and UI framework (Addons)"
+category = "main"
+optional = false
+python-versions = "<3.12,>=3.7"
+files = [
+    {file = "PySide6_Addons-6.4.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:e94d3d6385723c6c3c78b321498e6ab7331f67c77d6233d314c98b89cc629449"},
+    {file = "PySide6_Addons-6.4.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5c06fa0e1bc6269b9e80e004f928eadc4c7f07bca51e41b375f79f3dc17c94ea"},
+    {file = "PySide6_Addons-6.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:03245466c3844681cdd7d350c1c94444cafff4c86394b44b6bff32643a9668c6"},
+    {file = "PySide6_Addons-6.4.2-pp39-pypy39_pp73-macosx_10_9_universal2.whl", hash = "sha256:101bfe096a426eab15cc02f4d5755ace564ce53693cb44b3fc66223709d999b5"},
+    {file = "PySide6_Addons-6.4.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f5160f28cec8068f717150d7e9a054c6ae0034c75e404b9ae198f620e8bcc7c3"},
+    {file = "PySide6_Addons-6.4.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:9fddedee6d5d3c0c98677f421530402a4107f4b4ad773c596d5dd21366f88abf"},
+]
+
+[package.dependencies]
+PySide6-Essentials = "6.4.2"
+shiboken6 = "6.4.2"
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.4.2"
+description = "Python bindings for the Qt cross-platform application and UI framework (Essentials)"
+category = "main"
+optional = false
+python-versions = "<3.12,>=3.7"
+files = [
+    {file = "PySide6_Essentials-6.4.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:8f208567e27c9caede517f07ec53cb6b3f9472d72866080393f3150393683c46"},
+    {file = "PySide6_Essentials-6.4.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8c3d37cca6e27f6da12b50b20e741d593ccc857bdcdb82d97f8f7c8bfe53639a"},
+    {file = "PySide6_Essentials-6.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:8061b68d7eb4ace0ad4443c66747ebac92f686ba704ac343f58e9e9eed8f1c0f"},
+    {file = "PySide6_Essentials-6.4.2-pp39-pypy39_pp73-macosx_10_9_universal2.whl", hash = "sha256:459202678a5217d1b1ad44ca6da2033e73082d702eafd842c1bf6952e243eb65"},
+    {file = "PySide6_Essentials-6.4.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:7d01e1fd4136cbc3f5516d1c7187a694dd5b6d09a4be3de6e184d0845070ba85"},
+    {file = "PySide6_Essentials-6.4.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0b00979a37a2cf0b848d5ac1eb595e4480687f0ddd34d82cbc738dfe7e8976bc"},
+]
+
+[package.dependencies]
+shiboken6 = "6.4.2"
+
+[[package]]
 name = "pytest"
 version = "7.2.0"
 description = "pytest: simple powerful testing with Python"
@@ -771,6 +831,22 @@ files = [
 ]
 
 [[package]]
+name = "shiboken6"
+version = "6.4.2"
+description = "Python/C++ bindings helper module"
+category = "main"
+optional = false
+python-versions = "<3.12,>=3.7"
+files = [
+    {file = "shiboken6-6.4.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:6131d32cce4114924dabea313fc345745f95ce567631349f2fad170ebff4bfee"},
+    {file = "shiboken6-6.4.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0616c1a12d1e51e680595b3940b986275c1df952a751416a0730a59e5b90105f"},
+    {file = "shiboken6-6.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:2278f8d6ab6f3377e82f72b6305e06bd53e9e479729de489e7a5205296bdb74e"},
+    {file = "shiboken6-6.4.2-pp39-pypy39_pp73-macosx_10_9_universal2.whl", hash = "sha256:0c706fd0e6eeb49d807aaef08f078526eb35bee1d84209cf66cb1ff70508b93a"},
+    {file = "shiboken6-6.4.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:58511b2d0f77f3153b0371e0da2730db38195cb72e5d450e32a52db25c6af06d"},
+    {file = "shiboken6-6.4.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d66bfdd80bbb3c8f9165afad4bb8786434a75456a36f8ee90b583c31ef311a50"},
+]
+
+[[package]]
 name = "strip-ansi"
 version = "0.1.1"
 description = "Strip ANSI escape sequences from a string"
@@ -870,4 +946,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.11"
-content-hash = "a9c6233aa53837d4ca3f46223226293b368e71cc89ffcf5a3f8f1851356189f1"
+content-hash = "0c6081bcb22cdd2dae101bb2eaf3d5128b230246b653ca2abb400ad1fad7dc54"

--- a/poetry.lock
+++ b/poetry.lock
@@ -602,25 +602,6 @@ files = [
 shiboken2 = "5.15.2.1"
 
 [[package]]
-name = "pyside2-stubs"
-version = "5.15.2.1.2"
-description = "PEP561 stub files for the *PySide2/Qt5 for Python* framework"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "PySide2-stubs-5.15.2.1.2.tar.gz", hash = "sha256:87b25aa47a4f99898e2282874e4f27411034780f6643461b1cf39b02b4937657"},
-    {file = "PySide2_stubs-5.15.2.1.2-py3-none-any.whl", hash = "sha256:2bbe78bab9ab015f6d38cbcdca24dd7d4c5180236bcb62e3eddadcd1a390fea8"},
-]
-
-[package.dependencies]
-mypy = ">=0.940"
-PySide2 = ">=5.11.0"
-
-[package.extras]
-dev = ["pytest"]
-
-[[package]]
 name = "pytest"
 version = "7.2.0"
 description = "pytest: simple powerful testing with Python"
@@ -848,6 +829,17 @@ files = [
 ]
 
 [[package]]
+name = "types-pyside2"
+version = "5.15.2.1.1"
+description = "The most accurate stubs for PySide2"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types_PySide2-5.15.2.1.1-py3-none-any.whl", hash = "sha256:50e7882de41328cca5e641be8c732ab3fd03bcf22fd97c9f0740990cd0b2be95"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -878,4 +870,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.11"
-content-hash = "19e19811c8306bffc0f591f8eb231dd0281346057e1ecf295886824cda23fcb1"
+content-hash = "a9c6233aa53837d4ca3f46223226293b368e71cc89ffcf5a3f8f1851356189f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pyinstaller = {version = "*", platform = "darwin"}
 black = "*"
 isort = "*"
 mypy = "*"
-PySide2-stubs = "*"
+types-PySide2 = "*"
 
 # Dependencies required for testing the code.
 [tool.poetry.group.test.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ license = "MIT"
 python = ">=3.7,<3.11"
 click = "*"
 appdirs = "*"
-PySide2 = "5.15.2.1"
+PySide2 = {version = "5.15.2.1", platform = "linux"}
+PySide6 = {version = "^6.4.1", markers = "sys_platform == 'win32' or sys_platform == 'darwin'"}
 colorama = "*"
 pyxdg = {version = "*", platform = "linux"}
 


### PR DESCRIPTION
I tested:
- **MacOS**: dev env + building and running a `.app`
- **Windows**: dev env + building and running `.exe`
-  **Linux**: dev env (still on PySide2) -- see [reasoning here](https://github.com/freedomofpress/dangerzone/issues/211)

Fixes #177

> **Note**: When building on Windows, CXFreeze apparently copies the entire poetry virtualenv into the `.exe` and when you run `poetry install` it only adds the new software -- it doesn't remove old one. So I moved from `PySide2` to `PySide6` and `PySide2` was still installed but no longer the dependencies. However, I saw in the build log that it was getting included.
> 
> To ensure we don't ship `PySide2` accidentally it's recommended to uninstall the virtualenv with `poetry env remove [virtualenv]`