### PR TITLE
Remove (most) attacker-controlled error messages

### DIFF
--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -373,9 +373,9 @@ async def main() -> int:
         error_code = 0  # Success!
     except errors.ConversionException as e:  # Expected Errors
         error_code = e.error_code
-    except (RuntimeError, TimeoutError, ValueError) as e:  # Unexpected Errors
+    except Exception as e:
         converter.update_progress(str(e), error=True)
-        error_code = 1
+        error_code = errors.UnexpectedConversionError.error_code
     if not running_on_qubes():
         # Write debug information (containers version)
         with open("/tmp/dangerzone/captured_output.txt", "wb") as container_log:

--- a/dangerzone/conversion/doc_to_pixels_qubes_wrapper.py
+++ b/dangerzone/conversion/doc_to_pixels_qubes_wrapper.py
@@ -72,9 +72,12 @@ async def main() -> None:
         converter = DocumentToPixels()
         await converter.convert()
     except errors.ConversionException as e:
+        await write_bytes(str(e).encode(), file=sys.stderr)
         sys.exit(e.error_code)
-    except (RuntimeError, TimeoutError, ValueError) as e:
-        sys.exit(1)
+    except Exception as e:
+        await write_bytes(str(e).encode(), file=sys.stderr)
+        error_code = errors.UnexpectedConversionError.error_code
+        sys.exit(error_code)
 
     num_pages = len(list(out_dir.glob("*.rgb")))
     await write_int(num_pages)

--- a/dangerzone/conversion/doc_to_pixels_qubes_wrapper.py
+++ b/dangerzone/conversion/doc_to_pixels_qubes_wrapper.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional, TextIO
 
+from . import errors
 from .doc_to_pixels import DocumentToPixels
 
 
@@ -67,8 +68,13 @@ async def main() -> None:
     with open("/tmp/input_file", "wb") as f:
         f.write(data)
 
-    converter = DocumentToPixels()
-    await converter.convert()
+    try:
+        converter = DocumentToPixels()
+        await converter.convert()
+    except errors.ConversionException as e:
+        sys.exit(e.error_code)
+    except (RuntimeError, TimeoutError, ValueError) as e:
+        sys.exit(1)
 
     num_pages = len(list(out_dir.glob("*.rgb")))
     await write_int(num_pages)

--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -1,9 +1,11 @@
 from typing import List, Optional, Type
 
+# XXX: errors start at 128 for conversion-related issues
+ERROR_SHIFT = 128
 
 class ConversionException(Exception):
     error_message = "Unspecified error"
-    error_code = -1
+    error_code = ERROR_SHIFT
 
     def __init__(self, error_message: Optional[str] = None) -> None:
         if error_message:
@@ -19,22 +21,22 @@ class ConversionException(Exception):
 
 
 class DocFormatUnsupported(ConversionException):
-    error_code = 10
+    error_code = ERROR_SHIFT + 10
     error_message = "The document format is not supported"
 
 
 class DocFormatUnsupportedHWPQubes(DocFormatUnsupported):
-    error_code = 16
+    error_code = ERROR_SHIFT + 16
     error_message = "HWP / HWPX formats are not supported in Qubes"
 
 
 class LibreofficeFailure(ConversionException):
-    error_code = 20
+    error_code = ERROR_SHIFT + 20
     error_message = "Conversion to PDF with LibreOffice failed"
 
 
 class InvalidGMConversion(ConversionException):
-    error_code = 30
+    error_code = ERROR_SHIFT + 30
     error_message = "Invalid conversion (Graphics Magic)"
 
     def __init__(self, error_message: str) -> None:
@@ -42,26 +44,26 @@ class InvalidGMConversion(ConversionException):
 
 
 class PagesException(ConversionException):
-    error_code = 40
+    error_code = ERROR_SHIFT + 40
 
 
 class NoPageCountException(PagesException):
-    error_code = 41
+    error_code = ERROR_SHIFT + 41
     error_message = "Number of pages could not be extracted from PDF"
 
 
 class PDFtoPPMException(ConversionException):
-    error_code = 50
+    error_code = ERROR_SHIFT + 50
     error_message = "Error converting PDF to Pixels (pdftoppm)"
 
 
 class PDFtoPPMInvalidHeader(PDFtoPPMException):
-    error_code = 51
+    error_code = ERROR_SHIFT + 51
     error_message = "Error converting PDF to Pixels (Invalid PPM header)"
 
 
 class PDFtoPPMInvalidDepth(PDFtoPPMException):
-    error_code = 52
+    error_code = ERROR_SHIFT + 52
     error_message = "Error converting PDF to Pixels (Invalid PPM depth)"
 
 

