### PR TITLE
Fix failing CI by using PySide6 in all of our dev environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,10 +151,10 @@ jobs:
       - run:
           name: Install poetry dependencies
           command: |
-            # Remove this pin once the upstream Poetry issue is fixed:
+            sudo pip3 install poetry
+            # This flag is important, due to an open upstream Poetry issue:
             # https://github.com/python-poetry/poetry/issues/7184
-            sudo pip3 install poetry==1.2.2
-            poetry install
+            poetry install --no-ansi
       - run:
           name: Prepare cache directory
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,10 @@ jobs:
             # https://github.com/python-poetry/poetry/issues/7184
             poetry install --no-ansi
       - run:
+          name: Install test dependencies
+          command: |
+            sudo apt-get install -y libqt5gui5 --no-install-recommends
+      - run:
           name: Prepare cache directory
           command: |
             sudo mkdir -p /caches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,32 @@ jobs:
             ./dev_scripts/env.py --distro ubuntu --version 22.04 run --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
+  ci-fedora-37:
+    machine:
+      image: ubuntu-2004:202111-01
+    steps:
+      - checkout
+      - run: *install-podman
+
+      - run:
+          name: Prepare cache directory
+          command: |
+            sudo mkdir -p /caches
+            sudo chown -R $USER:$USER /caches
+      - restore_cache: *restore-cache
+      - run: *copy-image
+
+      - run:
+          name: Prepare Dangerzone environment
+          command: |
+            ./dev_scripts/env.py --distro fedora --version 37 build-dev
+
+      - run:
+          name: Run CI tests
+          command: |
+            ./dev_scripts/env.py --distro fedora --version 37 run --dev \
+                bash -c 'cd dangerzone; poetry run make test'
+
   ci-fedora-36:
     machine:
       image: ubuntu-2004:202111-01
@@ -464,6 +490,9 @@ workflows:
           requires:
             - build-container-image
       - ci-debian-bookworm:
+          requires:
+            - build-container-image
+      - ci-fedora-37:
           requires:
             - build-container-image
       - ci-fedora-36:

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -74,7 +74,7 @@ RUN dnf install -y rpm-build podman python3 make python3-pip qt5-qtbase-gui \
 
 # FIXME: Drop this fix after it's resolved upstream.
 # See https://github.com/freedomofpress/dangerzone/issues/286#issuecomment-1347149783
-RUN dnf reinstall -y shadow-utils && dnf clean all
+RUN rpm --restore shadow-utils
 
 RUN dnf install -y mupdf && dnf clean all
 """
@@ -120,7 +120,7 @@ RUN dnf install -y mupdf && dnf clean all
 
 # FIXME: Drop this fix after it's resolved upstream.
 # See https://github.com/freedomofpress/dangerzone/issues/286#issuecomment-1347149783
-RUN dnf reinstall -y shadow-utils && dnf clean all
+RUN rpm --restore shadow-utils
 """
 
 # The Dockerfile for building an environment with Dangerzone installed in it. Parts of

--- a/dev_scripts/pytest-wrapper.py
+++ b/dev_scripts/pytest-wrapper.py
@@ -14,7 +14,6 @@ import re
 import subprocess
 import sys
 
-import pytest
 from pkg_resources import parse_version
 
 from dangerzone.isolation_provider.container import Container
@@ -30,14 +29,22 @@ def get_podman_version():
     return version.split("-dev")[0]  # exclude "-dev" suffix from version
 
 
+def run_tests(pytest_args):
+    cmd = ["pytest"] + pytest_args
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
+        sys.exit(1)
+
+
 def run_tests_in_parallel(pytest_args):
-    args = pytest_args + ["-n", "4"]
-    exit_code = pytest.main(args)
+    print("running tests in parallel")
+    run_tests(pytest_args + ["-n", "4"])
 
 
 def run_tests_in_sequence(pytest_args):
     print("running tests sequentially")
