### PR TITLE
Fix Linter Failure in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           # Debian bug [1]. Once this bug is fixed, revert to installing
           # Poetry from the Debian repos instead, which is more stable.
           #
-          # Also, we pin the Poetry version to 1.2.2, to sidestep a Poetry bug
+          # Also, we run poetry with --no-ansi, to sidestep a Poetry bug
           # [2] that currently exists in 1.3.
           #
           # [1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1029156
@@ -98,8 +98,8 @@ jobs:
           command: |
             apt-get update
             apt-get install -y make python3 python3-pip --no-install-recommends
-            pip install poetry==1.2.2
-            poetry install --only lint
+            pip install poetry
+            poetry install --no-ansi --only lint
       - run:
           name: Run linters to enforce code style
           command: poetry run make lint

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -167,6 +167,8 @@ python3 -m pip install poetry
 
 Change to the `dangerzone` folder, and install the poetry dependencies:
 
+> **Note**: due to an issue with [poetry](https://github.com/python-poetry/poetry/issues/1917), if it prompts for your keying, disable the keyring with `keyring --disable` and run the command again.
+
 ```
 poetry install
 ```
@@ -212,6 +214,8 @@ python -m pip install poetry
 ```
 
 Change to the `dangerzone` folder, and install the poetry dependencies:
+
+> **Note**: due to an issue with [poetry](https://github.com/python-poetry/poetry/issues/1917), if it prompts for your keying, disable the keyring with `keyring --disable` and run the command again.
 
 ```
 poetry install


### PR DESCRIPTION
- unpins poetry version by using alternative fix to upstream bug in poetry (following @eloquence's [suggestion](https://github.com/freedomofpress/redmine_docs/blame/switch-to-poetry/.circleci/config.yml#L10))
- Fixes out of sync `BUILD.md` instructions and `qa.py`