### PR TITLE
Fix "Choose..." button not opening dir selection dialog on Qt6

### DIFF
--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -610,8 +610,8 @@ class SettingsWidget(QtWidgets.QWidget):
         # open the directory where the user last saved it
         dialog.setDirectory(self.dangerzone.output_dir)
 
-        # allow only the selection of directories
-        dialog.setFileMode(QtWidgets.QFileDialog.DirectoryOnly)
+        # Allow only the selection of directories
+        dialog.setFileMode(QtWidgets.QFileDialog.Directory)
         dialog.setOption(QtWidgets.QFileDialog.ShowDirsOnly, True)
 
         if dialog.exec_() == QtWidgets.QFileDialog.Accepted:


### PR DESCRIPTION
When clicking on the "Choose..." button nothing would happen visually and it would show the error:

```python
  Traceback (most recent call last):
    File "/home/user/dangerzone/dangerzone/gui/main_window.py", line 614, in select_output_directory
      dialog.setFileMode(QtWidgets.QFileDialog.DirectoryOnly)
```

According to the PySide docs, QFileDialog.DirectoryOnly has been deprecated in Qt4.6 [1]. This was not an issue probably on PySide2 because it must have used an earlier Qt version.

Fixes #360

[1]: https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QFileDialog.html#PySide2.QtWidgets.PySide2.QtWidgets.QFileDialog.FileMode