### PR TITLE
Add full test coverage for update notifications

### DIFF
--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -37,8 +37,8 @@ class Application(QtWidgets.QApplication):
     document_selected = QtCore.Signal(list)
     application_activated = QtCore.Signal()
 
-    def __init__(self) -> None:
-        super(Application, self).__init__()
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        super(Application, self).__init__(*args, **kwargs)
         self.setQuitOnLastWindowClosed(False)
         with open(get_resource_path("dangerzone.css"), "r") as f:
             style = f.read()

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -149,21 +149,22 @@ class Dialog(QtWidgets.QDialog):
 
         message_layout = self.create_layout()
 
-        ok_button = QtWidgets.QPushButton(ok_text)
-        ok_button.clicked.connect(self.clicked_ok)
+        self.ok_button = QtWidgets.QPushButton(ok_text)
+        self.ok_button.clicked.connect(self.clicked_ok)
+
         if extra_button_text:
-            extra_button = QtWidgets.QPushButton(extra_button_text)
-            extra_button.clicked.connect(self.clicked_extra)
+            self.extra_button = QtWidgets.QPushButton(extra_button_text)
+            self.extra_button.clicked.connect(self.clicked_extra)
 
         buttons_layout = QtWidgets.QHBoxLayout()
         buttons_layout.addStretch()
-        buttons_layout.addWidget(ok_button)
+        buttons_layout.addWidget(self.ok_button)
         if extra_button_text:
-            buttons_layout.addWidget(extra_button)
+            buttons_layout.addWidget(self.extra_button)
         if has_cancel:
-            cancel_button = QtWidgets.QPushButton(cancel_text)
-            cancel_button.clicked.connect(self.clicked_cancel)
-            buttons_layout.addWidget(cancel_button)
+            self.cancel_button = QtWidgets.QPushButton(cancel_text)
+            self.cancel_button.clicked.connect(self.clicked_cancel)
+            buttons_layout.addWidget(self.cancel_button)
 
         layout = QtWidgets.QVBoxLayout()
         layout.addLayout(message_layout)

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -187,7 +187,7 @@ class MainWindow(QtWidgets.QMainWindow):
         version = self.dangerzone.settings.get("updater_latest_version")
         changelog = self.dangerzone.settings.get("updater_latest_changelog")
 
-        changelog_widget = CollapsibleBox("Changelog")
+        changelog_widget = CollapsibleBox("What's New?")
         changelog_layout = QtWidgets.QVBoxLayout()
         changelog_text_box = QtWidgets.QTextBrowser()
         changelog_text_box.setHtml(changelog)

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -97,7 +97,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.hamburger_button.setIconSize(
             QtCore.QSize(HAMBURGER_MENU_SIZE, HAMBURGER_MENU_SIZE)
         )
-        # FIXME: Maybe remove the box around the icon as well
         self.hamburger_button.setStyleSheet(
             "QToolButton::menu-indicator { image: none; }"
         )
@@ -281,7 +280,6 @@ class MainWindow(QtWidgets.QMainWindow):
             )
 
             sep = hamburger_menu.insertSeparator(hamburger_menu.actions()[0])
