### PR TITLE
Explicitly import html.parser for Cx_Freeze to build

### DIFF
--- a/dangerzone/gui/updater.py
+++ b/dangerzone/gui/updater.py
@@ -18,6 +18,10 @@ else:
     except ImportError:
         from PySide2 import QtCore, QtWidgets
 
+# XXX implict import for "markdown" module required for Cx_Freeze to build on Windows
+# See https://github.com/freedomofpress/dangerzone/issues/501
+import html.parser
+
 import markdown
 import requests
 


### PR DESCRIPTION
The markdown dependency uses importlib to monkeypatch 'html.parser' [1]. Due to this approach 'html.parser' is never explicitly stated as a dependency. This works fine in most cases, since it's part of the python standard lib. But on Windows the build tool (CxFreeze) ships in the .exe only the modules needed. And because html.parser is never mentioned, it fails with an error (see issue #501).

Fixes #501

[1]: https://github.com/Python-Markdown/markdown/blob/master/markdown/htmlparser.py#L29