### PR TITLE
Force text color to be black

### DIFF
--- a/share/dangerzone.css
+++ b/share/dangerzone.css
@@ -5,6 +5,10 @@ QLineEdit {
     padding: 3px;
 }
 
+QWidget {
+    color: black;
+}
+
 /*
  * QLabel left-adjacent to a QLineEdit to give the illusion
  * that it is part of it, but just not editable


### PR DESCRIPTION
Add a rule in our `dangerzone.css` file to make the text in all of our widgets black. This is supposedly the default option, based on our experience so far. After the update to the latest PySide6 libraries (see #482), we've seen that in Fedora 37 the text color is set to grey. This gives the impression that the window is disabled, so we want to set the text color to black by default.

Before:

![dz_grey](https://github.com/freedomofpress/dangerzone/assets/2507626/5b1dece8-616a-403d-a37d-50d418ff2ebc)

After:

![dz_black](https://github.com/freedomofpress/dangerzone/assets/2507626/609d655b-3cff-44e8-bc27-c8823d2d976f)
