### PR TITLE
Force Podman use the overlay storage driver

### DIFF
--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -141,6 +141,11 @@ USER user
 WORKDIR /home/user
 VOLUME /home/user/dangerzone
 
+# Force Podman to use a specific configuration.
+# See https://github.com/freedomofpress/dangerzone/issues/489
+RUN mkdir -p /home/user/.config/containers
+COPY storage.conf /home/user/.config/containers
+
 # Install Poetry under ~/.local/bin.
 # See https://github.com/freedomofpress/dangerzone/issues/351
 # FIXME: pipx install poetry does not work for Ubuntu Focal.
@@ -188,6 +193,12 @@ RUN echo user:2000:2000 > /etc/subgid
 
 USER user
 WORKDIR /home/user
+
+########################################
+# Force Podman to use a specific configuration.
+# See https://github.com/freedomofpress/dangerzone/issues/489
+RUN mkdir -p /home/user/.config/containers
+COPY storage.conf /home/user/.config/containers
 """
 
 
@@ -446,6 +457,7 @@ class Env:
         # Populate the build context.
         shutil.copy(git_root() / "pyproject.toml", build_dir)
         shutil.copy(git_root() / "poetry.lock", build_dir)
+        shutil.copy(git_root() / "dev_scripts" / "storage.conf", build_dir)
         with open(build_dir / "Dockerfile", mode="w") as f:
             f.write(dockerfile)
 
@@ -492,6 +504,7 @@ class Env:
 
         # Populate the build context.
         shutil.copy(package_src, package_dst)
+        shutil.copy(git_root() / "dev_scripts" / "storage.conf", build_dir)
         with open(build_dir / "Dockerfile", mode="w") as f:
             f.write(dockerfile)
 

--- a/dev_scripts/storage.conf
+++ b/dev_scripts/storage.conf
@@ -1,0 +1,2 @@
+[storage]
+driver = "overlay"


### PR DESCRIPTION
Force Podman to use the overlay storage driver in our Dangerzone environments. We have seen that in certain cases, Podman may opt to use the vfs storage driver instead, which is more space-intensive.

Closes #489

_(Note: this fix [has already been used](https://github.com/freedomofpress/dangerzone/actions/runs/5717214360) to make our failing CI tests for PR #460 pass)_