--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Type
 # XXX: errors start at 128 for conversion-related issues
 ERROR_SHIFT = 128
 
+
 class ConversionException(Exception):
     error_message = "Unspecified error"
     error_code = ERROR_SHIFT
@@ -65,6 +66,11 @@ class PDFtoPPMInvalidHeader(PDFtoPPMException):
 class PDFtoPPMInvalidDepth(PDFtoPPMException):
     error_code = ERROR_SHIFT + 52
     error_message = "Error converting PDF to Pixels (Invalid PPM depth)"
+
+
+class UnexpectedConversionError(PDFtoPPMException):
+    error_code = ERROR_SHIFT + 100
+    error_message = "Some unxpected error occured while converting the document"
 
 
 def exception_from_error_code(error_code: int) -> Optional[ConversionException]:

--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -1,0 +1,73 @@
+from typing import List, Optional, Type
+
+
+class ConversionException(Exception):
+    error_message = "Unspecified error"
+    error_code = -1
+
+    def __init__(self, error_message: Optional[str] = None) -> None:
+        if error_message:
+            self.error_message = error_message
+        super().__init__(self.error_message)
+
+    @classmethod
+    def get_subclasses(cls) -> List[Type["ConversionException"]]:
+        subclasses = [cls]
+        for subclass in cls.__subclasses__():
+            subclasses += subclass.get_subclasses()
+        return subclasses
+
+
+class DocFormatUnsupported(ConversionException):
+    error_code = 10
+    error_message = "The document format is not supported"
+
+
+class DocFormatUnsupportedHWPQubes(DocFormatUnsupported):
+    error_code = 16
+    error_message = "HWP / HWPX formats are not supported in Qubes"
+
+
+class LibreofficeFailure(ConversionException):
+    error_code = 20
+    error_message = "Conversion to PDF with LibreOffice failed"
+
+
+class InvalidGMConversion(ConversionException):
+    error_code = 30
+    error_message = "Invalid conversion (Graphics Magic)"
+
+    def __init__(self, error_message: str) -> None:
+        super(error_message)
+
+
+class PagesException(ConversionException):
+    error_code = 40
+
+
+class NoPageCountException(PagesException):
+    error_code = 41
+    error_message = "Number of pages could not be extracted from PDF"
+
+
+class PDFtoPPMException(ConversionException):
+    error_code = 50
+    error_message = "Error converting PDF to Pixels (pdftoppm)"
+
+
+class PDFtoPPMInvalidHeader(PDFtoPPMException):
+    error_code = 51
+    error_message = "Error converting PDF to Pixels (Invalid PPM header)"
+
+
+class PDFtoPPMInvalidDepth(PDFtoPPMException):
+    error_code = 52
+    error_message = "Error converting PDF to Pixels (Invalid PPM depth)"
+
+
+def exception_from_error_code(error_code: int) -> Optional[ConversionException]:
+    """returns the conversion exception corresponding to the error code"""
+    for cls in ConversionException.get_subclasses():
+        if cls.error_code == error_code:
+            return cls()
+    raise ValueError(f"Unknown error code '{error_code}'")

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional
 
 from colorama import Fore, Style
 
+from ..conversion.errors import ConversionException
 from ..document import Document
 from ..util import replace_control_chars
 
@@ -36,7 +37,10 @@ class IsolationProvider(ABC):
         document.mark_as_converting()
         try:
             success = self._convert(document, ocr_lang)
-        except Exception:
+        except ConversionException as e:
+            success = False
+            self.print_progress_trusted(document, True, e.error_message, 0)
+        except Exception as e:
             success = False
             log.exception(
                 f"An exception occurred while converting document '{document.id}'"

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 from typing import Any, Callable, List, Optional, Tuple
 
+from ..conversion.errors import exception_from_error_code
 from ..document import Document
 from ..util import (
     get_resource_path,
@@ -305,6 +306,9 @@ class Container(IsolationProvider):
 
         if ret != 0:
             log.error("documents-to-pixels failed")
+
+            # XXX Reconstruct exception from error code
+            raise exception_from_error_code(ret)  # type: ignore [misc]
         else:
             # TODO: validate convert to pixels output
 


### PR DESCRIPTION
Creates exceptions in the server code to be shared with the client via an identifying exit code. These exceptions are then reconstructed in the client.

Refs #456 but does not completely fix it. Unexpected exceptions and progress descriptions are still passed in Containers.

This was addressed in the process of fixing https://github.com/freedomofpress/dangerzone/issues/430, since in Qubes we'll have server errors that we'll need to communicate.