### PR TITLE
Container: fix issues pdftoppm-related (timeout & errors)

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -8,6 +8,7 @@ RUN apk -U upgrade && \
     libreoffice \
     openjdk8 \
     poppler-utils \
+    poppler-data \
     python3 \
     py3-magic \
     tesseract-ocr \

--- a/container/dangerzone.py
+++ b/container/dangerzone.py
@@ -305,7 +305,10 @@ class DangerzoneConverter:
                 num_pages = int(num_pages_str)
                 page = int(page_str)
             except ValueError as e:
-                raise RuntimeError("Conversion from PDF to PPM failed") from e
+                # Ignore all non-progress related output, since pdftoppm sends
+                # everything to stderr and thus, errors can't be distinguished
+                # easily. We rely instead on the exit code.
+                return
 
             percentage_per_page = 45.0 / num_pages
             self.percentage += percentage_per_page


### PR DESCRIPTION
After running the documents over a large test set some issues related to `pdftoppm` came to light. This provides fixes to some of those issues.