### PR TITLE
 WIP: Add instructions for publishing/installing Fedora packages to/from packages.freedom.press

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,17 +53,52 @@ sudo apt install -y dangerzone
 
 ### Fedora
 
-Add our repository following [these instructions](https://packagecloud.io/firstlookmedia/code/install#manual-rpm), or by running this script:
+### 1. Add our repository
+
+Start by installing our repository. This allows you to
+
+Open a terminal window and type the following commands:
 
 ```
-curl -s https://packagecloud.io/install/repositories/firstlookmedia/code/script.rpm.sh | sudo bash
+gpg --keyserver hkps://keys.openpgp.org --recv-key "DE28 AB24 1FA4 8260 FAC9  B8BA A7C9 B385 2260 4281"
+gpg --export --armor A7C9B38522604281 | sudo tee /etc/pki/rpm-gpg/RPM-GPG-dangerzone.pub > /dev/null
+sudo yum-config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 ```
 
-Install Dangerzone:
+
+### 2. Install Dangerzone
+
 
 ```
-sudo dnf install -y dangerzone
+sudo dnf install dangerzone
 ```
+
+<details>
+<summary>Importing GPG key 0x22604281: ... Is this ok [y/N]:</summary>
+
+After some minutes of running the above command (depending on your internet speed) you'll be asked to confirm the fingerprint of our signing key. This is to make sure that in the case our servers are compromized your computer stays safe. It should look like this:
+
+```console
+--------------------------------------------------------------------------------
+Total                                           389 kB/s | 732 MB     32:07
+Dangerzone repository                           3.8 MB/s | 3.8 kB     00:00
+Importing GPG key 0x22604281:
+ Userid     : "Dangerzone Release Key <dangerzone-release-key@freedom.press>"
+ Fingerprint: DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281
+ From       : /etc/pki/rpm-gpg/RPM-GPG-dangerzone.pub
+Is this ok [y/N]:
+```
+
+> **Note**: If it does not show this fingerprint confirmation or the fingerprint does not match, it is possible that our servers were compromized. Be distrustful and reach our to us.
+
+The `Fingerprint` should be `DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281`. For extra security, you should confirm matches the one at the bottom of our website ([dangerzone.rocks](https://dangerzone.rocks)) and our [mastodon account](https://fosstodon.org/@dangerzone) bio.
+
+After confirming that it matches, type `y` (for yes) and the installation should proceed.
+
+
+</details>
+
+
 
 ## Build from source
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,21 +53,10 @@ sudo apt install -y dangerzone
 
 ### Fedora
 
-### 1. Add our repository
-
-Open a terminal window and type the following commands:
+Type the following commands in a terminal:
 
 ```
-gpg --keyserver hkps://keys.openpgp.org --recv-key "DE28 AB24 1FA4 8260 FAC9  B8BA A7C9 B385 2260 4281"
-gpg --export --armor A7C9B38522604281 | sudo tee /etc/pki/rpm-gpg/RPM-GPG-dangerzone.pub > /dev/null
-sudo yum-config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
-```
-
-
-### 2. Install Dangerzone
-
-
-```
+sudo dnf config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,8 +55,6 @@ sudo apt install -y dangerzone
 
 ### 1. Add our repository
 
-Start by installing our repository. This allows you to
-
 Open a terminal window and type the following commands:
 
 ```
@@ -89,7 +87,7 @@ Importing GPG key 0x22604281:
 Is this ok [y/N]:
 ```
 
-> **Note**: If it does not show this fingerprint confirmation or the fingerprint does not match, it is possible that our servers were compromized. Be distrustful and reach our to us.
+> **Note**: If it does not show this fingerprint confirmation or the fingerprint does not match, it is possible that our servers were compromized. Be distrustful and reach out to us.
 
 The `Fingerprint` should be `DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281`. For extra security, you should confirm matches the one at the bottom of our website ([dangerzone.rocks](https://dangerzone.rocks)) and our [mastodon account](https://fosstodon.org/@dangerzone) bio.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,7 +78,7 @@ Is this ok [y/N]:
 
 > **Note**: If it does not show this fingerprint confirmation or the fingerprint does not match, it is possible that our servers were compromized. Be distrustful and reach out to us.
 
-The `Fingerprint` should be `DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281`. For extra security, you should confirm matches the one at the bottom of our website ([dangerzone.rocks](https://dangerzone.rocks)) and our [mastodon account](https://fosstodon.org/@dangerzone) bio.
+The `Fingerprint` should be `DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281`. For extra security, you should confirm it matches the one at the bottom of our website ([dangerzone.rocks](https://dangerzone.rocks)) and our [Mastodon account](https://fosstodon.org/@dangerzone) bio.
 
 After confirming that it matches, type `y` (for yes) and the installation should proceed.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -214,10 +214,6 @@ Linux binaries are automatically built and deployed to repositories when a new t
 
 ### Fedora
 
-Because the Fedora packages do not contain compiled Python code for a specific
-Python version, we can create a single Debian package and use it for all of our
-Debian-based distros.
-
 > **NOTE**: This procedure will have to be done for every supported Fedora version.
 >
 > In this example, we'll use Fedora 37 as an example.
@@ -245,7 +241,7 @@ Create a .rpm:
 ```
 
 Publish the .rpm under `./dist` to the
-[`freedomofpress/yum-tools-prod`](https://github.com/freedomofpress/yum-tools-prod) repo, but sending a PR. Follow the instructions in that repo on how to do so.
+[`freedomofpress/yum-tools-prod`](https://github.com/freedomofpress/yum-tools-prod) repo, by sending a PR. Follow the instructions in that repo on how to do so.
 
 
 ## Publishing the release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -212,6 +212,42 @@ Rename `Dangerzone.msi` to `Dangerzone-$VERSION.msi`.
 
 Linux binaries are automatically built and deployed to repositories when a new tag is pushed.
 
+### Fedora
+
+Because the Fedora packages do not contain compiled Python code for a specific
+Python version, we can create a single Debian package and use it for all of our
+Debian-based distros.
+
+> **NOTE**: This procedure will have to be done for every supported Fedora version.
+>
+> In this example, we'll use Fedora 37 as an example.
+
+Create a Fedora development environment. You can [follow the
+instructions in our build section](https://github.com/freedomofpress/dangerzone/blob/main/BUILD.md#fedora),
+or create your own locally with:
+
+```sh
+./dev_scripts/env.py --distro fedora --version 37 build-dev
+./dev_scripts/env.py --distro fedora --version 37 run --dev bash
+cd dangerzone
+```
+
+Build the latest container:
+
+```sh
+./install/linux/build-image.sh
+```
+
+Create a .rpm:
+
+```sh
+./install/linux/build-rpm.py
+```
+
+Publish the .rpm under `./dist` to the
+[`freedomofpress/yum-tools-prod`](https://github.com/freedomofpress/yum-tools-prod) repo, but sending a PR. Follow the instructions in that repo on how to do so.
+
+
 ## Publishing the release
 
 To publish the release:


### PR DESCRIPTION
Adds install / deployment instructions for Fedora.

Install deployment suggests:
  - adding our key fingerprint to dangerzone.rocks and mastodon bio, potentially (for cross-checking), following [GrapheneOS's approach](https://grapheneos.org/install/cli#obtaining-factory-images) to fingerprint verification (as opposed to the rather complex PGP web of trust)
  - adding a repo definition to packages.freedom.press for easier installation