-            # FIXME: Add green bubble next to the text.
             success_action = QtGui.QAction("New version available", hamburger_menu)  # type: ignore [attr-defined]
             success_action.setIcon(
                 QtGui.QIcon(self.load_svg_image("hamburger_menu_update_available.svg"))

--- a/dangerzone/gui/updater.py
+++ b/dangerzone/gui/updater.py
@@ -26,8 +26,6 @@ from .logic import Alert, DangerzoneGui
 log = logging.getLogger(__name__)
 
 
-# TODO: Create a wiki page that explains how updates work for Dangerzone, before
-# merging this.
 MSG_CONFIRM_UPDATE_CHECKS = """\
 <p>Do you want to be notified about new Dangerzone releases?</p>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import typing
+
+import pytest
+
+from dangerzone.gui import Application
+
+
+# Use this fixture to make `pytest-qt` invoke our custom QApplication.
+# See https://pytest-qt.readthedocs.io/en/latest/qapplication.html#testing-custom-qapplications
+@pytest.fixture(scope="session")
+def qapp_cls() -> typing.Type[Application]:
+    return Application

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1,26 +1,22 @@
+import time
+import typing
+
+from PySide6 import QtCore, QtWidgets
 from pytest import MonkeyPatch, fixture
 from pytest_mock import MockerFixture
 from pytestqt.qtbot import QtBot
 
 from dangerzone.gui import MainWindow
-from dangerzone.gui import updater as updater_mod
-from dangerzone.gui.main_window import *
+from dangerzone.gui import main_window as main_window_module
+from dangerzone.gui import updater as updater_module
+from dangerzone.gui.logic import DangerzoneGui
+from dangerzone.gui.main_window import ContentWidget
 from dangerzone.gui.updater import UpdateReport, UpdaterThread
 from dangerzone.util import get_version
 
 from .. import sample_doc, sample_pdf
-from . import qt_updater, updater
-from .test_updater import default_updater_settings
-
-# FIXME: See https://github.com/freedomofpress/dangerzone/issues/320 for more details.
-if typing.TYPE_CHECKING:
-    from PySide2 import QtCore
-else:
-    try:
-        from PySide6 import QtCore, QtGui, QtWidgets
-    except ImportError:
-        from PySide2 import QtCore, QtGui, QtWidgets
-
+from . import qt_updater as updater
+from .test_updater import assert_report_equal, default_updater_settings
 
 ##
 ## Widget Fixtures
@@ -28,7 +24,7 @@ else:
 
 
 @fixture
-def content_widget(qtbot: QtBot, mocker: MockerFixture) -> QtWidgets.QWidget:
+def content_widget(qtbot: QtBot, mocker: MockerFixture) -> ContentWidget:
     # Setup
     mock_app = mocker.MagicMock()
     dummy = mocker.MagicMock()
@@ -38,63 +34,280 @@ def content_widget(qtbot: QtBot, mocker: MockerFixture) -> QtWidgets.QWidget:
     return w
 
 
-def test_qt(
+def test_default_menu(
     qtbot: QtBot,
-    qt_updater: UpdaterThread,
+    updater: UpdaterThread,
+) -> None:
+    """Check that the default menu entries are in order."""
+    updater.dangerzone.settings.set("updater_check", True)
+
+    window = MainWindow(updater.dangerzone)
+    menu_actions = window.hamburger_button.menu().actions()
+    assert len(menu_actions) == 3
+
+    toggle_updates_action = menu_actions[0]
+    assert toggle_updates_action.text() == "Check for updates"
+    assert toggle_updates_action.isChecked()
+
+    separator = menu_actions[1]
+    assert separator.isSeparator()
+
+    exit_action = menu_actions[2]
+    assert exit_action.text() == "Exit"
+
+    toggle_updates_action.trigger()
+    assert not toggle_updates_action.isChecked()
+    assert updater.dangerzone.settings.get("updater_check") == False
+
+
+def test_no_update(
+    qtbot: QtBot,
+    updater: UpdaterThread,
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
 ) -> None:
-    updater = qt_updater
+    """Test that when no update has been detected, the user is not alerted."""
+    # Check that when no update is detected, e.g., due to update cooldown, an empty
+    # report is received that does not affect the menu entries.
+    curtime = int(time.time())
     updater.dangerzone.settings.set("updater_check", True)
-    updater.dangerzone.settings.set("updater_last_check", 0)
+    updater.dangerzone.settings.set("updater_errors", 9)
+    updater.dangerzone.settings.set("updater_last_check", curtime)
+
     expected_settings = default_updater_settings()
     expected_settings["updater_check"] = True
-
-    mock_upstream_info = {"tag_name": f"v{get_version()}", "body": "changelog"}
-
-    # Always assume that we can perform multiple update checks in a row.
-    monkeypatch.setattr(updater, "_should_postpone_update_check", lambda: False)
-
-    # Make requests.get().json() return the above dictionary.
-    requests_mock = mocker.MagicMock()
-    requests_mock().json.return_value = mock_upstream_info
-    monkeypatch.setattr(updater_mod.requests, "get", requests_mock)
+    expected_settings["updater_errors"] = 0  # errors must be cleared
+    expected_settings["updater_last_check"] = curtime
 
     window = MainWindow(updater.dangerzone)
     window.register_update_handler(updater.finished)
+    handle_updates_spy = mocker.spy(window, "handle_updates")
+
+    menu_actions_before = window.hamburger_button.menu().actions()
+
     with qtbot.waitSignal(updater.finished) as blocker:
         updater.start()
 
-    assert len(window.hamburger_button.menu().actions()) == 3
+    # Check that the callback function gets an empty report.
+    handle_updates_spy.assert_called_once()
+    assert_report_equal(handle_updates_spy.call_args.args[0], UpdateReport())
+
+    # Check that the menu entries remain exactly the same.
+    menu_actions_after = window.hamburger_button.menu().actions()
+    assert menu_actions_before == menu_actions_after
+
+    # Check that any previous update errors are cleared.
+    assert updater.dangerzone.settings.get_updater_settings() == expected_settings
+
+
+def test_update_detected(
+    qtbot: QtBot,
+    updater: UpdaterThread,
+    monkeypatch: MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Test that a newly detected version leads to a notification to the user."""
+    updater.dangerzone.settings.set("updater_check", True)
+    updater.dangerzone.settings.set("updater_last_check", 0)
+    updater.dangerzone.settings.set("updater_errors", 9)
+
+    # Make requests.get().json() return the following dictionary.
+    mock_upstream_info = {"tag_name": "99.9.9", "body": "changelog"}
+    mocker.patch("dangerzone.gui.updater.requests.get")
+    requests_mock = updater_module.requests.get
+    requests_mock().status_code = 200  # type: ignore [call-arg]
+    requests_mock().json.return_value = mock_upstream_info  # type: ignore [attr-defined, call-arg]
+
+    window = MainWindow(updater.dangerzone)
+    window.register_update_handler(updater.finished)
+    handle_updates_spy = mocker.spy(window, "handle_updates")
+    load_svg_spy = mocker.spy(window, "load_svg_image")
+
+    menu_actions_before = window.hamburger_button.menu().actions()
+
+    with qtbot.waitSignal(updater.finished) as blocker:
+        updater.start()
+
+    menu_actions_after = window.hamburger_button.menu().actions()
+
+    # Check that the callback function gets an update report.
+    handle_updates_spy.assert_called_once()
+    assert_report_equal(
+        handle_updates_spy.call_args.args[0], UpdateReport("99.9.9", "<p>changelog</p>")
+    )
+
+    # Check that the settings have been updated properly.
+    expected_settings = default_updater_settings()
+    expected_settings["updater_check"] = True
     expected_settings["updater_last_check"] = updater.dangerzone.settings.get(
         "updater_last_check"
     )
-    assert updater.dangerzone.settings.get_updater_settings() == expected_settings
-
-    mock_upstream_info["tag_name"] = "v99.9.9"
-    mock_upstream_info["changelog"] = "changelog"
     expected_settings["updater_latest_version"] = "99.9.9"
     expected_settings["updater_latest_changelog"] = "<p>changelog</p>"
+    expected_settings["updater_errors"] = 0
+    assert updater.dangerzone.settings.get_updater_settings() == expected_settings
+
+    # Check that the hamburger icon has changed with the expected SVG image.
+    assert load_svg_spy.call_count == 2
+    assert load_svg_spy.call_args_list[0].args[0] == "hamburger_menu_update_success.svg"
+    assert (
+        load_svg_spy.call_args_list[1].args[0] == "hamburger_menu_update_available.svg"
+    )
+
+    # Check that new menu entries have been added.
+    menu_actions_after = window.hamburger_button.menu().actions()
+    assert len(menu_actions_after) == 5
+    assert menu_actions_after[2:] == menu_actions_before
+
+    success_action = menu_actions_after[0]
+    assert success_action.text() == "New version available"
+
+    separator = menu_actions_after[1]
+    assert separator.isSeparator()
+
+    # Check that clicking in the new menu entry, opens a dialog.
+    update_dialog_spy = mocker.spy(main_window_module, "UpdateDialog")
+
+    def check_dialog() -> None:
+        dialog = updater.dangerzone.app.activeWindow()
+
+        update_dialog_spy.assert_called_once()
+        kwargs = update_dialog_spy.call_args.kwargs
+        assert "99.9.9" in kwargs["title"]
+        assert "dangerzone.rocks" in kwargs["intro_msg"]
+        assert not kwargs["middle_widget"].toggle_button.isChecked()
+        collapsible_box = kwargs["middle_widget"]
+        text_browser = (
+            collapsible_box.layout().itemAt(1).widget().layout().itemAt(0).widget()
+        )
+        assert collapsible_box.toggle_button.text() == "What's New?"
+        assert text_browser.toPlainText() == "changelog"
+
+        height_initial = dialog.sizeHint().height()
+        width_initial = dialog.sizeHint().width()
+
+        # Collapse the "What's New" section and ensure that the dialog's height
+        # increases.
+        with qtbot.waitSignal(collapsible_box.toggle_animation.finished) as blocker:
+            collapsible_box.toggle_button.click()
+
+        assert dialog.sizeHint().height() > height_initial
+        assert dialog.sizeHint().width() == width_initial
+
+        # Uncollapse the "What's New" section, and ensure that the dialog's height gets
+        # back to the original value.
+        with qtbot.waitSignal(collapsible_box.toggle_animation.finished) as blocker:
+            collapsible_box.toggle_button.click()
+
+        assert dialog.sizeHint().height() == height_initial
+        assert dialog.sizeHint().width() == width_initial
+
+        dialog.close()
+
+    QtCore.QTimer.singleShot(500, check_dialog)
+    success_action.trigger()
+
+    # FIXME: We should check the content of the dialog here.
+
+
+def test_update_error(
+    qtbot: QtBot,
+    updater: UpdaterThread,
+    monkeypatch: MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Test that an error during an update check leads to a notification to the user."""
+    # Test 1 - Check that the first error does not notify the user.
+    updater.dangerzone.settings.set("updater_check", True)
+    updater.dangerzone.settings.set("updater_last_check", 0)
+    updater.dangerzone.settings.set("updater_errors", 0)
+
+    # Make requests.get() return an errorthe following dictionary.
+    mocker.patch("dangerzone.gui.updater.requests.get")
+    requests_mock = updater_module.requests.get
+    requests_mock.side_effect = Exception("failed")  # type: ignore [attr-defined]
+
+    window = MainWindow(updater.dangerzone)
+    window.register_update_handler(updater.finished)
+    handle_updates_spy = mocker.spy(window, "handle_updates")
+    load_svg_spy = mocker.spy(window, "load_svg_image")
+
+    menu_actions_before = window.hamburger_button.menu().actions()
 
     with qtbot.waitSignal(updater.finished) as blocker:
         updater.start()
 
-    # The separator and install updates button has been added
-    assert len(window.hamburger_button.menu().actions()) == 5
+    menu_actions_after = window.hamburger_button.menu().actions()
+
+    # Check that the callback function gets an update report.
+    handle_updates_spy.assert_called_once()
+    assert "failed" in handle_updates_spy.call_args.args[0].error
+
+    # Check that the settings have been updated properly.
+    expected_settings = default_updater_settings()
+    expected_settings["updater_check"] = True
+    expected_settings["updater_last_check"] = updater.dangerzone.settings.get(
+        "updater_last_check"
+    )
+    expected_settings["updater_errors"] += 1
+    assert updater.dangerzone.settings.get_updater_settings() == expected_settings
+
+    # Check that the hamburger icon has not changed.
+    assert load_svg_spy.call_count == 0
+
+    # Check that no menu entries have been added.
+    assert menu_actions_before == menu_actions_after
+
+    # Test 2 - Check that the second error does not notify the user either.
+    updater.dangerzone.settings.set("updater_last_check", 0)
+    with qtbot.waitSignal(updater.finished) as blocker:
+        updater.start()
+
+    assert load_svg_spy.call_count == 0
+
+    # Check that the settings have been updated properly.
+    expected_settings["updater_errors"] += 1
     expected_settings["updater_last_check"] = updater.dangerzone.settings.get(
         "updater_last_check"
     )
     assert updater.dangerzone.settings.get_updater_settings() == expected_settings
 
-    # TODO:
-    # 1. Test that hamburger icon changes according to the update status.
-    # 2. Check that the dialogs for new updates / update errors have the expected
-    #    content.
-    # 3. Check that a user can toggle updates from the hamburger menu.
-    # 4. Check that errors are cleared from the settings, whenever we have a successful
-    #    update check.
-    # 5. Check that latest version/changelog, as well as update errors, are cached in
-    #    the settings
+    # Check that no menu entries have been added.
+    assert menu_actions_before == menu_actions_after
+
+    # Test 3 - Check that a third error shows a new menu entry.
+    updater.dangerzone.settings.set("updater_last_check", 0)
+    with qtbot.waitSignal(updater.finished) as blocker:
+        updater.start()
+
+    menu_actions_after = window.hamburger_button.menu().actions()
+    assert len(menu_actions_after) == 5
+    assert menu_actions_after[2:] == menu_actions_before
+
+    error_action = menu_actions_after[0]
+    assert error_action.text() == "Update error"
+
+    separator = menu_actions_after[1]
+    assert separator.isSeparator()
+
+    # Check that clicking in the new menu entry, opens a dialog.
+    update_dialog_spy = mocker.spy(main_window_module, "UpdateDialog")
+
+    def check_dialog() -> None:
+        dialog = updater.dangerzone.app.activeWindow()
+
+        update_dialog_spy.assert_called_once()
+        kwargs = update_dialog_spy.call_args.kwargs
+        assert kwargs["title"] == "Update check error"
+        assert "Something went wrong" in kwargs["intro_msg"]
+        assert "Encountered an exception" in kwargs["middle_widget"].toPlainText()
+        assert "failed" in kwargs["middle_widget"].toPlainText()
+        assert "dangerzone.rocks" in kwargs["epilogue_msg"]
+
+        dialog.close()
+
+    QtCore.QTimer.singleShot(500, check_dialog)
+    error_action.trigger()
 
 
 ##

--- a/tests/gui/test_updater.py
+++ b/tests/gui/test_updater.py
@@ -156,18 +156,19 @@ def test_user_prompts(
     #
     # When Dangerzone runs for a second time, users can be prompted to enable update
     # checks. Depending on their answer, we should either enable or disable them.
-    alert_mock = mocker.MagicMock()
-    monkeypatch.setattr(updater_module, "Alert", alert_mock)
+    mocker.patch("dangerzone.gui.updater.UpdateCheckPrompt")
+    prompt_mock = updater_module.UpdateCheckPrompt
+    prompt_mock().x_pressed = False
 
     # Check disabling update checks.
-    alert_mock().launch.return_value = False
+    prompt_mock().launch.return_value = False  # type: ignore [attr-defined]
     expected_settings["updater_check"] = False
     assert updater.should_check_for_updates() == False
     assert updater.dangerzone.settings.get_updater_settings() == expected_settings
 
     # Reset the "updater_check" field and check enabling update checks.
     updater.dangerzone.settings.set("updater_check", None)
-    alert_mock().launch.return_value = True
+    prompt_mock().launch.return_value = True  # type: ignore [attr-defined]
     expected_settings["updater_check"] = True
     assert updater.should_check_for_updates() == True
     assert updater.dangerzone.settings.get_updater_settings() == expected_settings
@@ -176,7 +177,7 @@ def test_user_prompts(
     #
     # From the third run onwards, users should never be prompted for enabling update
     # checks.
-    alert_mock.side_effect = RuntimeError("Should not be called")
+    prompt_mock().side_effect = RuntimeError("Should not be called")  # type: ignore [attr-defined]
     for check in [True, False]:
         updater.dangerzone.settings.set("updater_check", check)
         assert updater.should_check_for_updates() == check


### PR DESCRIPTION
This PR adds some extra tests that were missing from the original #466 PR. The new tests cover all the GUI functionality that was not covered in previous tests. Also, it:

1. Improves the logic that is related to getting info from GitHub.
2. Adds a way to differentiate between a user who clicks on "Cancel" and "X".