### PR TITLE
Detect if we received EOF due to a command that failed

### DIFF
--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -68,6 +68,15 @@ class PDFtoPPMInvalidDepth(PDFtoPPMException):
     error_message = "Error converting PDF to Pixels (Invalid PPM depth)"
 
 
+class InterruptedConversion(ConversionException):
+    """Protocol received num of bytes different than expected"""
+
+    error_code = ERROR_SHIFT + 60
+    error_message = (
+        "Something interrupted the conversion and it could not be completed."
+    )
+
+
 class UnexpectedConversionError(PDFtoPPMException):
     error_code = ERROR_SHIFT + 100
     error_message = "Some unexpected error occurred while converting the document"

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -13,8 +13,8 @@ import zipfile
 from pathlib import Path
 from typing import IO, Callable, Optional
 
+from ..conversion import errors
 from ..conversion.common import calculate_timeout, running_on_qubes
-from ..conversion.errors import exception_from_error_code
 from ..conversion.pixels_to_pdf import PixelsToPDF
 from ..document import Document
 from ..util import (
@@ -41,7 +41,7 @@ def read_bytes(f: IO[bytes], size: int, timeout: float, exact: bool = True) -> b
     """Read bytes from a file-like object."""
     buf = nonblocking_read(f, size, timeout)
     if exact and len(buf) != size:
-        raise ValueError("Did not receive exact number of bytes")
+        raise errors.InterruptedConversion
     return buf
 
 
@@ -126,7 +126,7 @@ class Qubes(IsolationProvider):
 
             try:
                 n_pages = read_int(self.proc.stdout, timeout)
-            except ValueError:
+            except errors.InterruptedConversion:
                 error_code = p.wait()
                 # XXX Reconstruct exception from error code
                 raise exception_from_error_code(error_code)  # type: ignore [misc]


### PR DESCRIPTION
Handle incomplete reads due to EOF by checking if the underlying command has exited. If so, raise the corresponding exception.

Refs #430
