### PR TITLE
Grab just the image ID

### DIFF
--- a/install/linux/build-image.sh
+++ b/install/linux/build-image.sh
@@ -11,4 +11,4 @@ echo "Saving and compressing container image"
 podman save $TAG | gzip > share/container.tar.gz
 
 echo "Looking up the image id"
-podman images --filter=reference=$TAG > share/image-id.txt
+podman images -q --filter=reference=$TAG > share/image-id.txt

--- a/install/macos/build-image.sh
+++ b/install/macos/build-image.sh
@@ -11,4 +11,4 @@ echo "Saving and compressing container image"
 docker save $TAG | gzip > share/container.tar.gz
 
 echo "Looking up the image id"
-docker images --filter=reference=$TAG > share/image-id.txt
+docker images -q --filter=reference=$TAG > share/image-id.txt


### PR DESCRIPTION
When building the image, grab the image id using `-q`, which removes all the decorations in the output and just keeps the image ID.