### PR TITLE
Bump timeouts

### DIFF
--- a/container/dangerzone.py
+++ b/container/dangerzone.py
@@ -25,8 +25,9 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import magic
 
-TIMEOUT_PER_PAGE: float = 10  # (seconds)
-TIMEOUT_PER_MB: float = 10  # (seconds)
+TIMEOUT_PER_PAGE: float = 30  # (seconds)
+TIMEOUT_PER_MB: float = 30  # (seconds)
+TIMEOUT_MIN: float = 60  # (seconds)
 
 
 async def read_stream(sr: asyncio.StreamReader, callback: Callable = None) -> bytes:
@@ -126,7 +127,7 @@ class DangerzoneConverter:
 
         # Do not have timeouts lower than 10 seconds, if the file size is small, since
         # we need to take into account the program's startup time as well.
-        timeout = max(TIMEOUT_PER_MB * size, 10)
+        timeout = max(TIMEOUT_PER_MB * size, TIMEOUT_MIN)
         if pages:
             timeout = max(timeout, TIMEOUT_PER_PAGE * pages)
         return timeout


### PR DESCRIPTION
Perform the following timeout bumps:

1. Increase the minimum timeout per page/MiB by x3. The rationale is that 10 seconds is a reasonable timeout, but to be on the safe side, it's best if we multiply it by a safety factor.
2. Increase the minimum timeout from 10 seconds to 60 seconds. 10 seconds may be too little if the application runtime (e.g., LibreOffice) is slow to start due to background CPU thrashing.