### PR TITLE
Enable container logging and add large test logic and documentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/test_docs_large"]
+	path = tests/test_docs_large
+	url = https://github.com/freedomofpress/dangerzone-test-set

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test:
 	# shared state.
 	# See more in https://github.com/freedomofpress/dangerzone/issues/493
 	pytest --co -q tests/gui | grep -v ' collected' | xargs -n 1 pytest -v
-	pytest -v --cov --ignore dev_scripts --ignore tests/gui
+	pytest -v --cov --ignore dev_scripts --ignore tests/gui --ignore tests/test_large_set.py
 
 
 # Makefile self-help borrowed from the securedrop-client project

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ MYPY_ARGS := --ignore-missing-imports \
 			 --disallow-untyped-defs \
 			 --show-error-codes \
 			 --warn-unreachable \
-			 --warn-unused-ignores
+			 --warn-unused-ignores \
+			 --exclude $(LARGE_TEST_REPO_DIR)/*.py
 
 mypy-host:
 	mypy $(MYPY_ARGS) dangerzone
@@ -57,12 +58,13 @@ test-large-init: test-large-requirements
 	@echo "initializing 'test_docs_large' submodule"
 	git submodule init $(LARGE_TEST_REPO_DIR)
 	git submodule update $(LARGE_TEST_REPO_DIR)
-	git lfs pull $(LARGE_TEST_REPO_DIR)
+	cd $(LARGE_TEST_REPO_DIR) && $(MAKE) clone-docs
 
 TEST_LARGE_RESULTS:=$(LARGE_TEST_REPO_DIR)/results/junit/commit_$(GIT_DESC).junit.xml
 .PHONY: tests-large
 test-large: test-large-init  ## Run large test set
 	python -m pytest tests/test_large_set.py::TestLargeSet -v $(JUNIT_FLAGS) --junitxml=$(TEST_LARGE_RESULTS)
+	python $(TEST_LARGE_RESULTS)/report.py $(TEST_LARGE_RESULTS)
 
 # Makefile self-help borrowed from the securedrop-client project
 # Explaination of the below shell command should it ever break.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-large-init: test-large-requirements
 TEST_LARGE_RESULTS:=$(LARGE_TEST_REPO_DIR)/results/junit/commit_$(GIT_DESC).junit.xml
 .PHONY: tests-large
 test-large: test-large-init  ## Run large test set
-	python -m pytest tests/test_large_set.py::TestLargeSet -v $(JUNIT_FLAGS) --junitxml=$(TEST_LARGE_RESULTS)
+	python -m pytest --tb=no tests/test_large_set.py::TestLargeSet -v $(JUNIT_FLAGS) --junitxml=$(TEST_LARGE_RESULTS)
 	python $(TEST_LARGE_RESULTS)/report.py $(TEST_LARGE_RESULTS)
 
 # Makefile self-help borrowed from the securedrop-client project

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,14 @@
 
 This section documents the release process. Unless you're a dangerzone developer making a release, you'll probably never need to follow it.
 
+## Large document testing
+
+Parallel to the QA process, the release candidate should be put through the large document tests in a dedicated machine to run overnight.
+
+Follow the instructions in `docs/developer/TESTING.md` to run the tests.
+
+These tests will identify any regressions or progression in terms of document coverage.
+
 ## QA
 
 To ensure that new releases do not introduce regressions, and support existing

--- a/dangerzone/conversion/common.py
+++ b/dangerzone/conversion/common.py
@@ -22,84 +22,87 @@ def running_on_qubes() -> bool:
     return os.path.exists("/usr/share/qubes/marker-vm")
 
 
-async def read_stream(
-    sr: asyncio.StreamReader, callback: Optional[Callable] = None
-) -> bytes:
-    """Consume a byte stream line-by-line.
-
-    Read all lines in a stream until EOF. If a user has passed a callback, call it for
-    each line.
-
-    Note that the lines are in bytes, since we can't assume that all command output will
-    be UTF-8 encoded. Higher level commands are advised to decode the output to Unicode,
-    if they know its encoding.
-    """
-    buf = b""
-    while True:
-        line = await sr.readline()
-        if sr.at_eof():
-            break
-        if callback is not None:
-            callback(line)
-        # TODO: This would be a good place to log the received line, mostly for debug
-        # logging.
-        buf += line
-    return buf
-
-
-async def run_command(
-    args: List[str],
-    *,
-    error_message: str,
-    timeout_message: str,
-    timeout: Optional[float],
-    stdout_callback: Optional[Callable] = None,
-    stderr_callback: Optional[Callable] = None,
-) -> Tuple[bytes, bytes]:
-    """Run a command and get its output.
-
-    Run a command using asyncio.subprocess, consume its standard streams, and return its
-    output in bytes.
-
-    :raises RuntimeError: if the process returns a non-zero exit status
-    :raises TimeoutError: if the process times out
-    """
-    # Start the provided command, and return a handle. The command will run in the
-    # background.
-    proc = await asyncio.subprocess.create_subprocess_exec(
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-
-    assert proc.stdout is not None
-    assert proc.stderr is not None
-
-    # Create asynchronous tasks that will consume the standard streams of the command,
-    # and call callbacks if necessary.
-    stdout_task = asyncio.create_task(read_stream(proc.stdout, stdout_callback))
-    stderr_task = asyncio.create_task(read_stream(proc.stderr, stderr_callback))
-
-    # Wait until the command has finished, for a specific timeout. Then, verify that the
-    # command has completed successfully. In any other case, raise an exception.
-    try:
-        ret = await asyncio.wait_for(proc.wait(), timeout=timeout)
-    except asyncio.exceptions.TimeoutError:
-        raise TimeoutError(timeout_message)
-    if ret != 0:
-        raise RuntimeError(error_message)
-
-    # Wait until the tasks that consume the command's standard streams have exited as
-    # well, and return their output.
-    stdout = await stdout_task
-    stderr = await stderr_task
-    return (stdout, stderr)
-
-
 class DangerzoneConverter:
     def __init__(self, progress_callback: Optional[Callable] = None) -> None:
         self.percentage: float = 0.0
         self.progress_callback = progress_callback
+        self.captured_output: bytes = b""
+
+    async def read_stream(
+        self, sr: asyncio.StreamReader, callback: Optional[Callable] = None
+    ) -> bytes:
+        """Consume a byte stream line-by-line.
+
+        Read all lines in a stream until EOF. If a user has passed a callback, call it for
+        each line.
+
+        Note that the lines are in bytes, since we can't assume that all command output will
+        be UTF-8 encoded. Higher level commands are advised to decode the output to Unicode,
+        if they know its encoding.
+        """
+        buf = b""
+        while True:
+            line = await sr.readline()
+            if sr.at_eof():
+                break
+            self.captured_output += line
+            if callback is not None:
+                callback(line)
+            buf += line
+        return buf
+
+    async def run_command(
+        self,
+        args: List[str],
+        *,
+        error_message: str,
+        timeout_message: str,
+        timeout: Optional[float],
+        stdout_callback: Optional[Callable] = None,
+        stderr_callback: Optional[Callable] = None,
+    ) -> Tuple[bytes, bytes]:
+        """Run a command and get its output.
+
+        Run a command using asyncio.subprocess, consume its standard streams, and return its
+        output in bytes.
+
+        :raises RuntimeError: if the process returns a non-zero exit status
+        :raises TimeoutError: if the process times out
+        """
+        # Start the provided command, and return a handle. The command will run in the
+        # background.
+        proc = await asyncio.subprocess.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+
+        # Create asynchronous tasks that will consume the standard streams of the command,
+        # and call callbacks if necessary.
+        stdout_task = asyncio.create_task(
+            self.read_stream(proc.stdout, stdout_callback)
+        )
+        stderr_task = asyncio.create_task(
+            self.read_stream(proc.stderr, stderr_callback)
+        )
+
+        # Wait until the command has finished, for a specific timeout. Then, verify that the
+        # command has completed successfully. In any other case, raise an exception.
+        try:
+            ret = await asyncio.wait_for(proc.wait(), timeout=timeout)
+        except asyncio.exceptions.TimeoutError:
+            raise TimeoutError(timeout_message)
+        if ret != 0:
+            raise RuntimeError(error_message)
+
+        # Wait until the tasks that consume the command's standard streams have exited as
+        # well, and return their output.
+        stdout = await stdout_task
+        stderr = await stderr_task
+        return (stdout, stderr)
 
     def calculate_timeout(
         self, size: float, pages: Optional[float] = None

--- a/dangerzone/conversion/common.py
+++ b/dangerzone/conversion/common.py
@@ -77,6 +77,10 @@ class DangerzoneConverter:
             stderr=asyncio.subprocess.PIPE,
         )
 
+        # Log command to debug log so we can trace back which errors
+        # are from each command
+        self.captured_output += f">>> {' '.join(args)}\n".encode()
+
         assert proc.stdout is not None
         assert proc.stderr is not None
 

--- a/dangerzone/conversion/common.py
+++ b/dangerzone/conversion/common.py
@@ -79,7 +79,7 @@ class DangerzoneConverter:
 
         # Log command to debug log so we can trace back which errors
         # are from each command
-        self.captured_output += f">>> {' '.join(args)}\n".encode()
+        self.captured_output += f"[COMMAND] {' '.join(args)}\n".encode()
 
         assert proc.stdout is not None
         assert proc.stderr is not None

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -18,7 +18,7 @@ from typing import Dict, Optional
 
 import magic
 
-from .common import DangerzoneConverter, run_command, running_on_qubes
+from .common import DangerzoneConverter, running_on_qubes
 
 
 class DocumentToPixels(DangerzoneConverter):
@@ -189,7 +189,7 @@ class DocumentToPixels(DangerzoneConverter):
                 "/tmp",
                 "/tmp/input_file",
             ]
-            await run_command(
+            await self.run_command(
                 args,
                 error_message="Conversion to PDF with LibreOffice failed",
                 timeout_message=(
@@ -213,7 +213,7 @@ class DocumentToPixels(DangerzoneConverter):
                 "/tmp/input_file",
                 "/tmp/input_file.pdf",
             ]
-            await run_command(
+            await self.run_command(
                 args,
                 error_message="Conversion to PDF with GraphicsMagick failed",
                 timeout_message=(
@@ -231,7 +231,7 @@ class DocumentToPixels(DangerzoneConverter):
 
         # Obtain number of pages
         self.update_progress("Calculating number of pages")
-        stdout, _ = await run_command(
+        stdout, _ = await self.run_command(
             ["pdfinfo", pdf_filename],
             error_message="PDF file is corrupted",
             timeout_message=(
@@ -317,7 +317,7 @@ class DocumentToPixels(DangerzoneConverter):
 
         page_base = "/tmp/page"
 
-        await run_command(
+        await self.run_command(
             [
                 "pdftoppm",
                 pdf_filename,
@@ -351,7 +351,7 @@ class DocumentToPixels(DangerzoneConverter):
             f"/usr/lib/libreoffice/share/extensions/{libreoffice_ext}/",
             f"/libreoffice_ext/{libreoffice_ext}",
         ]
-        await run_command(
+        await self.run_command(
             unzip_args,
             error_message="LibreOffice extension installation failed (unzipping)",
             timeout_message="unzipping LibreOffice extension timed out 5 seconds",

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -388,5 +388,6 @@ async def main() -> int:
             container_log.write(converter.captured_output)
     return error_code
 
+
 if __name__ == "__main__":
     sys.exit(asyncio.run(main()))

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -377,12 +377,16 @@ async def main() -> int:
 
     try:
         await converter.convert()
+        error_code = 0  # Success!
     except (RuntimeError, TimeoutError, ValueError) as e:
         converter.update_progress(str(e), error=True)
-        return 1
-    else:
-        return 0  # Success!
+        error_code = 1
 
+    if not running_on_qubes():
+        # Write debug information (containers version)
+        with open("/tmp/dangerzone/captured_output.txt", "wb") as container_log:
+            container_log.write(converter.captured_output)
+    return error_code
 
 if __name__ == "__main__":
     sys.exit(asyncio.run(main()))

--- a/dangerzone/conversion/doc_to_pixels_qubes_wrapper.py
+++ b/dangerzone/conversion/doc_to_pixels_qubes_wrapper.py
@@ -84,6 +84,9 @@ async def main() -> None:
             rgb_data = rgb_file.read()
             await write_bytes(rgb_data)
 
+    # Write debug information
+    await write_bytes(converter.captured_output, file=sys.stderr)
+
 
 if __name__ == "__main__":
     sys.exit(asyncio.run(main()))

--- a/dangerzone/conversion/pixels_to_pdf.py
+++ b/dangerzone/conversion/pixels_to_pdf.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import sys
 
-from .common import DangerzoneConverter, run_command, running_on_qubes
+from .common import DangerzoneConverter, running_on_qubes
 
 
 class PixelsToPDF(DangerzoneConverter):
@@ -47,7 +47,7 @@ class PixelsToPDF(DangerzoneConverter):
                 self.update_progress(
                     f"Converting page {page}/{num_pages} from pixels to searchable PDF"
                 )
-                await run_command(
+                await self.run_command(
                     [
                         "gm",
                         "convert",
@@ -65,7 +65,7 @@ class PixelsToPDF(DangerzoneConverter):
                     ),
                     timeout=timeout,
                 )
-                await run_command(
+                await self.run_command(
                     [
                         "tesseract",
                         png_filename,
@@ -88,7 +88,7 @@ class PixelsToPDF(DangerzoneConverter):
                 self.update_progress(
                     f"Converting page {page}/{num_pages} from pixels to PDF"
                 )
-                await run_command(
+                await self.run_command(
                     [
                         "gm",
                         "convert",
@@ -119,7 +119,7 @@ class PixelsToPDF(DangerzoneConverter):
         for page in range(1, num_pages + 1):
             args.append(f"/tmp/page-{page}.pdf")
         args.append(f"/tmp/safe-output.pdf")
-        await run_command(
+        await self.run_command(
             args,
             error_message="Merging pages into a single PDF failed",
             timeout_message=(
@@ -133,7 +133,7 @@ class PixelsToPDF(DangerzoneConverter):
 
         # Compress
         self.update_progress("Compressing PDF")
-        await run_command(
+        await self.run_command(
             ["ps2pdf", "/tmp/safe-output.pdf", "/tmp/safe-output-compressed.pdf"],
             error_message="Compressing PDF failed",
             timeout_message=(

--- a/dangerzone/conversion/pixels_to_pdf.py
+++ b/dangerzone/conversion/pixels_to_pdf.py
@@ -156,11 +156,17 @@ async def main() -> int:
 
     try:
         await converter.convert()
+        error_code = 0  # Success!
+
     except (RuntimeError, TimeoutError, ValueError) as e:
         converter.update_progress(str(e), error=True)
-        return 1
-    else:
-        return 0  # Success!
+        error_code = 1
+
+    if not running_on_qubes():
+        # Write debug information (containers version)
+        with open("/safezone/captured_output.txt", "wb") as container_log:
+            container_log.write(converter.captured_output)
+    return error_code
 
 
 if __name__ == "__main__":

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -11,6 +11,8 @@ from ..util import replace_control_chars
 log = logging.getLogger(__name__)
 
 MAX_CONVERSION_LOG_CHARS = 150 * 50  # up to ~150 lines of 50 characters
+CONVERSION_LOG_START = "-----CONVERSION LOG START-----"
+CONVERSION_LOG_END = "-----CONVERSION LOG END-----"
 
 
 class IsolationProvider(ABC):
@@ -88,8 +90,8 @@ class IsolationProvider(ABC):
         conversion_string = replace_control_chars(untrusted_conversion_str)
 
         # Add armor (gpg-style)
-        armor_start = "-----CONVERSION LOG START-----\n"
-        armor_end = "-----CONVERSION LOG END-----"
+        armor_start = f"{CONVERSION_LOG_START}\n"
+        armor_end = CONVERSION_LOG_END
         return armor_start + conversion_string + armor_end
 
 

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -10,6 +10,8 @@ from ..util import replace_control_chars
 
 log = logging.getLogger(__name__)
 
+MAX_CONVERSION_LOG_CHARS = 150 * 50  # up to ~150 lines of 50 characters
+
 
 class IsolationProvider(ABC):
     """

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -11,8 +11,10 @@ from ..util import replace_control_chars
 log = logging.getLogger(__name__)
 
 MAX_CONVERSION_LOG_CHARS = 150 * 50  # up to ~150 lines of 50 characters
-CONVERSION_LOG_START = "-----CONVERSION LOG START-----"
-CONVERSION_LOG_END = "-----CONVERSION LOG END-----"
+DOC_TO_PIXELS_LOG_START = "----- DOC TO PIXELS LOG START -----"
+DOC_TO_PIXELS_LOG_END = "----- DOC TO PIXELS LOG END -----"
+PIXELS_TO_PDF_LOG_START = "----- PIXELS TO PDF LOG START -----"
+PIXELS_TO_PDF_LOG_END = "----- PIXELS TO PDF LOG END -----"
 
 
 class IsolationProvider(ABC):
@@ -90,8 +92,8 @@ class IsolationProvider(ABC):
         conversion_string = replace_control_chars(untrusted_conversion_str)
 
         # Add armor (gpg-style)
-        armor_start = f"{CONVERSION_LOG_START}\n"
-        armor_end = CONVERSION_LOG_END
+        armor_start = f"{DOC_TO_PIXELS_LOG_START}\n"
+        armor_end = DOC_TO_PIXELS_LOG_END
         return armor_start + conversion_string + armor_end
 
 

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -84,6 +84,14 @@ class IsolationProvider(ABC):
     def get_max_parallel_conversions(self) -> int:
         pass
 
+    def sanitize_conversion_str(self, untrusted_conversion_str: str) -> str:
+        conversion_string = replace_control_chars(untrusted_conversion_str)
+
+        # Add armor (gpg-style)
+        armor_start = "-----CONVERSION LOG START-----\n"
+        armor_end = "-----CONVERSION LOG END-----"
+        return armor_start + conversion_string + armor_end
+
 
 # From global_common:
 

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -337,6 +337,13 @@ class Container(IsolationProvider):
                 # We did it
                 success = True
 
+        if getattr(sys, "dangerzone_dev", False):
+            log_path = safe_dir / "captured_output.txt"
+            with open(log_path, "r", encoding="ascii", errors="replace") as f:
+                untrusted_log = f.read(MAX_CONVERSION_LOG_CHARS)
+            text = f"Container output: (pixels to PDF)\n{self.sanitize_conversion_str(untrusted_log)}"
+            log.info(text)
+
         return success
 
     def get_max_parallel_conversions(self) -> int:

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -18,7 +18,12 @@ from ..util import (
     get_tmp_dir,
     replace_control_chars,
 )
-from .base import MAX_CONVERSION_LOG_CHARS, IsolationProvider
+from .base import (
+    MAX_CONVERSION_LOG_CHARS,
+    PIXELS_TO_PDF_LOG_END,
+    PIXELS_TO_PDF_LOG_START,
+    IsolationProvider,
+)
 
 # Define startupinfo for subprocesses
 if platform.system() == "Windows":
@@ -339,10 +344,13 @@ class Container(IsolationProvider):
 
         if getattr(sys, "dangerzone_dev", False):
             log_path = safe_dir / "captured_output.txt"
-            with open(log_path, "r", encoding="ascii", errors="replace") as f:
-                untrusted_log = f.read(MAX_CONVERSION_LOG_CHARS)
-            text = f"Container output: (pixels to PDF)\n{self.sanitize_conversion_str(untrusted_log)}"
-            log.info(text)
+            if log_path.exists():  # If first stage failed this may not exist
+                with open(log_path, "r", encoding="ascii", errors="replace") as f:
+                    text = (
+                        f"Container output: (pixels to PDF)\n"
+                        f"{PIXELS_TO_PDF_LOG_START}{f.read()}{PIXELS_TO_PDF_LOG_END}"
+                    )
+                    log.info(text)
 
         return success
 

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -295,7 +295,7 @@ class Container(IsolationProvider):
             with open(log_path, "r", encoding="ascii", errors="replace") as f:
                 untrusted_log = f.read(MAX_CONVERSION_LOG_CHARS)
             log.info(
-                f"Conversion output (doc to pixels):\n{replace_control_chars(untrusted_log)}"
+                f"Conversion output (doc to pixels):\n{self.sanitize_conversion_str(untrusted_log)}"
             )
 
         if ret != 0:

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -12,7 +12,12 @@ import tempfile
 from typing import Any, Callable, List, Optional, Tuple
 
 from ..document import Document
-from ..util import get_resource_path, get_subprocess_startupinfo, get_tmp_dir
+from ..util import (
+    get_resource_path,
+    get_subprocess_startupinfo,
+    get_tmp_dir,
+    replace_control_chars,
+)
 from .base import MAX_CONVERSION_LOG_CHARS, IsolationProvider
 
 # Define startupinfo for subprocesses
@@ -288,9 +293,10 @@ class Container(IsolationProvider):
         if getattr(sys, "dangerzone_dev", False):
             log_path = pixel_dir / "captured_output.txt"
             with open(log_path, "r", encoding="ascii", errors="replace") as f:
-                log.info(
-                    f"Conversion output (doc to pixels):\n{f.read(MAX_CONVERSION_LOG_CHARS)}"
-                )
+                untrusted_log = f.read(MAX_CONVERSION_LOG_CHARS)
+            log.info(
+                f"Conversion output (doc to pixels):\n{replace_control_chars(untrusted_log)}"
+            )
 
         if ret != 0:
             log.error("documents-to-pixels failed")

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -145,7 +145,7 @@ class Qubes(IsolationProvider):
         if getattr(sys, "dangerzone_dev", False):
             untrusted_log = read_debug_text(p)
             log.info(
-                f"Conversion output (doc to pixels):\n{replace_control_chars(untrusted_log)}"
+                f"Conversion output (doc to pixels)\n{self.sanitize_conversion_str(untrusted_log)}"
             )
 
         # FIXME pass OCR stuff properly (see #455)

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -28,6 +28,8 @@ CONVERTED_FILE_PATH = (
     "/tmp/safe-output-compressed.pdf"
 )
 
+MAX_CONVERSION_LOG_CHARS = 150 * 50  # up to ~150 lines of 50 characters
+
 
 def read_bytes(p: subprocess.Popen, buff_size: int) -> bytes:
     """Read bytes from stdout."""
@@ -38,6 +40,15 @@ def read_int(p: subprocess.Popen) -> int:
     """Read 2 bytes from stdout, and decode them as int."""
     untrusted_int = p.stdout.read(2)  # type: ignore [union-attr]
     return int.from_bytes(untrusted_int, signed=False)
+
+
+def read_debug_text(p: subprocess.Popen) -> str:
+    """Read arbitrarily long text (for debug purposes)"""
+    if p.stderr:
+        untrusted_text = p.stderr.read(MAX_CONVERSION_LOG_CHARS)
+        return untrusted_text.decode("ascii", errors="replace")
+    else:
+        return ""
 
 
 class Qubes(IsolationProvider):
@@ -75,6 +86,7 @@ class Qubes(IsolationProvider):
                     ["/usr/bin/qrexec-client-vm", "@dispvm:dz-dvm", "dz.ConvertDev"],
                     stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
                 )
                 assert p.stdin is not None
 
@@ -89,6 +101,7 @@ class Qubes(IsolationProvider):
                     ["/usr/bin/qrexec-client-vm", "@dispvm:dz-dvm", "dz.Convert"],
                     stdin=f,
                     stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
                 )
 
             n_pages = read_int(p)
@@ -125,6 +138,10 @@ class Qubes(IsolationProvider):
         # TODO handle leftover code input
         text = "Converted document to pixels"
         self.print_progress_trusted(document, False, text, percentage)
+
+        if getattr(sys, "dangerzone_dev", False):
+            text = f"Conversion output (doc to pixels):\n{read_debug_text(p)}"
+            log.info(text)
 
         # FIXME pass OCR stuff properly (see #455)
         old_environ = dict(os.environ)

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -143,8 +143,10 @@ class Qubes(IsolationProvider):
         self.print_progress_trusted(document, False, text, percentage)
 
         if getattr(sys, "dangerzone_dev", False):
-            text = f"Conversion output (doc to pixels):\n{read_debug_text(p)}"
-            log.info(text)
+            untrusted_log = read_debug_text(p)
+            log.info(
+                f"Conversion output (doc to pixels):\n{replace_control_chars(untrusted_log)}"
+            )
 
         # FIXME pass OCR stuff properly (see #455)
         old_environ = dict(os.environ)

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -46,6 +46,7 @@ def read_debug_text(p: subprocess.Popen) -> str:
     """Read arbitrarily long text (for debug purposes)"""
     if p.stderr:
         untrusted_text = p.stderr.read(MAX_CONVERSION_LOG_CHARS)
+        p.stderr.close()
         return untrusted_text.decode("ascii", errors="replace")
     else:
         return ""
@@ -134,6 +135,9 @@ class Qubes(IsolationProvider):
 
                 text = f"Converting page {page}/{n_pages} to pixels"
                 self.print_progress_trusted(document, False, text, percentage)
+
+        # Ensure nothing else is read after all bitmaps are obtained
+        p.stdout.close()  # type: ignore [union-attr]
 
         # TODO handle leftover code input
         text = "Converted document to pixels"

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -22,13 +22,12 @@ log = logging.getLogger(__name__)
 from ..conversion.common import running_on_qubes
 from ..conversion.pixels_to_pdf import PixelsToPDF
 from ..util import get_resource_path, get_subprocess_startupinfo, get_tmp_dir
+from .base import MAX_CONVERSION_LOG_CHARS
 
 CONVERTED_FILE_PATH = (
     # FIXME won't work for parallel conversions (see #454)
     "/tmp/safe-output-compressed.pdf"
 )
-
-MAX_CONVERSION_LOG_CHARS = 150 * 50  # up to ~150 lines of 50 characters
 
 
 def read_bytes(p: subprocess.Popen, buff_size: int) -> bytes:

--- a/docs/developer/TESTING.md
+++ b/docs/developer/TESTING.md
@@ -1,0 +1,38 @@
+# Dangerzone Testing
+
+Dangerzone has some automated testing under `tests/`.
+
+The following assumes that you have already setup the development environment.
+
+## Run tests
+
+Unit / integration tests are run with:
+
+```bash
+poetry run make test
+```
+
+## Run large tests
+
+We also have a larger set of tests that can take a day or more to run, where we evaluate the completeness of Dangerzone conversions.
+
+```bash
+poetry run make test-large
+```
+
+### Test report generation
+After running the large tests, a report is stored under `tests/test_docs_large/results/junit/` and it is composed of the JUnit XML file describing the pytest run.
+
+This report can be analysed for errors. It is obtained by running:
+
+```bash
+cd tests/docs_test_large
+make report
+```
+
+If you want to run the report on some historical test result, you can call:
+
+```bash
+cd tests/docs_test_large
+python report.py tests/test_docs_large/results/junit/commit_<COMMIT_ID>.junit.xml
+```

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,7 +22,9 @@ test_docs = [
 ]
 
 # Pytest parameter decorators
-for_each_doc = pytest.mark.parametrize("doc", test_docs)
+for_each_doc = pytest.mark.parametrize(
+    "doc", test_docs, ids=[str(doc.name) for doc in test_docs]
+)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,6 +159,10 @@ class TestCli:
                     stale_files = list(tmp_dir.iterdir())
                     assert not stale_files
 
+        # XXX Print stdout so that junitXML exports with output capturing
+        # actually include the stdout + stderr (they are combined into stdout)
+        print(result.stdout)
+
         return CLIResult.reclass_click_result(result, args)
 
 

--- a/tests/test_large_set.py
+++ b/tests/test_large_set.py
@@ -10,6 +10,7 @@ from _pytest.fixtures import FixtureRequest
 
 from dangerzone.document import SAFE_EXTENSION
 
+from .test_cli import TestCli
 
 test_docs_repo_dir = Path(__file__).parent / "test_docs_large"
 test_docs_dir = test_docs_repo_dir / "all_documents"
@@ -59,16 +60,27 @@ for_each_100M_doc = pytest.mark.parametrize(
 )
 
 
-
-class TestLargeSet():
+class TestLargeSet(TestCli):
     def run_doc_test(self, doc: Path, tmp_path: Path) -> None:
         output_file_path = str(tmp_path / "output.pdf")
-        p = subprocess.Popen([
-            "python", "dev_scripts/dangerzone-cli", "--output-filename", output_file_path, "--ocr-lang", "eng", str(doc)
-        ], stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
+        p = subprocess.Popen(
+            [
+                "python",
+                "dev_scripts/dangerzone-cli",
+                "--output-filename",
+                output_file_path,
+                "--ocr-lang",
+                "eng",
+                str(doc),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
         out, _ = p.communicate()
         from strip_ansi import strip_ansi
+
         print(strip_ansi(out.decode()))
+        assert p.returncode == 0
 
     @for_each_10K_doc
     def test_10K_docs(self, doc: Path, tmp_path: Path) -> None:

--- a/tests/test_large_set.py
+++ b/tests/test_large_set.py
@@ -1,0 +1,87 @@
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import List
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from dangerzone.document import SAFE_EXTENSION
+
+
+test_docs_repo_dir = Path(__file__).parent / "test_docs_large"
+test_docs_dir = test_docs_repo_dir / "all_documents"
+TEST_DOCS_REPO = "git@github.com:freedomofpress/dangerzone-test-set.git"
+FORMATS_REGEX = (
+    r".*\.(pdf|docx|doc|xlsx|xls|pptx|ppt|odt|ods|odp|odg|jpg|jpeg|gif|png)$"
+)
+
+
+def ensure_test_data_exists() -> None:
+    if len(os.listdir(test_docs_repo_dir)) == 0:
+        print("Test data repository it empty. Skipping large tests.")
+        exit(1)
+
+
+def get_test_docs(min_size: int, max_size: int) -> List[Path]:
+    ensure_test_data_exists()
+    return sorted(
+        [
+            doc
+            for doc in test_docs_dir.rglob("*")
+            if doc.is_file()
+            and min_size < doc.stat().st_size < max_size
+            and not (doc.name.endswith(SAFE_EXTENSION))
+            and re.match(FORMATS_REGEX, doc.name)
+        ]
+    )
+
+
+docs_10K = get_test_docs(min_size=0, max_size=10 * 2**10)
+docs_100K = get_test_docs(min_size=10 * 2**10, max_size=100 * 2**10)
+docs_10M = get_test_docs(min_size=100 * 2**10, max_size=10 * 2**20)
+docs_100M = get_test_docs(min_size=10 * 2**20, max_size=100 * 2**20)
+
+# Pytest parameter decorators
+for_each_10K_doc = pytest.mark.parametrize(
+    "doc", docs_10K, ids=[str(doc.name) for doc in docs_10K]
+)
+for_each_100K_doc = pytest.mark.parametrize(
+    "doc", docs_100K, ids=[str(doc.name) for doc in docs_100K]
+)
+for_each_10M_doc = pytest.mark.parametrize(
+    "doc", docs_10M, ids=[str(doc.name) for doc in docs_10M]
+)
+for_each_100M_doc = pytest.mark.parametrize(
+    "doc", docs_100M, ids=[str(doc.name) for doc in docs_100M]
+)
+
+
+
+class TestLargeSet():
+    def run_doc_test(self, doc: Path, tmp_path: Path) -> None:
+        output_file_path = str(tmp_path / "output.pdf")
+        p = subprocess.Popen([
+            "python", "dev_scripts/dangerzone-cli", "--output-filename", output_file_path, "--ocr-lang", "eng", str(doc)
+        ], stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
+        out, _ = p.communicate()
+        from strip_ansi import strip_ansi
+        print(strip_ansi(out.decode()))
+
+    @for_each_10K_doc
+    def test_10K_docs(self, doc: Path, tmp_path: Path) -> None:
+        self.run_doc_test(doc, tmp_path)
+
+    @for_each_100K_doc
+    def test_100K_docs(self, doc: Path, tmp_path: Path) -> None:
+        self.run_doc_test(doc, tmp_path)
+
+    @for_each_10M_doc
+    def test_10M_docs(self, doc: Path, tmp_path: Path) -> None:
+        self.run_doc_test(doc, tmp_path)
+
+    @for_each_100M_doc
+    def test_100M_docs(self, doc: Path, tmp_path: Path) -> None:
+        self.run_doc_test(doc, tmp_path)


### PR DESCRIPTION
Adds a large pool of document that can and should be used prior to a release to understand effects of the new release over a real-world scenario.
    
Documents are stored in an external git LFS repo under `tests/test_docs_large` and currently it's about 11K documents gathered from multiple PDF readers and office suite's test sets.
    
Documentation on how to run the tests is under `docs/developer/TESTING.md`

Fixes #319 