### PR TITLE
Remove duplicated Qubes message: "Safe PDF Created"

### DIFF
--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -183,10 +183,6 @@ class Qubes(IsolationProvider):
             PixelsToPDF(progress_callback=print_progress_wrapper).convert(ocr_lang)
         )
 
-        percentage = 100.0
-        text = "Safe PDF created"
-        self.print_progress_trusted(document, False, text, percentage)
-
         shutil.move(CONVERTED_FILE_PATH, document.output_filename)
         success = True
 


### PR DESCRIPTION
Fixes #555.  This is a leftover from when we didn't have progress reports from the second stage conversion (AKA. pixels to PDF) in #429.