### PR TITLE
Updater dialog: make "yes" the default button

### DIFF
--- a/dangerzone/gui/updater.py
+++ b/dangerzone/gui/updater.py
@@ -72,6 +72,7 @@ class UpdateCheckPrompt(Alert):
         assert self.cancel_button is not None
         buttons_layout.addWidget(self.cancel_button)
         buttons_layout.addWidget(self.ok_button)
+        self.ok_button.setDefault(True)
         return buttons_layout
 
 


### PR DESCRIPTION
Fixes #507
![updtr](https://github.com/freedomofpress/dangerzone/assets/47065258/1b006184-c5b4-4274-9499-21e11985d994)
