### PR TITLE
Disable HWP / HWPX conversion on MacOS M1 / Qubes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 - Inform about new updates on MacOS/Windows platforms, by periodically checking
   our GitHub releases page ([issue #189](https://github.com/freedomofpress/dangerzone/issues/189))
 - Feature: Add support for HWP/HWPX files (Hancom Office) ([issue #243](https://github.com/freedomofpress/dangerzone/issues/243), thanks to [@OctopusET](https://github.com/OctopusET))
+  * **NOTE:** This feature is not yet supported on MacOS with Apple Silicon CPU
+    or Qubes OS ([issue #494](https://github.com/freedomofpress/dangerzone/issues/494),
+     [issue #498](https://github.com/freedomofpress/dangerzone/issues/498))
 - Allow users to change their document selection from the UI ([issue #428](https://github.com/freedomofpress/dangerzone/issues/428))
 - Add a note in our README for MacOS 11+ users blocked by SIP ([PR #401](https://github.com/freedomofpress/dangerzone/pull/401), thanks to [@keywordnew](https://github.com/keywordnew))
 - Platform support: Alpha integration with Qubes OS ([issue #411](https://github.com/freedomofpress/dangerzone/issues/411))

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Dangerzone can convert these types of document into safe PDFs:
 - ODF Presentation (`.odp`)
 - ODF Graphics (`.odg`)
 - Hancom HWP (Hangul Word Processor) (`.hwp`, `.hwpx`)
+  * Not supported on
+    [MacOS with Apple Silicon CPU](https://github.com/freedomofpress/dangerzone/issues/498)
+    or [Qubes OS](https://github.com/freedomofpress/dangerzone/issues/494)
 - Jpeg (`.jpg`, `.jpeg`)
 - GIF (`.gif`)
 - PNG (`.png`)

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -185,6 +185,12 @@ class DocumentToPixels(DangerzoneConverter):
                 timeout=timeout,
             )
             pdf_filename = "/tmp/input_file.pdf"
+            # XXX: Sometimes, LibreOffice can fail with status code 0. So, we need to
+            # always check if the file exists. See:
+            #
+            #     https://github.com/freedomofpress/dangerzone/issues/494
+            if not os.path.exists(pdf_filename):
+                raise ValueError("Conversion to PDF with LibreOffice failed")
         elif conversion["type"] == "convert":
             self.update_progress("Converting to PDF using GraphicsMagick")
             args = [

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -134,11 +134,7 @@ class DocumentToPixels(DangerzoneConverter):
         }
 
         # Detect MIME type
-        try:
-            mime = magic.Magic(mime=True)
-            mime_type = mime.from_file("/tmp/input_file")
-        except TypeError:
-            mime_type = magic.detect_from_filename("/tmp/input_file").mime_type
+        mime_type = self.detect_mime_type("/tmp/input_file")
 
         # Validate MIME type
         if mime_type not in conversions:
@@ -147,7 +143,7 @@ class DocumentToPixels(DangerzoneConverter):
         # Temporary fix for the HWPX format
         # Should be removed after new release of `file' (current release 5.44)
         if mime_type == "application/zip":
-            file_type = magic.from_file("/tmp/input_file")
+            file_type = self.detect_mime_type("/tmp/input_file")
             hwpx_file_type = 'Zip data (MIME type "application/hwp+zip"?)'
             if file_type == hwpx_file_type:
                 mime_type = "application/x-hwp+zip"
@@ -341,6 +337,19 @@ class DocumentToPixels(DangerzoneConverter):
             timeout_message="unzipping LibreOffice extension timed out 5 seconds",
             timeout=5,
         )
+
+    def detect_mime_type(self, path: str) -> str:
+        """Detect MIME types in a platform-agnostic type.
+
+        Detect the MIME type of a file, either on Qubes or container platforms.
+        """
+        try:
+            mime = magic.Magic(mime=True)
+            mime_type = mime.from_file("/tmp/input_file")
+        except TypeError:
+            mime_type = magic.detect_from_filename("/tmp/input_file").mime_type
+
+        return mime_type
 
 
 async def main() -> int:

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -24,7 +24,7 @@ from .. import errors
 from ..document import SAFE_EXTENSION, Document
 from ..isolation_provider.container import Container, NoContainerTechException
 from ..isolation_provider.dummy import Dummy
-from ..isolation_provider.qubes import Qubes
+from ..isolation_provider.qubes import Qubes, is_qubes_native_conversion
 from ..util import get_resource_path, get_subprocess_startupinfo, get_version
 from .logic import Alert, CollapsibleBox, DangerzoneGui, UpdateDialog
 from .updater import UpdateReport
@@ -551,9 +551,19 @@ class DocSelectionWidget(QtWidgets.QWidget):
         self.file_dialog = QtWidgets.QFileDialog()
         self.file_dialog.setWindowTitle("Open Documents")
         self.file_dialog.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
+
+        # XXX: We disable loading HWP/HWPX files on Qubes or MacOS M1 platforms, because
+        # H2ORestart does not work there. See:
+        #
+        # https://github.com/freedomofpress/dangerzone/issues/494
+        # https://github.com/freedomofpress/dangerzone/issues/498
+        hwp_filters = "*.hwp *.hwpx"
+        if platform.machine() in ("arm64", "aarch64") or is_qubes_native_conversion():
+            hwp_filters = ""
+
         self.file_dialog.setNameFilters(
             [
-                "Documents (*.pdf *.docx *.doc *.docm *.xlsx *.xls *.pptx *.ppt *.odt *.odg *.odp *.ods *.hwp *.hwpx *.jpg *.jpeg *.gif *.png *.tif *.tiff)"
+                f"Documents (*.pdf *.docx *.doc *.docm *.xlsx *.xls *.pptx *.ppt *.odt *.odg *.odp *.ods {hwp_filters} *.jpg *.jpeg *.gif *.png *.tif *.tiff)"
             ]
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import base64
 import contextlib
 import copy
 import os
+import platform
 import re
 import shutil
 import sys
@@ -19,6 +20,7 @@ from strip_ansi import strip_ansi
 
 from dangerzone.cli import cli_main, display_banner
 from dangerzone.document import ARCHIVE_SUBDIR, SAFE_EXTENSION
+from dangerzone.isolation_provider.qubes import is_qubes_native_conversion
 
 from . import TestBase, for_each_doc, for_each_external_doc, sample_pdf
 
@@ -302,6 +304,8 @@ class TestCliConversion(TestCliBasic):
 class TestExtraFormats(TestCli):
     @for_each_external_doc("*hwp*")
     def test_hancom_office(self, doc: str) -> None:
+        if platform.machine() in ("arm64", "aarch64") or is_qubes_native_conversion():
+            pytest.skip("HWP / HWPX formats are not supported on this platform")
         with tempfile.NamedTemporaryFile("wb", delete=False) as decoded_doc:
             with open(doc, "rb") as encoded_doc:
                 decoded_doc.write(base64.b64decode(encoded_doc.read()))


### PR DESCRIPTION
The HWP / HWPX conversion feature does not work on the following
platforms:

* MacOS with Apple Silicon CPU
* Native Qubes OS

For this reason, we need to:

1. Disable it on the GUI side, by not allowing the user to select these
   files.
2. Throw an error on the isolation provider side, in case the user
   directly attempts to convert the file (either through CLI or via
   "Open With").

Refs #494
Refs #498