### PR TITLE
ci: Add security scanning

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,70 @@
+name: Scan latest app and container
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * *' # Run every day at 00:00 UTC.
+
+jobs:
+  security-scan-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build container image
+        run: docker build container --tag dangerzone.rocks/dangerzone:latest
+      # NOTE: Scan first without failing, else we won't be able to read the scan
+      # report.
+      - name: Scan container image (no fail)
+        uses: anchore/scan-action@v3
+        id: scan_container
+        with:
+          image: "dangerzone.rocks/dangerzone:latest"
+          fail-build: false
+          only-fixed: true
+          severity-cutoff: critical
+      - name: Upload container scan report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan_container.outputs.sarif }}
+          category: container
+      - name: Inspect container scan report
+        run: cat ${{ steps.scan_container.outputs.sarif }}
+      - name: Scan container image
+        uses: anchore/scan-action@v3
+        with:
+          image: "dangerzone.rocks/dangerzone:latest"
+          fail-build: true
+          only-fixed: true
+          severity-cutoff: critical
+
+  security-scan-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      # NOTE: Scan first without failing, else we won't be able to read the scan
+      # report.
+      - name: Scan application (no fail)
+        uses: anchore/scan-action@v3
+        id: scan_app
+        with:
+          path: "."
+          fail-build: false
+          only-fixed: true
+          severity-cutoff: critical
+      - name: Upload application scan report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan_app.outputs.sarif }}
+          category: app
+      - name: Inspect application scan report
+        run: cat ${{ steps.scan_app.outputs.sarif }}
+      - name: Scan application
+        uses: anchore/scan-action@v3
+        with:
+          path: "."
+          fail-build: true
+          only-fixed: true
+          severity-cutoff: critical

--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -1,0 +1,77 @@
+name: Scan released app and container
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run every day at 00:00 UTC.
+
+jobs:
+  security-scan-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Download container image for the latest release
+        run: |
+          VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | jq -r '.tag_name')
+          wget https://github.com/freedomofpress/dangerzone/releases/download/${VERSION}/container.tar.gz
+      - name: Load container image
+        run: docker load -i container.tar.gz
+      # NOTE: Scan first without failing, else we won't be able to read the scan
+      # report.
+      - name: Scan container image (no fail)
+        uses: anchore/scan-action@v3
+        id: scan_container
+        with:
+          image: "dangerzone.rocks/dangerzone:latest"
+          fail-build: false
+          only-fixed: true
+          severity-cutoff: critical
+      - name: Upload container scan report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan_container.outputs.sarif }}
+          category: container
+      - name: Inspect container scan report
+        run: cat ${{ steps.scan_container.outputs.sarif }}
+      - name: Scan container image
+        uses: anchore/scan-action@v3
+        with:
+          image: "dangerzone.rocks/dangerzone:latest"
+          fail-build: true
+          only-fixed: true
+          severity-cutoff: critical
+
+  security-scan-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Checkout the latest released tag
+        run: |
+          VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | jq -r '.tag_name')
+          git checkout $VERSION
+      # NOTE: Scan first without failing, else we won't be able to read the scan
+      # report.
+      - name: Scan application (no fail)
+        uses: anchore/scan-action@v3
+        id: scan_app
+        with:
+          path: "."
+          fail-build: false
+          only-fixed: true
+          severity-cutoff: critical
+      - name: Upload application scan report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan_app.outputs.sarif }}
+          category: app
+      - name: Inspect application scan report
+        run: cat ${{ steps.scan_app.outputs.sarif }}
+      - name: Scan application
+        uses: anchore/scan-action@v3
+        with:
+          path: "."
+          fail-build: true
+          only-fixed: true
+          severity-cutoff: critical

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,43 @@
+# This configuration file will be used to track CVEs that we can ignore for the
+# latest release of Dangerzone, and offer our analysis.
+
+ignore:
+  # CVE-2023-1255
+  # =============
+  #
+  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2023-1255
+  # Verdict: Dangerzone is not affected. The rationale is the following:
+  #
+  #   1. This CVE affects software that performs encryption, typically disk
+  #      encryption, which is not the case for Dangerzone.
+  #      Also, the worst outcome
+  #   2. The NVD entry reports the severity of this CVE as "Medium", which is
+  #      yet another sign that we can ignore it.
+  #   3. The worst outcome is denial of service, which is acceptable in our
+  #      case.
+  - vulnerability: CVE-2023-1255
+
+  # CVE-2023-28879
+  # ==============
+  #
+  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2023-28879
+  # Write up: https://offsec.almond.consulting/ghostscript-cve-2023-28879.html
+  # Verdict: Dangerzone is not affected. The rationale is the following:
+  #
+  #   1. This CVE affects the PostScript interpreter of Ghostscript (i.e., .ps
+  #      files). This is evident from the write up, and the PoCs in GitHub:
+  #      https://github.com/AlmondOffSec/PoCs/tree/master/Ghostscript_rce
+  #   2. Dangerzone does not accept .ps files. The GUI does not allow users to
+  #      select them and, even if you force them through the CLI, Dangerone will
+  #      report that "The document format is not supported".
+  #   3. Depending on the document type, the first conversion command will
+  #      either be LibreOffice, GraphicsMagick, or pdftoppm. None of these
+  #      commands call a Ghostscript binary
+  #      (see here for the list of Ghostscript binaries:
+  #      https://pkgs.alpinelinux.org/contents?branch=edge&name=ghostscript&arch=x86&repo=main)
+  #   4. We tested out removing the GhostScript package from the container
+  #      image. We verified that the only place where a Ghostscript binary is
+  #      used is when compressing the final PDF (ps2pdf). The compression takes
+  #      place after the document has been converted to pixels, so the attacker
+  #      has no control over it.
+  - vulnerability: CVE-2023-28879

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Security
+
+- Continuously scan our Python dependencies and container image for
+  vulnerabilities ([issue #222](https://github.com/freedomofpress/dangerzone/issues/222))
+
 ## Dangerzone 0.4.1
 
 ### Added

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -25,7 +25,7 @@ RUN apk -U upgrade && \
     tesseract-ocr-data-chr \
     tesseract-ocr-data-dan \
     tesseract-ocr-data-deu \
-    tesseract-ocr-data-ell \
+    tesseract-ocr-data-grc \
     tesseract-ocr-data-enm \
     tesseract-ocr-data-epo \
     tesseract-ocr-data-equ \


### PR DESCRIPTION
Add two GitHub Actions workflows, that perform the following checks:

* Security scan the Python dependencies of the Dangerzone application
  (`poetry.lock`), for the current/main branch.
* Build and security scan the Dangerzone container image for the
  current/main branch.
* Security scan the Python dependencies of the Dangerzone application
  (`poetry.lock`), for the latest release of Dangerzone (currently
  v0.4.1).
* Download and security scan the Dangerzone container image for the
  latest release of Dangerzone (currently v0.4.1).

The first two checks will run on branch pushes, PRs, and nightly. The
last two checks will run only nightly, since the code in the current
branch cannot affect already released artifacts.

Note that in order to be able to run our checks on the released container image, 
we need to make it part of our release artifacts.

Also, besides the security scans, these workflows will also update the
Security alerts in the GitHub page for the Dangerzone project, and print
the SARIF report to the stdout, for debugging purposes.

Finally, ignore two CVEs from our security scans, which were triggered when
scanning the Dangerzone container image for v0.4.1. These CVEs do not
affect out users, and we offer an explanation why.

Closes #222
