### PR TITLE
Enable building an Ubuntu Focal Dangerzone env

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -5,8 +5,8 @@
 Install dependencies:
 
 ```sh
-sudo apt install -y podman dh-python make libqt5gui5 \
-    python3 python3-dev python3-venv python3-pip python3-stdeb
+sudo apt install -y podman dh-python build-essential fakeroot make libqt5gui5 \
+    python3 python3-dev python3-venv python3-pip python3-stdeb python3-all
 ```
 
 Install poetry (you may need to add `~/.local/bin/` to your `PATH` first):

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -60,7 +60,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends podman uidmap dh-python make \
-        libqt5gui5 python3 python3-dev python3-venv python3-pip python3-stdeb \
+        build-essential fakeroot libqt5gui5 python3 python3-dev python3-venv \
+        python3-pip python3-stdeb python3-all \
     && rm -rf /var/lib/apt/lists/*
 RUN apt-get update \
     && apt-get install -y --no-install-recommends mupdf \

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -762,6 +762,24 @@ class QADebianBased(QALinux):
         self.shell_run("./install/linux/build-deb.py")
 
 
+class QADebianBullseye(QADebianBased):
+
+    DISTRO = "debian"
+    VERSION = "bullseye"
+
+
+class QADebianBookworm(QADebianBased):
+
+    DISTRO = "debian"
+    VERSION = "bookworm"
+
+
+class QAUbuntu2004(QADebianBased):
+
+    DISTRO = "ubuntu"
+    VERSION = "20.04"
+
+
 class QAUbuntu2204(QADebianBased):
 
     DISTRO = "ubuntu"

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -155,8 +155,8 @@ CONTENT_BUILD_DEBIAN_UBUNTU = r"""## Debian/Ubuntu
 Install dependencies:
 
 ```sh
-sudo apt install -y podman dh-python make libqt5gui5 \
-    python3 python3-dev python3-venv python3-pip python3-stdeb
+sudo apt install -y podman dh-python build-essential fakeroot make libqt5gui5 \
+    python3 python3-dev python3-venv python3-pip python3-stdeb python3-all
 ```
 
 Install poetry (you may need to add `~/.local/bin/` to your `PATH` first):


### PR DESCRIPTION
Add some missing build dependencies, and the ability to install Podman, on Ubuntu Focal envs. Then, add it as an extra distro, along with some that were missing, in our QA script.