### PR TITLE
Windows: fix "Open with" dialog showing Dangerzone description

### DIFF
--- a/setup-windows.py
+++ b/setup-windows.py
@@ -11,7 +11,9 @@ packages = ["dangerzone", "dangerzone.gui"]
 setup(
     name="dangerzone",
     version=version,
-    description="Take potentially dangerous PDFs, office documents, or images and convert them to a safe PDF",
+    # On Windows description will show as the app's name in the "Open With" menu. See:
+    # https://github.com/freedomofpress/dangerzone/issues/283#issuecomment-1365148805
+    description="Dangerzone",
     packages=packages,
     options={
         "build_exe": {


### PR DESCRIPTION
The "open with" dialog on windows was showing the description of Dangerzone instead of its app name. The issue was that on windows it shows the description there.

Fixes #283

To test this I had to create a new windows user, since caching issues were preventing me from seeing the new description.


![dz](https://user-images.githubusercontent.com/47065258/209552394-134516f1-2d11-4139-adb8-ebbc8a173979.PNG)

> **Note**: in the image above it shows as lower case. In the submitted code it should now show as upper case.
