### PR TITLE
Run CLI tests in Windows and macOS via Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   push:
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '0 0 * * *' # Run every day at 00:00 UTC.
 
 jobs:
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Tests
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    env:
+      DUMMY_CONVERSION: True
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install poetry
+      - run: poetry install
+      - name: Run CLI tests
+        run: poetry run make test
+
+  macOS:
+    runs-on: macos-latest
+    env:
+      DUMMY_CONVERSION: True
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install poetry
+      - run: poetry install
+      - name: Run CLI tests
+        run: poetry run make test

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint-apply: lint-black-apply lint-isort-apply ## apply all the linter's suggesti
 
 .PHONY: test
 test:
-	./dev_scripts/pytest-wrapper.py -v --cov --ignore dev_scripts
+	python ./dev_scripts/pytest-wrapper.py -v --cov --ignore dev_scripts
 
 # Makefile self-help borrowed from the securedrop-client project
 # Explaination of the below shell command should it ever break.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,6 +126,9 @@ class TestCli(TestBase):
             # to tokenize it.
             args = (args,)
 
+        if os.environ.get("DUMMY_CONVERSION", False):
+            args = ("--unsafe-dummy-conversion", *args)
+
         # TODO: Replace this with `contextlib.chdir()` [1], which was added in
         # Python 3.11.
         #


### PR DESCRIPTION
Depends on https://github.com/freedomofpress/dangerzone/pull/302.

Configures GitHub Actions to run tests with the dummy converter and disables certain tests that fail because of said converter.

Github Actions was chosen for this as opposed to our usual Cicle CI due to the lack of cost and the issues the folks at OnionShare experienced.

>**Note**: the windows evironment appears to be Windows Server and not a end-user version.