### PR TITLE
Bump python version on Windows to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: pip install poetry
       - run: poetry install
       - name: Run CLI tests

--- a/BUILD.md
+++ b/BUILD.md
@@ -294,7 +294,7 @@ it to convert a document.
 
 Install [Docker Desktop](https://www.docker.com/products/docker-desktop). Make sure to choose your correct CPU, either Intel Chip or Apple Chip.
 
-Install the latest version of Python 3.10 [from python.org](https://www.python.org/downloads/macos/), and make sure `/Library/Frameworks/Python.framework/Versions/3.10/bin` is in your `PATH`.
+Install the latest version of Python 3.11 [from python.org](https://www.python.org/downloads/macos/), and make sure `/Library/Frameworks/Python.framework/Versions/3.11/bin` is in your `PATH`.
 
 Install Python dependencies:
 
@@ -346,7 +346,7 @@ The output is in the `dist` folder.
 
 Install [Docker Desktop](https://www.docker.com/products/docker-desktop).
 
-Install the latest version of Python 3.10 (64-bit) [from python.org](https://www.python.org/downloads/windows/). Make sure to check the "Add Python 3.10 to PATH" checkbox on the first page of the installer.
+Install the latest version of Python 3.11 (64-bit) [from python.org](https://www.python.org/downloads/windows/). Make sure to check the "Add Python 3.11 to PATH" checkbox on the first page of the installer.
 
 
 Install Microsoft Visual C++ 14.0 or greater. Get it with ["Microsoft C++ Build Tools"](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and make sure to select "Desktop development with C++" when installing.
@@ -400,7 +400,7 @@ Open a command prompt, cd into the dangerzone directory, and run:
 poetry run python .\setup-windows.py build
 ```
 
-In `build\exe.win32-3.10\` you will find `dangerzone.exe`, `dangerzone-cli.exe`, and all supporting files.
+In `build\exe.win32-3.11\` you will find `dangerzone.exe`, `dangerzone-cli.exe`, and all supporting files.
 
 ### To build the installer
 

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -257,7 +257,7 @@ CONTENT_BUILD_WINDOWS = r"""## Windows
 
 Install [Docker Desktop](https://www.docker.com/products/docker-desktop).
 
-Install the latest version of Python 3.10 (64-bit) [from python.org](https://www.python.org/downloads/windows/). Make sure to check the "Add Python 3.10 to PATH" checkbox on the first page of the installer.
+Install the latest version of Python 3.11 (64-bit) [from python.org](https://www.python.org/downloads/windows/). Make sure to check the "Add Python 3.11 to PATH" checkbox on the first page of the installer.
 
 
 Install Microsoft Visual C++ 14.0 or greater. Get it with ["Microsoft C++ Build Tools"](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and make sure to select "Desktop development with C++" when installing.

--- a/install/windows/build-app.bat
+++ b/install/windows/build-app.bat
@@ -6,8 +6,8 @@ REM build the exe
 python .\setup-windows.py build
 
 REM code sign dangerzone.exe
-signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.10\dangerzone.exe
-signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.10\dangerzone-cli.exe
+signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.11\dangerzone.exe
+signtool.exe sign /v /d "Dangerzone" /sha1 1a0345732140749bdaa03efe8591b2c2a036884c /tr http://timestamp.digicert.com build\exe.win-amd64-3.11\dangerzone-cli.exe
 
 REM build the wix file
 python install\windows\build-wxs.py > build\Dangerzone.wxs

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -23,12 +23,12 @@ def build_data(dirname, dir_prefix, id_, name):
                 id_prefix = id_
 
             # Skip lib/PySide6/examples folder due to ilegal file names
-            if "\\build\\exe.win-amd64-3.10\\lib\\PySide6\\examples" in dirname:
+            if "\\build\\exe.win-amd64-3.11\\lib\\PySide6\\examples" in dirname:
                 continue
 
             # Skip lib/PySide6/qml/QtQuick folder due to ilegal file names
             # XXX Since we're not using Qml it should be no problem
-            if "\\build\\exe.win-amd64-3.10\\lib\\PySide6\\qml\\QtQuick" in dirname:
+            if "\\build\\exe.win-amd64-3.11\\lib\\PySide6\\qml\\QtQuick" in dirname:
                 continue
 
             id_value = f"{id_prefix}{basename.capitalize().replace('-', '_')}"
@@ -128,7 +128,7 @@ def main():
     dist_dir = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
         "build",
-        "exe.win-amd64-3.10",
+        "exe.win-amd64-3.11",
     )
     if not os.path.exists(dist_dir):
         print("You must build the dangerzone binary before running this")
@@ -152,7 +152,7 @@ def main():
     data["dirs"][0]["dirs"].append(
         build_data(
             dist_dir,
-            "exe.win-amd64-3.10",
+            "exe.win-amd64-3.11",
             "INSTALLDIR",
             "Dangerzone",
         )


### PR DESCRIPTION
Python 3.10.12 fixes some CVEs for which Dangerzone does not appear to be affected, however its binaries are not made available by the python foundation. Moving to 3.11 should be trivial since this was already deployed in Fedora 37+.