### PR TITLE
Update notarization instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -172,9 +172,15 @@ To make a macOS release, go to macOS build machine:
 - Run `poetry run ./install/macos/build-app.py --only-codesign`; this will make `dist/Dangerzone.dmg`
   * You need to run this command as the account that has access to the code signing certificate
   * You must run this command from the MacOS UI, from a terminal application.
-- Notarize it: `xcrun altool --notarize-app --primary-bundle-id "media.firstlook.dangerzone" -u "micah@firstlook.org" -p "$PASSWORD" --file dist/Dangerzone.dmg`
-- Wait for it to get approved, check status with: `xcrun altool --notarization-history 0 -u "micah@firstlook.org" -p "$PASSWORD"`
-- (If it gets rejected, you can see why with: `xcrun altool --notarization-info $REQUEST_UUID -u "micah@firstlook.org" -p "$PASSWORD"`)
+- Notarize it: `xcrun altool --notarize-app --primary-bundle-id "press.freedom.dangerzone" -u "<email>" --file dist/Dangerzone.dmg`
+  * You need to change the `<email>` in the above command with the email
+    associated with the Apple Developer ID.
+  * This command will ask you for a password. Prefer creating an application
+    password associated with your Apple Developer ID, which will be used
+    specifically for `altool`.
+- Wait for it to get approved, check status with: `xcrun altool --notarization-history 0 -u "<email>"`
+  * You will also receive an update in your email.
+- (If it gets rejected, you can see why with: `xcrun altool --notarization-info $REQUEST_UUID -u "<email>"`)
 - After it's approved, staple the ticket: `xcrun stapler staple dist/Dangerzone.dmg`
 
 This process ends up with the final file:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -252,13 +252,9 @@ repo, by sending a PR. Follow the instructions in that repo on how to do so.
 
 ### Fedora
 
-Linux binaries are automatically built and deployed to repositories when a new tag is pushed.
-
-### Fedora
-
 > **NOTE**: This procedure will have to be done for every supported Fedora version.
 >
-> In this example, we'll use Fedora 37 as an example.
+> In this section, we'll use Fedora 37 as an example.
 
 Create a Fedora development environment. You can [follow the
 instructions in our build section](https://github.com/freedomofpress/dangerzone/blob/main/BUILD.md#fedora),

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -165,7 +165,7 @@ git checkout v$VERSION
 To make a macOS release, go to macOS build machine:
 
 - Build machine must have:
-  - Apple-trusted `Apple Development: Trevor Timm (TW4JVM8ZCU)` code-signing certificates installed
+  - Apple-trusted `Developer ID Application: Freedom of the Press Foundation (94ZZGGGJ3W)` code-signing certificates installed
 - Verify and checkout the git tag for this release
 - Run `poetry install`
 - Run `poetry run ./install/macos/build-app.py`; this will make `dist/Dangerzone.app`

--- a/install/macos/build-app.py
+++ b/install/macos/build-app.py
@@ -75,7 +75,7 @@ def sign_app_bundle(build_path, dist_path, app_path):
     icon_path = os.path.join(root, "install", "macos", "dangerzone.icns")
 
     print("○ Code signing app bundle")
-    identity_name_application = "Apple Development: Trevor Timm (TW4JVM8ZCU)"
+    identity_name_application = "Developer ID Application: Freedom of the Press Foundation (94ZZGGGJ3W)"
     entitlements_plist_path = os.path.join(root, "install/macos/entitlements.plist")
 
     for path in itertools.chain(

--- a/install/macos/build-app.py
+++ b/install/macos/build-app.py
@@ -75,7 +75,9 @@ def sign_app_bundle(build_path, dist_path, app_path):
     icon_path = os.path.join(root, "install", "macos", "dangerzone.icns")
 
     print("○ Code signing app bundle")
-    identity_name_application = "Developer ID Application: Freedom of the Press Foundation (94ZZGGGJ3W)"
+    identity_name_application = (
+        "Developer ID Application: Freedom of the Press Foundation (94ZZGGGJ3W)"
+    )
     entitlements_plist_path = os.path.join(root, "install/macos/entitlements.plist")
 
     for path in itertools.chain(


### PR DESCRIPTION
This PR simply updates notarization instructions, based on our recent run with FPF's signing certificates. Also, it removes a redundant section in the Fedora release instructions.