### PR TITLE
Show Exceptions Raised During Document Conversion

### DIFF
--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -200,3 +200,6 @@ class Document:
         if not isinstance(other, Document):
             return False
         return self.input_filename == other.input_filename
+
+    def __hash__(self) -> int:
+        return hash(self.id)


### PR DESCRIPTION
Exceptions raised during the document conversion process would be silently hidden. This was because ThreadPoolExecuter created various threads and hid any exceptions raised.

Fixes #309