### PR TITLE
ci: Fix transient errors in Debian Bullseye

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,12 +299,29 @@ jobs:
             ./dev_scripts/env.py --distro debian --version bookworm run --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
+  # NOTE: Making CI tests work in Debian Bullseye requires some tip-toeing
+  # around certain Podman issues, as you'll see below. Read the following for
+  # more details:
+  #
+  # https://github.com/freedomofpress/dangerzone/issues/388
   ci-debian-bullseye:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2204:2023.04.2
     steps:
       - checkout
       - run: *install-podman
+      - run:
+          name: Configure Podman for Ubuntu 22.04
+          command: |
+            # This config circumvents the following issues:
+            # * https://github.com/containers/podman/issues/6368
+            # * https://github.com/containers/podman/issues/10987
+            mkdir -p ~/.config/containers
+            cat > ~/.config/containers/containers.conf \<<EOF
+            [engine]
+            cgroup_manager="cgroupfs"
+            events_logger="file"
+            EOF
 
       - run:
           name: Prepare cache directory
@@ -318,6 +335,22 @@ jobs:
           name: Prepare Dangerzone environment
           command: |
             ./dev_scripts/env.py --distro debian --version bullseye build-dev
+
+      - run:
+          name: Configure Podman for Debian Bullseye
+          command: |
+            # Copy the Podman config into the container image we created for the
+            # Dangerzone environment.
+            cp ~/.config/containers/containers.conf containers.conf
+            cat > Dockerfile.bullseye \<<EOF
+            FROM dangerzone.rocks/build/debian:bullseye-backports
+            RUN mkdir -p /home/user/.config/containers
+            COPY containers.conf /home/user/.config/containers/
+            EOF
+
+            # Create a new image from the Dangerzone environment and re-tag it.
+            podman build -t dangerzone.rocks/build/debian:bullseye-backports \
+                -f Dockerfile.bullseye .
 
       - run:
           name: Run CI tests

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -71,15 +71,19 @@ RUN . /etc/os-release \
 """
 
 # FIXME: Do we really need the python3-venv packages?
-# XXX: We install uidmap separately, because it is not a hard dependency for Podman, and
-# we use --no-install-recommends.
 DOCKERFILE_BUILD_DEV_DEBIAN_DEPS = r"""
 ARG DEBIAN_FRONTEND=noninteractive
 
+# NOTE: Podman has several recommended packages that are actually essential for rootless
+# containers. Instead of specifying them by name, we can install Podman with all of its
+# recommendations, which increases the image size, but makes the environment less flaky.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends podman uidmap dh-python make \
-        build-essential fakeroot fuse-overlayfs libqt5gui5 pipx python3 python3-dev \
-        python3-venv python3-stdeb python3-all \
+    && apt-get install -y podman \
+    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends dh-python make build-essential \
+        fakeroot libqt5gui5 pipx python3 python3-dev python3-venv python3-stdeb \
+        python3-all \
     && rm -rf /var/lib/apt/lists/*
 # NOTE: `pipx install poetry` fails on Ubuntu Focal, when installed through APT. By
 # installing the latest version, we sidestep this issue.
@@ -143,7 +147,7 @@ RUN cd /home/user/dangerzone && poetry --no-ansi install
 DOCKERFILE_BUILD_DEBIAN_DEPS = r"""
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends mupdf fuse-overlayfs \
+    && apt-get install -y --no-install-recommends mupdf \
     && rm -rf /var/lib/apt/lists/*
 """
 


### PR DESCRIPTION
Fix transient errors in Debian Bullseye CI tests by using a different machine image (Ubuntu 22.04 vs Ubuntu 20.04), and solving some Podman config issues along the way.

Fixes #388