### PR TITLE
Always pull base image when building ours

### DIFF
--- a/install/linux/build-image.sh
+++ b/install/linux/build-image.sh
@@ -5,7 +5,7 @@ set -e
 TAG=dangerzone.rocks/dangerzone:latest
 
 echo "Building container image"
-podman build dangerzone/ -f Dockerfile --tag $TAG
+podman build --pull dangerzone/ -f Dockerfile --tag $TAG
 
 echo "Saving and compressing container image"
 podman save $TAG | gzip > share/container.tar.gz

--- a/install/macos/build-image.sh
+++ b/install/macos/build-image.sh
@@ -5,7 +5,7 @@ set -e
 TAG=dangerzone.rocks/dangerzone:latest
 
 echo "Building container image"
-docker build dangerzone/ -f Dockerfile --tag $TAG
+docker build --pull dangerzone/ -f Dockerfile --tag $TAG
 
 echo "Saving and compressing container image"
 docker save $TAG | gzip > share/container.tar.gz

--- a/install/windows/build-image.py
+++ b/install/windows/build-image.py
@@ -9,6 +9,7 @@ def main():
         [
             "docker",
             "build",
+            "--pull",
             "dangerzone/",
             "-f",
             "Dockerfile",


### PR DESCRIPTION
Always pull the base container image (alpine:latest) before building our own container image. Else, in an environments that we haven't touched for a while, an older image may be used.