### PR TITLE
Add missing Dangerzone module in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ dangerous PDFs, office documents, or images and converts them to safe PDFs. \
 It uses container technology to convert the documents within a secure sandbox.\
 """,
     url="https://github.com/freedomofpress/dangerzone",
-    packages=["dangerzone", "dangerzone.gui"],
+    packages=["dangerzone", "dangerzone.gui", "dangerzone.isolation_provider"],
     data_files=[
         (
             "share/applications",


### PR DESCRIPTION
While creating a Debian package for Dangerzone, we found out that the `dangerzone.isolation_provider` submodule was not copied to the final package. Turns out that it was missing from the packages list that we define in `setup.py`.

Include this package in the proper section in `setup.py`.