### PR TITLE
Add a required --distro option to build-deb.py

### DIFF
--- a/install/linux/build-deb.py
+++ b/install/linux/build-deb.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
+import argparse
 import inspect
 import os
 import shutil
@@ -21,6 +23,22 @@ def run(cmd):
 
 
 def main():
+    parser = argparse.ArgumentParser(
+        prog=sys.argv[0],
+        description="Dev script for building Dangerzone debs",
+    )
+    # FIXME: The name of the distro is important, as it can help users who are upgrading
+    # from a distro version to another. If we *do* need to provide a name at some point,
+    # here's a suggestion on how we should tackle naming:
+    #
+    # https://github.com/freedomofpress/dangerzone/pull/322#issuecomment-1428665162
+    parser.add_argument(
+        "--distro",
+        required=False,
+        help="The name of the Debian-based distro",
+    )
+    args = parser.parse_args()
+
     dist_path = os.path.join(root, "dist")
     deb_dist_path = os.path.join(root, "deb_dist")
 
@@ -31,13 +49,31 @@ def main():
         shutil.rmtree(deb_dist_path)
 
     print("* Building DEB package")
-    # This command also builds the Debian source package, and then creates the DEB
-    # package, meaning that we don't need to run `sdist_dsc` as well.
-    run(["python3", "setup.py", "--command-packages=stdeb.command", "bdist_deb"])
+    # NOTE: This command first builds the Debian source package, and then creates the
+    # final DEB package. We could simply call `bdist_deb`, which performs `sdist_dsc`
+    # implicitly, but we wouldn't be able to pass the Debian version argument. Because
+    # we do this in a single invocation though, there's no performance cost.
+    if args.distro is None:
+        deb_ver_args = ()
+        deb_ver = "1"
+    else:
+        deb_ver_args = ("--debian-version", args.distro)
+        deb_ver = args.distro
+
+    run(
+        [
+            "python3",
+            "setup.py",
+            "--command-packages=stdeb.command",
+            "sdist_dsc",
+            *deb_ver_args,
+            "bdist_deb",
+        ]
+    )
 
     print("")
     print("* To install run:")
-    print("sudo dpkg -i deb_dist/dangerzone_{}-1_all.deb".format(version))
+    print(f"sudo dpkg -i deb_dist/dangerzone_{version}-{deb_ver}_all.deb")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since building with a Debian toolchain and an Ubuntu toolchain produce slightly different `.deb`s with different checksums, we want to tag each with the distro type in order to give them different filenames. This will allow them to coexist in the `packages.freedom.press` pool. (This is just about how packages are compressed right now, but perhaps someday there might be more significant differences, like one distro changes something related to container runtimes first.)

I've added `--distro` as a command-line option to match some other scripts in the repo. This is a required option for `build-deb.py`, so references to it in docs have been updated. I don't know if YAML inclusion (for CircleCI config) can pass a parameter so I just duplicated that block with a different `--distro`.

For the stdeb command itself, we used to just call `bdist_deb`, which took care of running `sdist_src` itself. However, `bdist_deb` can't pass additional options/arguments on to the subcommands it calls. So, it looks like the thing you can do is append multiple commands in the same argv. I did this, and successfully build a deb, but this needs to run through CI and be checked by a dev.