### PR TITLE
Introduce proportional timeouts

### DIFF
--- a/container/dangerzone.py
+++ b/container/dangerzone.py
@@ -121,6 +121,9 @@ class DangerzoneConverter:
         * Documents with lots of pages, but small file size.
         * Single images with large file size.
         """
+        if not int(os.environ.get("ENABLE_TIMEOUTS", 1)):
+            return None
+
         # Do not have timeouts lower than 10 seconds, if the file size is small, since
         # we need to take into account the program's startup time as well.
         timeout = max(TIMEOUT_PER_MB * size, 10)

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -36,6 +36,12 @@ def print_header(s: str) -> None:
 @click.option(
     "--unsafe-dummy-conversion", "dummy_conversion", flag_value=True, hidden=True
 )
+@click.option(
+    "--enable-timeouts / --disable-timeouts",
+    default=True,
+    show_default=True,
+    help="Enable/Disable timeouts during document conversion",
+)
 @click.argument(
     "filenames",
     required=True,
@@ -48,6 +54,7 @@ def print_header(s: str) -> None:
 def cli_main(
     output_filename: Optional[str],
     ocr_lang: Optional[str],
+    enable_timeouts: bool,
     filenames: List[str],
     archive: bool,
     dummy_conversion: bool,
@@ -57,7 +64,7 @@ def cli_main(
     if getattr(sys, "dangerzone_dev", False) and dummy_conversion:
         dangerzone = DangerzoneCore(Dummy())
     else:
-        dangerzone = DangerzoneCore(Container())
+        dangerzone = DangerzoneCore(Container(enable_timeouts=enable_timeouts))
 
     display_banner()
     if len(filenames) == 1 and output_filename:

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -62,6 +62,12 @@ class Application(QtWidgets.QApplication):
 @click.option(
     "--unsafe-dummy-conversion", "dummy_conversion", flag_value=True, hidden=True
 )
+@click.option(
+    "--enable-timeouts / --disable-timeouts",
+    default=True,
+    show_default=True,
+    help="Enable/Disable timeouts during document conversion",
+)
 @click.argument(
     "filenames",
     required=False,
@@ -71,7 +77,9 @@ class Application(QtWidgets.QApplication):
 )
 @click.version_option(version=get_version(), message="%(version)s")
 @errors.handle_document_errors
-def gui_main(dummy_conversion: bool, filenames: Optional[List[str]]) -> bool:
+def gui_main(
+    dummy_conversion: bool, filenames: Optional[List[str]], enable_timeouts: bool
+) -> bool:
     setup_logging()
 
     if platform.system() == "Darwin":
@@ -93,7 +101,7 @@ def gui_main(dummy_conversion: bool, filenames: Optional[List[str]]) -> bool:
         dummy = Dummy()
         dangerzone = DangerzoneGui(app, isolation_provider=dummy)
     else:
-        container = Container()
+        container = Container(enable_timeouts=enable_timeouts)
         dangerzone = DangerzoneGui(app, isolation_provider=container)
 
     # Allow Ctrl-C to smoothly quit the program instead of throwing an exception

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -36,8 +36,9 @@ class Container(IsolationProvider):
     # Name of the dangerzone container
     CONTAINER_NAME = "dangerzone.rocks/dangerzone"
 
-    def __init__(self) -> None:
-        pass
+    def __init__(self, enable_timeouts: bool) -> None:
+        self.enable_timeouts = 1 if enable_timeouts else 0
+        super().__init__()
 
     @staticmethod
     def get_runtime_name() -> str:
@@ -247,6 +248,8 @@ class Container(IsolationProvider):
             f"{document.input_filename}:/tmp/input_file",
             "-v",
             f"{pixel_dir}:/dangerzone",
+            "-e",
+            f"ENABLE_TIMEOUTS={self.enable_timeouts}",
         ]
         ret = self.exec_container(document, command, extra_args, stdout_callback)
         if ret != 0:
@@ -269,6 +272,8 @@ class Container(IsolationProvider):
                 f"OCR={ocr}",
                 "-e",
                 f"OCR_LANGUAGE={ocr_lang}",
+                "-e",
+                f"ENABLE_TIMEOUTS={self.enable_timeouts}",
             ]
             ret = self.exec_container(document, command, extra_args, stdout_callback)
             if ret != 0:


### PR DESCRIPTION
This is a PR that introduces proportional timeouts for the various Dangerzone commands that we use for doc conversions.

Taken from the respective commit:

> 
> Previously, we had a single timeout for each command (120 seconds),
> which didn't scale well either with the number of pages in a document,
> or with the size of the document.
> 
> In this commit, we look into each operation, and we're trying to figure
> out the following:
> 
> 1. What's the number of pages we will operate on?
> 2. How large is the document?
> 
> Knowing the above, we can break down a command into multiple operations,
> at least conceptually. Having a number of operations and a sane timeout
> value per operation (10 seconds), we can multiply those and reach to a
> timeout that fits the command better.

Fixes #327
Fixes #314
Fixes #306 

Note: The only thing missing for the PR is finding a large enough dataset in order to test this code against, and make it part of our CI tests.
