### PR TITLE
Reduce Container Dependencies

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,7 +10,6 @@ RUN apk -U upgrade && \
     poppler-utils \
     python3 \
     py3-magic \
-    py3-pillow \
     sudo \
     tesseract-ocr \
     tesseract-ocr-data-afr \
@@ -77,15 +76,6 @@ RUN apk -U upgrade && \
     tesseract-ocr-data-tur \
     tesseract-ocr-data-ukr \
     tesseract-ocr-data-vie
-
-# Install pdftk
-RUN \
-    wget https://gitlab.com/pdftk-java/pdftk/-/jobs/924565145/artifacts/raw/build/libs/pdftk-all.jar && \
-    mv pdftk-all.jar /usr/local/bin && \
-    chmod +x /usr/local/bin/pdftk-all.jar && \
-    echo '#!/bin/sh' > /usr/local/bin/pdftk && \
-    echo '/usr/bin/java -jar "/usr/local/bin/pdftk-all.jar" "$@"' >> /usr/local/bin/pdftk && \
-    chmod +x /usr/local/bin/pdftk
 
 COPY dangerzone.py /usr/local/bin/
 RUN chmod +x /usr/local/bin/dangerzone.py

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -6,7 +6,6 @@ RUN apk -U upgrade && \
     ghostscript \
     graphicsmagick \
     libreoffice \
-    openjdk8 \
     poppler-utils \
     python3 \
     py3-magic \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -9,7 +9,6 @@ RUN apk -U upgrade && \
     poppler-utils \
     python3 \
     py3-magic \
-    sudo \
     tesseract-ocr \
     tesseract-ocr-data-afr \
     tesseract-ocr-data-ara \


### PR DESCRIPTION
Removes three dependencies:
  - `sudo` - no longer needed
  - `openjdk-8` - see reasoning [here](https://github.com/freedomofpress/dangerzone/issues/232#issuecomment-1376149192)
  - `PDFtk` - explained below


## Removing PDFtk dependency (replace w/ pdftoppm)

PDFtk actually isn't needed. It was being used for breaking a PDF into pages but this is something that be replaced by the already present `pdftoppm` (packaged in `poppler-utils`). Furthermore, by removing this dependency we contribute to reproducible builds and overall supply chain security because it was obtained from gitlab with no signature verification or version pinning.

The replacement `pdftoppm` enabled us to do a shortcut:
    - before: PDF -> PDF pages -> PNG images -> RGB images
    - after:  PDF -> PPM images -> RGB images

### Note about PPM -> RGB "conversion"
And this last conversion step is trivial since the RGB format we were using is just a [PPM](https://en.wikipedia.org/wiki/Netpbm#File_formats) file without the metadata at the beginning. 

Furthermore, we were using a depth of [8 bits](https://github.com/freedomofpress/dangerzone/blob/642d868/container/dangerzone.py#L232) per color channel which is exactly the same depth as the the [.ppm file format](https://en.wikipedia.org/wiki/Netpbm#Description).

To verify the color accuracy, I compared two samples - one obtained from from `.pdf` to `.ppm` (via `pdftoppm`) and a "true" RGB file via the old process (`pdftocairo -png` + `gm convert input.png -depth 8 rgb:file.rgb`). Here's the result (compressed in `.png`) - left `.pdf`, center `.ppm` and right `.png`:

![comparison](https://user-images.githubusercontent.com/47065258/211543201-5b6c4694-c4db-4b52-8ac5-7576dbdc94f9.png)

When we compare the `.ppm` and the original `.rgb` file, we can see that they differ is some pixel values. But as can be seen in the picture, these minor differences are of little to no consequence to the final human-readable image.