### PR TITLE
Add note for MacOS 11+ users blocked by SIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,17 @@ Set up a development environment by following [these instructions](/BUILD.md).
 
 ## FAQ
 
+### "I'm experiencing an issue while using Dangerzone."
+
+Dangerzone gets updates to improve its features _and_ to fix problems. So, updating may be the simplest path to resolving the issue. Here is how to update:
+
+1. Check which version of Dangerzone you are currently usi: run Dangerzone, then look for the series of numbers to the left of the logo. It will look similar to `0.4.1`
+2. Now find the latest available version of Dangerzone: go to the [download page](https://dangerzone.rocks/#downloads). Look for the number displayed using the same format as in Step 1.
+3. Is the version on the Dangerzone download page higher than the version of your installed app? Go ahead and update.
+
 ### "I get `invalid json returned from container` on MacOS Big Sur or newer (MacOS 11.x.x or higher)"
+
+Are you using the latest Dangerzone?
 
 You _may_ be attempting to convert a file in a directory to which Docker Desktop does not have access. Dangerzone for Mac requires Docker Desktop for conversion. Docker Desktop, in turn, requires permission from MacOS to access the directory in which your target file is located.
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ Set up a development environment by following [these instructions](/BUILD.md).
 
 ### "I'm experiencing an issue while using Dangerzone."
 
-Dangerzone gets updates to improve its features _and_ to fix problems. So, updating may be the simplest path to resolving the issue. Here is how to update:
+Dangerzone gets updates to improve its features _and_ to fix problems. So, updating may be the simplest path to resolving the issue which brought you here. Here is how to update:
 
-1. Check which version of Dangerzone you are currently usi: run Dangerzone, then look for the series of numbers to the left of the logo. It will look similar to `0.4.1`
-2. Now find the latest available version of Dangerzone: go to the [download page](https://dangerzone.rocks/#downloads). Look for the number displayed using the same format as in Step 1.
+1. Check which version of Dangerzone you are currently using: run Dangerzone, then look for a series of numbers to the right of the logo within the app. The format of the numbers will look similar to `0.4.1`
+2. Now find the latest available version of Dangerzone: go to the [download page](https://dangerzone.rocks/#downloads). Look for the version number displayed. The number will be using the same format as in Step 1.
 3. Is the version on the Dangerzone download page higher than the version of your installed app? Go ahead and update.
 
 ### "I get `invalid json returned from container` on MacOS Big Sur or newer (MacOS 11.x.x or higher)"
 
-Are you using the latest Dangerzone?
+Are you using the latest version of Dangerzone? See the FAQ for: "I'm experiencing an issue while using Dangerzone."
 
 You _may_ be attempting to convert a file in a directory to which Docker Desktop does not have access. Dangerzone for Mac requires Docker Desktop for conversion. Docker Desktop, in turn, requires permission from MacOS to access the directory in which your target file is located.
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,19 @@ Dangerzone can convert these types of document into safe PDFs:
 Dangerzone was inspired by [Qubes trusted PDF](https://blog.invisiblethings.org/2013/02/21/converting-untrusted-pdfs-into-trusted.html), but it works in non-Qubes operating systems. It uses containers as sandboxes instead of virtual machines (using Docker for macOS, Windows, and Debian/Ubuntu, and [podman](https://podman.io/) for Fedora).
 
 Set up a development environment by following [these instructions](/BUILD.md).
+
+## FAQ
+
+### "I get `invalid json returned from container` on MacOS Big Sur or newer (MacOS 11.x.x or higher)"
+
+You _may_ be attempting to convert a file in a directory to which Docker Desktop does not have access. Dangerzone for Mac requires Docker Desktop for conversion. Docker Desktop, in turn, requires permission from MacOS to access the directory in which your target file is located.
+
+To grant this permission:
+
+1. On MacOS 13, choose Apple menu > System Settings. On lower versions, choose System Preferences.
+2. Tap into Privacy & Security in the sidebar. (You may need to scroll down.)
+3. In the Privacy section, tap into Files & Folders. (Again, you may need to scroll down.)
+4. Scroll to the entry for Docker. Tap the > to expand the entry.
+5. Enable the toggle beside the directory where your file is present. For example, if the file to be converted is in the Downloads folder, enable the toggle beside Downloads.
+
+(Full Disk Access permission has a similar effect, but it's enough to give Docker access to _only_ the directory containing the intended file(s) to be converted. Full Disk is unnecessary. As of 2023.04.28, granting one of these permissions continues to be required for successful conversion. Apologies for the extra steps. Dangerzone depends on Docker, and the fix for this issue needs to come from upstream. Read more on [#371](https://github.com/freedomofpress/dangerzone/issues/371#issuecomment-1516863056).)


### PR DESCRIPTION
A workaround for an issue related to SIP imposed on Docker has been identified in #371. This PR updates README.md to include friendly instructions for MacOS 11+ users blocked by this issue.

PR created at the request of @apyrgio in https://github.com/freedomofpress/dangerzone/issues/371#issuecomment-1523257761.

To include these instructions in the current README.md, I judged it most appropriate to nest it under a new FAQ section. Please feel free to refactor as needed.

Closes #371.