### PR TITLE
Drop Ubuntu 22.10 (Kinetic Kudu) support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,33 +181,6 @@ jobs:
             ./dev_scripts/env.py --distro ubuntu --version 23.04 run -g --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
-  ci-ubuntu-kinetic:
-    machine:
-      image: ubuntu-2004:202111-01
-    steps:
-      - checkout
-      - run: *install-podman
-
-      - run:
-          name: Prepare cache directory
-          command: |
-            sudo mkdir -p /caches
-            sudo chown -R $USER:$USER /caches
-      - run: *calculate-cache-key
-      - restore_cache: *restore-cache
-      - run: *copy-image
-
-      - run:
-          name: Prepare Dangerzone environment
-          command: |
-            ./dev_scripts/env.py --distro ubuntu --version 22.10 build-dev
-
-      - run:
-          name: Run CI tests
-          command: |
-            ./dev_scripts/env.py --distro ubuntu --version 22.10 run -g --dev \
-                bash -c 'cd dangerzone; poetry run make test'
-
   ci-ubuntu-jammy:
     machine:
       image: ubuntu-2004:202111-01
@@ -442,18 +415,6 @@ jobs:
       - run: *copy-image
       - run: *build-deb
 
-  build-ubuntu-kinetic:
-    docker:
-      - image: ubuntu:22.10
-    resource_class: medium+
-    steps:
-      - run: *install-dependencies-deb
-      - checkout
-      - run: *calculate-cache-key
-      - restore_cache: *restore-cache
-      - run: *copy-image
-      - run: *build-deb
-
   build-ubuntu-jammy:
     docker:
       - image: ubuntu:22.04
@@ -552,9 +513,6 @@ workflows:
       - ci-ubuntu-lunar:
           requires:
             - build-container-image
-      - ci-ubuntu-kinetic:
-          requires:
-            - build-container-image
       - ci-ubuntu-jammy:
           requires:
             - build-container-image
@@ -577,9 +535,6 @@ workflows:
           requires:
             - build-container-image
       - build-ubuntu-lunar:
-          requires:
-            - build-container-image
-      - build-ubuntu-kinetic:
           requires:
             - build-container-image
       - build-ubuntu-jammy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,6 @@ jobs:
           - target: ubuntu-22.04
             distro: ubuntu
             version: "22.04"
-          - target: ubuntu-22.10
-            distro: ubuntu
-            version: "22.10"
           - target: ubuntu-23.04
             distro: ubuntu
             version: "23.04"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 ### Removed
 
 - Platform support: Drop Fedora 36, since it's end-of-life ([issue #420](https://github.com/freedomofpress/dangerzone/issues/420))
+- Platform support: Drop Ubuntu 22.10 (Kinetic Kudu), since it's end-of-life ([issue #485](https://github.com/freedomofpress/dangerzone/issues/485))
 
 ### Fixed
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,6 @@
 Dangerzone is available for:
 
 - Ubuntu 23.04 (lunar)
-- Ubuntu 22.10 (kinetic)
 - Ubuntu 22.04 (jammy)
 - Ubuntu 20.04 (focal)
 - Debian 13 (trixie)

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -812,11 +812,6 @@ class QAUbuntu2204(QADebianBased):
     VERSION = "22.04"
 
 
-class QAUbuntu2210(QADebianBased):
-    DISTRO = "ubuntu"
-    VERSION = "22.10"
-
-
 class QAUbuntu2304(QADebianBased):
     DISTRO = "ubuntu"
     VERSION = "23.04"


### PR DESCRIPTION
Drop support for Ubuntu 22.10 (Kinetic Kudu), because it's past its [EOL date](https://endoflife.date/ubuntu).

Closes #485