### PR TITLE
Add comment about `poetry install` keyring prompt

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -17,6 +17,8 @@ python3 -m pip install poetry
 
 Change to the `dangerzone` folder, and install the poetry dependencies:
 
+> **Note**: due to an issue with [poetry](https://github.com/python-poetry/poetry/issues/1917), if it prompts for your keying, disable the keyring with `keyring --disable` and run the command again.
+
 ```
 poetry install
 ```
@@ -61,6 +63,8 @@ python -m pip install poetry
 ```
 
 Change to the `dangerzone` folder, and install the poetry dependencies:
+
+> **Note**: due to an issue with [poetry](https://github.com/python-poetry/poetry/issues/1917), if it prompts for your keying, disable the keyring with `keyring --disable` and run the command again.
 
 ```
 poetry install


### PR DESCRIPTION
Running `poetry install` would show a keyring prompt asking the user for a password or to create a new keyring. This should not be needed for a successful install.

discussion context: https://github.com/freedomofpress/dangerzone/pull/284#issue-1477773398