### PR TITLE
Fix CLI logging in non-dev enviornments

### DIFF
--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -105,11 +105,28 @@ args.override_parser_and_check_suspicious_options(cli_main)
 
 
 def setup_logging() -> None:
+    class EndUserLoggingFormatter(logging.Formatter):
+        """Prefixes any non-INFO log line with the log level"""
+
+        def format(self, record: logging.LogRecord) -> str:
+            if record.levelno == logging.INFO:
+                # Bypass formatter: print line directly
+                return record.getMessage()
+            else:
+                return super().format(record)
+
     if getattr(sys, "dangerzone_dev", False):
         fmt = "[%(levelname)-5s] %(message)s"
         logging.basicConfig(level=logging.DEBUG, format=fmt)
     else:
-        logging.basicConfig(level=logging.INFO, format="%(message)s")
+        # prefix non-INFO log lines with the respective log type
+        fmt = "%(levelname)s %(message)s"
+        formatter = EndUserLoggingFormatter(fmt=fmt)
+        ch = logging.StreamHandler()
+        ch.setFormatter(formatter)
+        logger = logging.getLogger()
+        logger.setLevel(logging.INFO)
+        logger.addHandler(ch)
 
 
 def display_banner() -> None:

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -106,10 +106,10 @@ args.override_parser_and_check_suspicious_options(cli_main)
 
 def setup_logging() -> None:
     if getattr(sys, "dangerzone_dev", False):
-        fmt = "%(message)s"
+        fmt = "[%(levelname)-5s] %(message)s"
         logging.basicConfig(level=logging.DEBUG, format=fmt)
     else:
-        logging.basicConfig(level=logging.INFO, format=fmt)
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 
 def display_banner() -> None:

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -105,7 +105,7 @@ args.override_parser_and_check_suspicious_options(cli_main)
 
 
 def setup_logging() -> None:
-    if getattr(sys, "dangerzone_dev", True):
+    if getattr(sys, "dangerzone_dev", False):
         fmt = "%(message)s"
         logging.basicConfig(level=logging.DEBUG, format=fmt)
     else:

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -109,7 +109,7 @@ def setup_logging() -> None:
         fmt = "%(message)s"
         logging.basicConfig(level=logging.DEBUG, format=fmt)
     else:
-        logging.basicConfig(level=logging.ERROR, format=fmt)
+        logging.basicConfig(level=logging.INFO, format=fmt)
 
 
 def display_banner() -> None:


### PR DESCRIPTION
In non-development environments, the logging was mistakenly logged at the `DEBUG` level. Only a few messages were at this level, though.

This PR enables the right level of logging and fixes its formatting.