### PR TITLE
Qubes: Stream page data in real time

### DIFF
--- a/dangerzone/conversion/common.py
+++ b/dangerzone/conversion/common.py
@@ -67,7 +67,7 @@ class DangerzoneConverter:
             line = await sr.readline()
             self.captured_output += line
             if callback is not None:
-                callback(line)
+                await callback(line)
             buf += line
         return buf
 

--- a/dangerzone/conversion/common.py
+++ b/dangerzone/conversion/common.py
@@ -63,10 +63,8 @@ class DangerzoneConverter:
         if they know its encoding.
         """
         buf = b""
-        while True:
+        while not sr.at_eof():
             line = await sr.readline()
-            if sr.at_eof():
-                break
             self.captured_output += line
             if callback is not None:
                 callback(line)

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -349,15 +349,21 @@ class DocumentToPixels(DangerzoneConverter):
             timeout=timeout,
         )
 
-        self.update_progress("Converted document to pixels")
-
-        # Move converted files into /tmp/dangerzone
-        for filename in (
+        final_files = (
             glob.glob("/tmp/page-*.rgb")
             + glob.glob("/tmp/page-*.width")
             + glob.glob("/tmp/page-*.height")
-        ):
+        )
+
+        # XXX: Sanity check to avoid situations like #560.
+        if not running_on_qubes() and len(final_files) != 3 * num_pages:
+            raise errors.PageCountMismatch()
+
+        # Move converted files into /tmp/dangerzone
+        for filename in final_files:
             shutil.move(filename, "/tmp/dangerzone")
+
+        self.update_progress("Converted document to pixels")
 
     async def install_libreoffice_ext(self, libreoffice_ext: str) -> None:
         self.update_progress(f"Installing LibreOffice extension '{libreoffice_ext}'")

--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -82,6 +82,13 @@ class MaxPageHeightException(PagesException):
     error_message = f"A page exceeded the maximum height."
 
 
+class PageCountMismatch(PagesException):
+    error_code = ERROR_SHIFT + 46
+    error_message = (
+        "The final document does not have the same page count as the original one"
+    )
+
+
 class PDFtoPPMException(ConversionException):
     error_code = ERROR_SHIFT + 50
     error_message = "Error converting PDF to Pixels (pdftoppm)"


### PR DESCRIPTION
Stream page data back to the caller, immediately after we read them from pdftoppm. This way, we have more accurate progress reports and timeouts.

**IMPORTANT:** This PR contains a fix for a grave bug (#560) that we uncovered will working on this issue, and is required for making this issue work.


Fixes #557
Fixes #560