-    exit_code = pytest.main(pytest_args)
+    run_tests(pytest_args)
 
 
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -583,25 +583,6 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
-name = "pyside2"
-version = "5.15.2.1"
-description = "Python bindings for the Qt cross-platform application and UI framework"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.11"
-files = [
-    {file = "PySide2-5.15.2.1-5.15.2-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:b5e1d92f26b0bbaefff67727ccbb2e1b577f2c0164b349b3d6e80febb4c5bde2"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:235240b6ec8206d9fdf0232472c6ef3241783d480425e5b54796f06e39ed23da"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-abi3-macosx_10_13_intel.whl", hash = "sha256:a9e2e6bbcb5d2ebb421e46e72244a0f4fe0943b2288115f80a863aacc1de1f06"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-abi3-manylinux1_x86_64.whl", hash = "sha256:23886c6391ebd916e835fa1b5ae66938048504fd3a2934ae3189a96cd5ac0b46"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-none-win32.whl", hash = "sha256:439509e53cfe05abbf9a99422a2cbad086408b0f9bf5e6f642ff1b13b1f8b055"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-none-win_amd64.whl", hash = "sha256:af6b263fe63ba6dea7eaebae80aa7b291491fe66f4f0057c0aafe780cc83da9d"},
-]
-
-[package.dependencies]
-shiboken2 = "5.15.2.1"
-
-[[package]]
 name = "pyside6"
 version = "6.4.2"
 description = "Python bindings for the Qt cross-platform application and UI framework"
@@ -815,22 +796,6 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-202
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
-name = "shiboken2"
-version = "5.15.2.1"
-description = "Python / C++ bindings helper module"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.11"
-files = [
-    {file = "shiboken2-5.15.2.1-5.15.2-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:f890f5611ab8f48b88cfecb716da2ac55aef99e2923198cefcf781842888ea65"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:87079c07587859a525b9800d60b1be971338ce9b371d6ead81f15ee5a46d448b"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-abi3-macosx_10_13_intel.whl", hash = "sha256:ffd3d0ec3d508e592d7ee3885d27fee1f279a49989f734eb130f46d9501273a9"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-abi3-manylinux1_x86_64.whl", hash = "sha256:63debfcc531b6a2b4985aa9b71433d2ad3bac542acffc729cc0ecaa3854390c0"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-none-win32.whl", hash = "sha256:eb0da44b6fa60c6bd317b8f219e500595e94e0322b33ec5b4e9f406bedaee555"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-none-win_amd64.whl", hash = "sha256:a0d0fdeb12b72c8af349b9642ccc67afd783dca449309f45e78cda50272fd6b7"},
-]
-
-[[package]]
 name = "shiboken6"
 version = "6.4.2"
 description = "Python/C++ bindings helper module"
@@ -945,5 +910,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7,<3.11"
-content-hash = "0c6081bcb22cdd2dae101bb2eaf3d5128b230246b653ca2abb400ad1fad7dc54"
+python-versions = ">=3.7,<3.12"
+content-hash = "6f9d5cf06f7f00efbf05fe3531356e29796538a990ed43f2638541dd66003428"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,10 @@ authors = ["Micah Lee <micah.lee@theintercept.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.11"
+python = ">=3.7,<3.12"
 click = "*"
 appdirs = "*"
-PySide2 = {version = "5.15.2.1", platform = "linux"}
-PySide6 = {version = "^6.4.1", markers = "sys_platform == 'win32' or sys_platform == 'darwin'"}
+PySide6 = "^6.4.1"
 colorama = "*"
 pyxdg = {version = "*", platform = "linux"}
 


### PR DESCRIPTION
Our CI currently fails for several reasons, the main one being that more and more environments (Fedora 37, Debian Bookworm) use Python 3.11, which is incompatible with PySide2 from PyPI.

In this PR, we remove PySide2 as a dev dependency, and we use PySide6 for all of our environments. The Debian/Fedora packages for Dangerzone will still require PySide2, but that should be the last reference to PySide2 remaining, until we fuly complete the Qt6 transition.

Fixes #294
Fixes #330

_(This PR depends on top of #296)_