### PR TITLE
Install Poetry in compliance with PEP 668

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,32 @@ jobs:
             ./dev_scripts/env.py --distro ubuntu --version 22.04 run --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
+  ci-ubuntu-focal:
+    machine:
+      image: ubuntu-2004:202111-01
+    steps:
+      - checkout
+      - run: *install-podman
+
+      - run:
+          name: Prepare cache directory
+          command: |
+            sudo mkdir -p /caches
+            sudo chown -R $USER:$USER /caches
+      - restore_cache: *restore-cache
+      - run: *copy-image
+
+      - run:
+          name: Prepare Dangerzone environment
+          command: |
+            ./dev_scripts/env.py --distro ubuntu --version 20.04 build-dev
+
+      - run:
+          name: Run CI tests
+          command: |
+            ./dev_scripts/env.py --distro ubuntu --version 20.04 run --dev \
+                bash -c 'cd dangerzone; poetry run make test'
+
   ci-fedora-37:
     machine:
       image: ubuntu-2004:202111-01
@@ -293,6 +319,32 @@ jobs:
           name: Run CI tests
           command: |
             ./dev_scripts/env.py --distro debian --version bookworm run --dev \
+                bash -c 'cd dangerzone; poetry run make test'
+
+  ci-debian-bullseye:
+    machine:
+      image: ubuntu-2004:202111-01
+    steps:
+      - checkout
+      - run: *install-podman
+
+      - run:
+          name: Prepare cache directory
+          command: |
+            sudo mkdir -p /caches
+            sudo chown -R $USER:$USER /caches
+      - restore_cache: *restore-cache
+      - run: *copy-image
+
+      - run:
+          name: Prepare Dangerzone environment
+          command: |
+            ./dev_scripts/env.py --distro debian --version bullseye build-dev
+
+      - run:
+          name: Run CI tests
+          command: |
+            ./dev_scripts/env.py --distro debian --version bullseye run --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
   build-ubuntu-kinetic:
@@ -483,7 +535,13 @@ workflows:
       - ci-ubuntu-jammy:
           requires:
             - build-container-image
+      - ci-ubuntu-focal:
+          requires:
+            - build-container-image
       - ci-debian-bookworm:
+          requires:
+            - build-container-image
+      - ci-debian-bullseye:
           requires:
             - build-container-image
       - ci-fedora-37:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,19 +86,13 @@ jobs:
       - run:
           name: Install dev. dependencies
           # Install only the necessary packages to run our linters.
-          # FIXME: We currently install Poetry from PyPI, due to an upstream
-          # Debian bug [1]. Once this bug is fixed, revert to installing
-          # Poetry from the Debian repos instead, which is more stable.
           #
-          # Also, we run poetry with --no-ansi, to sidestep a Poetry bug
-          # [2] that currently exists in 1.3.
-          #
-          # [1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1029156
-          # [2]: https://github.com/freedomofpress/dangerzone/issues/292#issuecomment-1351368122
+          # We run poetry with --no-ansi, to sidestep a Poetry bug that
+          # currently exists in 1.3. See:
+          # https://github.com/freedomofpress/dangerzone/issues/292#issuecomment-1351368122
           command: |
             apt-get update
-            apt-get install -y make python3 python3-pip --no-install-recommends
-            pip install poetry
+            apt-get install -y make python3 python3-poetry --no-install-recommends
             poetry install --no-ansi --only lint
       - run:
           name: Run linters to enforce code style

--- a/BUILD.md
+++ b/BUILD.md
@@ -6,14 +6,21 @@ Install dependencies:
 
 ```sh
 sudo apt install -y podman dh-python build-essential fakeroot make libqt5gui5 \
-    python3 python3-dev python3-venv python3-pip python3-stdeb python3-all
+    pipx python3 python3-dev python3-stdeb python3-all
 ```
 
