### PR TITLE
Show Exceptions Raised During Document Conversion

### DIFF
--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -26,7 +26,13 @@ class IsolationProvider(ABC):
         stdout_callback: Optional[Callable] = None,
     ) -> None:
         document.mark_as_converting()
-        success = self._convert(document, ocr_lang, stdout_callback)
+        try:
+            success = self._convert(document, ocr_lang, stdout_callback)
+        except Exception:
+            success = False
+            log.exception(
+                f"An exception occurred while converting document '{document.id}'"
+            )
         if success:
             document.mark_as_safe()
             if document.archive_after_conversion:


### PR DESCRIPTION
Depends on #302; Replaces #310. 

Exceptions raised during the document conversion process would be silently hidden. This was because ThreadPoolExecuter created various threads and hid any exceptions raised.

Fixes https://github.com/freedomofpress/dangerzone/issues/309