### PR TITLE
Better "dark mode" support

### DIFF
--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -12,6 +12,8 @@ from colorama import Fore
 # FIXME: See https://github.com/freedomofpress/dangerzone/issues/320 for more details.
 if typing.TYPE_CHECKING:
     from PySide2 import QtCore, QtGui, QtWidgets
+
+    from . import Application
 else:
     try:
         from PySide6 import QtCore, QtGui, QtWidgets
@@ -35,7 +37,7 @@ class DangerzoneGui(DangerzoneCore):
     """
 
     def __init__(
-        self, app: QtWidgets.QApplication, isolation_provider: IsolationProvider
+        self, app: "Application", isolation_provider: IsolationProvider
     ) -> None:
         super().__init__(isolation_provider)
 

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -162,6 +162,11 @@ class MainWindow(QtWidgets.QMainWindow):
         central_widget.setLayout(layout)
         self.setCentralWidget(central_widget)
 
+        # Set the OS color mode as a property on the MainWindow, which is the closest
+        # thing we have to a top-level container element akin to an HTML `<body>`.
+        # This allows us to make QSS rules conditional on the OS color mode.
+        self.setProperty("OSColorMode", self.dangerzone.app.os_color_mode.value)
+
         self.show()
 
     def load_svg_image(self, filename: str) -> QtGui.QPixmap:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ strip-ansi = "*"
 
 [tool.isort]
 profile = "black"
-skip = [".gitignore"]
+extend_skip = [".gitignore"]
 # This is necessary due to https://github.com/PyCQA/isort/issues/1835
 follow_links = false
 

--- a/share/dangerzone.css
+++ b/share/dangerzone.css
@@ -5,7 +5,7 @@ QLineEdit {
     padding: 3px;
 }
 
-QWidget {
+MainWindow[OSColorMode="light"] QWidget {
     color: black;
 }
 
@@ -19,6 +19,9 @@ QLabel[style="safe_extension_filename"] {
     border-style: solid;
     border-color: #c8c8c8;
     padding: 4px 0px 4px 4px;
+}
+
+MainWindow[OSColorMode="light"] QLabel[style="safe_extension_filename"] {
     background: white;
     color: grey;
 }

--- a/share/dangerzone.css
+++ b/share/dangerzone.css
@@ -26,6 +26,11 @@ MainWindow[OSColorMode="light"] QLabel[style="safe_extension_filename"] {
     color: grey;
 }
 
+MainWindow[OSColorMode="dark"] QLabel[style="safe_extension_filename"] {
+    background: black;
+    color: grey;
+}
+
 QLabel.docs-selection {
     font-size: 18px;
 }


### PR DESCRIPTION
Fixes #528—but for all platforms, not just macOS. I believe this approach should work on all platforms that provide an OS setting for a system-wide light or dark color mode, *but I have only tested this change on macOS*.

I decided to go with an approach that would work on both PySide2/Qt 5 and PySide6/Qt 6. If you want, I'm happy to file follow-up issues for:
1. Switching to `QGuiApplication.styleHints().colorScheme()`, only supported in Qt 6.5+.
2. Handling the (likely rare in typical usage) case where the user changes the OS color setting while the Dangerzone GUI is running, which requires the `colorSchemeChanged` signal added in Qt 6.5.

## Before this change

### Light Mode

<img width="712" alt="Screenshot 2023-09-22 at 15 32 38" src="https://github.com/freedomofpress/dangerzone/assets/407302/d182a2c6-910f-4828-acbb-08212daf0684">

### Dark Mode

<img width="712" alt="Screenshot 2023-09-22 at 15 33 33" src="https://github.com/freedomofpress/dangerzone/assets/407302/9bda447f-ef00-4d65-9e47-aeea585b203e">

Exhibits the issues described in #528.

## After this change

### Light Mode

<img width="712" alt="Screenshot 2023-09-22 at 22 46 01" src="https://github.com/freedomofpress/dangerzone/assets/407302/7a98c4d8-b257-4c1d-a7a9-7c48f07c0816">

Looks the same as Light Mode before this change.

### Dark Mode

<img width="712" alt="Screenshot 2023-09-22 at 22 48 08" src="https://github.com/freedomofpress/dangerzone/assets/407302/d6130a57-6b87-4b93-9137-cfb5b2693eae">

Fixes the issues described in #528 and adds a custom style for `QLabel[style="safe_extension_filename"]` in dark mode that's consistent with the preexisting custom appearance in Light Mode.