### PR TITLE
Add instructions for publishing/installing Debian packages to/from packages.freedom.press

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,10 +38,25 @@ Dangerzone is available for:
   ```
 </details>
 
-Add our repository following [these instructions](https://packagecloud.io/firstlookmedia/code/install#manual-deb), or by running this script:
+Add our repository following these instructions:
 
+Download the GPG key for the repo:
+
+```sh
+gpg --keyserver hkps://keys.openpgp.org \
+    --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
+    --recv-keys "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281"
+sudo mkdir -p /etc/apt/keyrings/
+sudo mv fpf-apt-tools-archive-keyring.gpg /etc/apt/keyrings
 ```
-curl -s https://packagecloud.io/install/repositories/firstlookmedia/code/script.deb.sh | sudo bash
+
+Add the URL of the repo in your APT sources:
+
+```sh
+source /etc/os-release
+echo deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
+    https://packages.freedom.press/apt-tools-prod ${VERSION_CODENAME?} main \
+    | sudo tee /etc/apt/sources.list.d/fpf-apt-tools.list
 ```
 
 Install Dangerzone:
@@ -50,6 +65,22 @@ Install Dangerzone:
 sudo apt update
 sudo apt install -y dangerzone
 ```
+
+<details>
+  <summary><i>:memo: Expand this section for a security notice on third-party Debian repos</i></summary>
+  </br>
+
+  This section follows the official instructions on configuring [third-party
+  Debian repos](https://wiki.debian.org/DebianRepository/UseThirdParty).
+
+  To mitigate a class of attacks against our APT repo (e.g., injecting packages
+  signed with an attacker key), we add an additional step in our instructions to
+  verify the downloaded GPG key against its fingerprint.
+
+  Aside from these protections, the user needs to be aware that Debian packages
+  run as `root` during the installation phase, so they need to place some trust
+  on our signed Debian packages. This holds for any third-party Debian repo.
+</details>
 
 ### Fedora
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -212,6 +212,40 @@ Rename `Dangerzone.msi` to `Dangerzone-$VERSION.msi`.
 
 ## Linux release
 
+### Debian/Ubuntu
+
+Because the Debian packages do not contain compiled Python code for a specific
+Python version, we can create a single Debian package and use it for all of our
+Debian-based distros.
+
+Create a Debian Bookworm development environment. You can [follow the
+instructions in our build section](https://github.com/freedomofpress/dangerzone/blob/main/BUILD.md#debianubuntu),
+or create your own locally with:
+
+```sh
+./dev_scripts/env.py --distro debian --version bookworm build-dev
+./dev_scripts/env.py --distro debian --version bookworm run --dev bash
+cd dangerzone
+```
+
+Build the latest container:
+
+```sh
+./install/linux/build-image.sh
+```
+
+Create a .deb:
+
+```sh
+./install/linux/build-deb.py
+```
+
+Publish the .deb under `./deb_dist` to the
+[`freedomofpress/apt-tools-prod`](https://github.com/freedomofpress/apt-tools-prod)
+repo, by sending a PR. Follow the instructions in that repo on how to do so.
+
+### Fedora
+
 Linux binaries are automatically built and deployed to repositories when a new tag is pushed.
 
 ### Fedora


### PR DESCRIPTION
This is a draft PR for updating our Debian/Ubuntu instructions, in preparation for the PackageCloud -> packages.freedom.press transition. It's draft for the following reason:

1. It depends on bringing our APT repo to a state that users can use. This means having a proper GPG key, submitting it somewhere that users can download, and testing our instructions in all platforms.

Outdated reasons:

2. The instructions may change if we use [`extrepo`](https://grep.be/blog/en/computer/debian/Announcing_extrepo/) as an easy way for users to add our repo.
    * Update: We _can_ use `extrepo`, once we have a proper key, but it will not be a blocker for the release.
3. It is based on a PR (#346) that will be merged soon.
   * Update: Merged.

Fixes #291