### PR TITLE
Remove pipes module and use shlex instead

### DIFF
--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pipes
 import platform
 import shlex
 import subprocess
@@ -68,7 +67,7 @@ class DangerzoneGui(DangerzoneCore):
             args = ["open", "-a", "Preview.app", filename]
 
             # Run
-            args_str = " ".join(pipes.quote(s) for s in args)
+            args_str = " ".join(shlex.quote(s) for s in args)
             log.info(Fore.YELLOW + "> " + Fore.CYAN + args_str)
             subprocess.run(args)
 
@@ -89,7 +88,7 @@ class DangerzoneGui(DangerzoneCore):
                     args[i] = filename
 
             # Open as a background process
-            args_str = " ".join(pipes.quote(s) for s in args)
+            args_str = " ".join(shlex.quote(s) for s in args)
             log.info(Fore.YELLOW + "> " + Fore.CYAN + args_str)
             subprocess.Popen(args)
 

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -3,8 +3,8 @@ import json
 import logging
 import os
 import pathlib
-import pipes
 import platform
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -152,7 +152,7 @@ class Container(IsolationProvider):
         document: Document,
         args: List[str],
     ) -> int:
-        args_str = " ".join(pipes.quote(s) for s in args)
+        args_str = " ".join(shlex.quote(s) for s in args)
         log.info("> " + args_str)
 
         with subprocess.Popen(


### PR DESCRIPTION
pipes module will be removed in python 3.13

I didn't add compatible code for 3.3 or lower, since all supported system has python 3.3+ version.

There may be problems with non-Unix shells such as Windows. (https://docs.python.org/3/library/shlex.html#shlex.quote)

Thanks: https://github.com/tox-dev/tox/pull/2418/files