### PR TITLE
Consume container output when it's not parsed

### DIFF
--- a/container/dangerzone.py
+++ b/container/dangerzone.py
@@ -48,7 +48,13 @@ def run_command(
     """
     if stdout_callback is None and stderr_callback is None:
         try:
-            subprocess.run(args, timeout=timeout, check=True)
+            subprocess.run(
+                args,
+                timeout=timeout,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
         except subprocess.CalledProcessError as e:
             raise RuntimeError(error_message) from e
         except subprocess.TimeoutExpired as e:


### PR DESCRIPTION
Revert `run_command()` logic to sending again stdout and stderr to /dev/null (just as it was prior to commit d28aa5a). 

Fixes #316