### PR TITLE
Adds minimal install advice on README.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,14 @@
-Dangerzone is available for:
+## MacOS
+See instructions on [README.md](README.md).
 
+## Windows
+See instructions on [README.md](README.md).
+
+## Linux
+On Linux, Dangerzone uses [Podman](https://podman.io/) instead of Docker Desktop for creating
+an isolated environment. It will be installed automatically when installing Dangerzone.
+
+Dangerzone is available for:
 - Ubuntu 23.04 (lunar)
 - Ubuntu 22.04 (jammy)
 - Ubuntu 20.04 (focal)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,8 @@
 ## MacOS
-See instructions on [README.md](README.md).
+See instructions in [README.md](README.md#macos).
 
 ## Windows
-See instructions on [README.md](README.md).
+See instructions in [README.md](README.md#windows).
 
 ## Linux
 On Linux, Dangerzone uses [Podman](https://podman.io/) instead of Docker Desktop for creating

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can also install Dangerzone for Mac using [Homebrew](https://brew.sh/): `bre
 
 ### Linux
 
-See [installing Dangerzone](INSTALL.md) for adding the Linux repositories to your system.
+See [installing Dangerzone](INSTALL.md#linux) for adding the Linux repositories to your system.
 
 ## Some features
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,27 @@ _Read more about Dangerzone in the [official site](https://dangerzone.rocks/abou
 
 ## Getting started
 
+### MacOS
 - Download [Dangerzone 0.4.2 for Mac (Apple Silicon CPU)](https://github.com/freedomofpress/dangerzone/releases/download/v0.4.2/Dangerzone-0.4.2-arm64.dmg)
 - Download [Dangerzone 0.4.2 for Mac (Intel CPU)](https://github.com/freedomofpress/dangerzone/releases/download/v0.4.2/Dangerzone-0.4.2-i686.dmg)
-- Download [Dangerzone 0.4.2 for Windows](https://github.com/freedomofpress/dangerzone/releases/download/v0.4.2/Dangerzone-0.4.2.msi)
-- See [installing Dangerzone](INSTALL.md) for Linux repositories
 
 You can also install Dangerzone for Mac using [Homebrew](https://brew.sh/): `brew install --cask dangerzone`
+
+> **Note**: you willl also need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+> This program needs to run alongside Dangerzone at all times, since it is what allows Dangerzone to
+> create the secure environment.
+
+### Windows
+
+- Download [Dangerzone 0.4.2 for Windows](https://github.com/freedomofpress/dangerzone/releases/download/v0.4.2/Dangerzone-0.4.2.msi)
+
+> **Note**: you will also need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+> This program needs to run alongside Dangerzone at all times, since it is what allows Dangerzone to
+> create the secure environment.
+
+### Linux
+
+See [installing Dangerzone](INSTALL.md) for adding the Linux repositories to your system.
 
 ## Some features
 


### PR DESCRIPTION
Makes it clear that one needs to install Docker for Desktop to use Dangerzone on Mac or Windows and Podman on linux. The app itself will warn the user about this, but we should state the prerequisites more clearly upfront.

Mentions mac and windows in INSTALL.md so that anyone reading this page does not wrongly assume that Dangerzone is a Linux-only app.

Fixes #475