-Install poetry (you may need to add `~/.local/bin/` to your `PATH` first):
+Install Poetry using `pipx` (recommended) and add it to your `$PATH`:
+
+_(See also a list of [alternative installation
+methods](https://python-poetry.org/docs/#installation))_
 
 ```sh
-python3 -m pip install poetry
+pipx ensurepath
+pipx install poetry
 ```
+
+After this, restart the terminal window, for the `poetry` command to be in your
+`$PATH`.
 
 Change to the `dangerzone` folder, and install the poetry dependencies:
 
@@ -53,13 +60,13 @@ Create a .deb:
 Install dependencies:
 
 ```sh
-sudo dnf install -y rpm-build podman python3 python3-pip qt5-qtbase-gui
+sudo dnf install -y rpm-build podman python3 pipx qt5-qtbase-gui
 ```
 
-Install poetry:
+Install Poetry using `pipx`:
 
 ```sh
-python -m pip install poetry
+pipx install poetry
 ```
 
 Change to the `dangerzone` folder, and install the poetry dependencies:

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -380,7 +380,7 @@ class Env:
         """Build a Linux environment and install tools for Dangerzone development."""
         if self.distro == "fedora":
             install_deps = DOCKERFILE_BUILD_DEV_FEDORA_DEPS
-        elif self.distro == "ubuntu" and self.version == "20.04":
+        elif self.distro == "ubuntu" and self.version in ("20.04", "focal"):
             install_deps = (
                 DOCKERFILE_UBUNTU_2004_DEPS + DOCKERFILE_BUILD_DEV_DEBIAN_DEPS
             )
@@ -418,7 +418,7 @@ class Env:
             install_cmd = "dnf install -y"
         else:
             install_deps = DOCKERFILE_BUILD_DEBIAN_DEPS
-            if self.distro == "ubuntu" and self.version == "20.04":
+            if self.distro == "ubuntu" and self.version in ("20.04", "focal"):
                 install_deps = (
                     DOCKERFILE_UBUNTU_2004_DEPS + DOCKERFILE_BUILD_DEBIAN_DEPS
                 )

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -371,7 +371,7 @@ class Env:
             print(" ".join(self.runtime_cmd + list(run_cmd)))
             return
 
-        dist_state.mkdir(exist_ok=True)
+        dist_state.mkdir(parents=True, exist_ok=True)
         (dist_state / "containers").mkdir(exist_ok=True)
         (dist_state / ".bash_history").touch(exist_ok=True)
         self.runtime_run(*run_cmd)

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -156,14 +156,21 @@ Install dependencies:
 
 ```sh
 sudo apt install -y podman dh-python build-essential fakeroot make libqt5gui5 \
-    python3 python3-dev python3-venv python3-pip python3-stdeb python3-all
+    pipx python3 python3-dev python3-stdeb python3-all
 ```
 
-Install poetry (you may need to add `~/.local/bin/` to your `PATH` first):
+Install Poetry using `pipx` (recommended) and add it to your `$PATH`:
+
+_(See also a list of [alternative installation
+methods](https://python-poetry.org/docs/#installation))_
 
 ```sh
-python3 -m pip install poetry
+pipx ensurepath
+pipx install poetry
 ```
+
+After this, restart the terminal window, for the `poetry` command to be in your
+`$PATH`.
 
 Change to the `dangerzone` folder, and install the poetry dependencies:
 
@@ -204,13 +211,13 @@ CONTENT_BUILD_FEDORA = r"""## Fedora
 Install dependencies:
 
 ```sh
-sudo dnf install -y rpm-build podman python3 python3-pip qt5-qtbase-gui
+sudo dnf install -y rpm-build podman python3 pipx qt5-qtbase-gui
 ```
 
-Install poetry:
+Install Poetry using `pipx`:
 
 ```sh
-python -m pip install poetry
+pipx install poetry
 ```
 
 Change to the `dangerzone` folder, and install the poetry dependencies:


### PR DESCRIPTION
Update our CI scripts and build instructions to replace `pip install poetry` with something which complies with PEP 668. More specifically:

1. For Debian Bookworm, we install Poetry from APT, as it's the desired version and there are no critical upstream bugs anymore.
2. For our CI environments, we install Poetry via `pipx`, which is the recommended way.
3. For user environments, we also suggest installing Poetry via `pipx` for security reasons, although we provide a link to alternative installlation methods.

Fixes #351