### PR TITLE
ci: Test building a .deb and installing it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,12 +299,29 @@ jobs:
             ./dev_scripts/env.py --distro debian --version bookworm run --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
+  # NOTE: Making CI tests work in Debian Bullseye requires some tip-toeing
+  # around certain Podman issues, as you'll see below. Read the following for
+  # more details:
+  #
+  # https://github.com/freedomofpress/dangerzone/issues/388
   ci-debian-bullseye:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2204:2023.04.2
     steps:
       - checkout
       - run: *install-podman
+      - run:
+          name: Configure Podman for Ubuntu 22.04
+          command: |
+            # This config circumvents the following issues:
+            # * https://github.com/containers/podman/issues/6368
+            # * https://github.com/containers/podman/issues/10987
+            mkdir -p ~/.config/containers
+            cat > ~/.config/containers/containers.conf \<<EOF
+            [engine]
+            cgroup_manager="cgroupfs"
+            events_logger="file"
+            EOF
 
       - run:
           name: Prepare cache directory
@@ -318,6 +335,22 @@ jobs:
           name: Prepare Dangerzone environment
           command: |
             ./dev_scripts/env.py --distro debian --version bullseye build-dev
+
+      - run:
+          name: Configure Podman for Debian Bullseye
+          command: |
+            # Copy the Podman config into the container image we created for the
+            # Dangerzone environment.
+            cp ~/.config/containers/containers.conf containers.conf
+            cat > Dockerfile.bullseye \<<EOF
+            FROM dangerzone.rocks/build/debian:bullseye-backports
+            RUN mkdir -p /home/user/.config/containers
+            COPY containers.conf /home/user/.config/containers/
+            EOF
+
+            # Create a new image from the Dangerzone environment and re-tag it.
+            podman build -t dangerzone.rocks/build/debian:bullseye-backports \
+                -f Dockerfile.bullseye .
 
       - run:
           name: Run CI tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,86 @@ jobs:
       - run: poetry install
       - name: Run CLI tests
         run: poetry run make test
+
+  build-deb:
+    runs-on: ubuntu-latest
+    env:
+      target: debian-bookworm
+      distro: debian
+      version: bookworm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Build dev environment
+        run: |
+          ./dev_scripts/env.py --distro ${{ env.distro }} \
+              --version ${{ env.version }} \
+              build-dev
+
+      - name: Build Dangerzone image
+        run: ./install/linux/build-image.sh
+
+      - name: Build Dangerzone .deb
+        run: |
+          ./dev_scripts/env.py --distro ${{ env.distro }} \
+              --version ${{ env.version }} \
+              run --dev ./dangerzone/install/linux/build-deb.py
+
+      - name: Upload Dangerzone .deb
+        uses: actions/upload-artifact@v3
+        with:
+          name: dangerzone.deb
+          path: "deb_dist/dangerzone_*_all.deb"
+
+  install-deb:
+    runs-on: ubuntu-latest
+    needs: build-deb
+    strategy:
+      matrix:
+        include:
+          - target: ubuntu-20.04
+            distro: ubuntu
+            version: "20.04"
+          - target: ubuntu-22.04
+            distro: ubuntu
+            version: "22.04"
+          - target: ubuntu-22.10
+            distro: ubuntu
+            version: "22.10"
+          - target: debian-bullseye
+            distro: debian
+            version: bullseye
+          - target: debian-bookworm
+            distro: debian
+            version: bookworm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Download Dangerzone .deb
+        uses: actions/download-artifact@v3
+        with:
+          name: dangerzone.deb
+          path: "deb_dist/"
+
+      - name: Create end-user environment on (${{ matrix.target }})
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              build
+
+      - name: Run a test command
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              run dangerzone-cli dangerzone/tests/test_docs/sample-pdf.pdf

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -71,15 +71,19 @@ RUN . /etc/os-release \
 """
 
 # FIXME: Do we really need the python3-venv packages?
-# XXX: We install uidmap separately, because it is not a hard dependency for Podman, and
-# we use --no-install-recommends.
 DOCKERFILE_BUILD_DEV_DEBIAN_DEPS = r"""
 ARG DEBIAN_FRONTEND=noninteractive
 
+# NOTE: Podman has several recommended packages that are actually essential for rootless
+# containers. Instead of specifying them by name, we can install Podman with all of its
+# recommendations, which increases the image size, but makes the environment less flaky.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends podman uidmap dh-python make \
-        build-essential fakeroot fuse-overlayfs libqt5gui5 pipx python3 python3-dev \
-        python3-venv python3-stdeb python3-all \
+    && apt-get install -y podman \
+    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends dh-python make build-essential \
+        fakeroot libqt5gui5 pipx python3 python3-dev python3-venv python3-stdeb \
+        python3-all \
     && rm -rf /var/lib/apt/lists/*
 # NOTE: `pipx install poetry` fails on Ubuntu Focal, when installed through APT. By
 # installing the latest version, we sidestep this issue.
@@ -143,7 +147,7 @@ RUN cd /home/user/dangerzone && poetry --no-ansi install
 DOCKERFILE_BUILD_DEBIAN_DEPS = r"""
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends mupdf fuse-overlayfs \
+    && apt-get install -y --no-install-recommends mupdf \
     && rm -rf /var/lib/apt/lists/*
 """
 

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -311,7 +311,23 @@ class Env:
         # We need to retain our UID, because we are mounting the Dangerzone source to
         # the container.
         if self.runtime == "podman":
-            run_cmd += ["--userns", "keep-id"]
+            uidmaps = [
+                "--uidmap",
+                "1000:0:1",
+                "--uidmap",
+                "0:1:1000",
+                "--uidmap",
+                "1001:1001:64536",
+            ]
+            gidmaps = [
+                "--gidmap",
+                "1000:0:1",
+                "--gidmap",
+                "0:1:1000",
+                "--gidmap",
+                "1001:1001:64536",
+            ]
+            run_cmd += uidmaps + gidmaps
 
         # Compute container runtime arguments for GUI purposes.
         if gui:


### PR DESCRIPTION
Update our GitHub Actions workflow with the following tests:

1. Build a .deb for Dangerzone on Debian Bookworm.
2. Install this .deb on every Debian-based platform that we support.
3. Test that the installed version runs successfully.

This way, we can be sure that .deb that we create on a single Debian
version (here we choose Debian Bookworm) works on all platforms.

Refs #358