### PR TITLE
Generalize "out of RAM" error to reflect other issues

### DIFF
--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -24,7 +24,7 @@ class ConversionException(Exception):
         return subclasses
 
 
-class QubesNotEnoughRAMError(ConversionException):
+class QubesConversionStartFailed(ConversionException):
     error_code = 126  # No ERROR_SHIFT since this is a qrexec error
     error_message = (
         "Could not start a disposable qube for the file conversion. "

--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -27,8 +27,8 @@ class ConversionException(Exception):
 class QubesNotEnoughRAMError(ConversionException):
     error_code = 126  # No ERROR_SHIFT since this is a qrexec error
     error_message = (
-        "Your system does not have enough RAM available to start the conversion. "
-        "Please close some qubes or programs and try again."
+        "Could not start a disposable qube for the file conversion. "
+        "More information should have shown up on the top-right corner of your screen."
     )
 
 

--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -24,7 +24,7 @@ class ConversionException(Exception):
         return subclasses
 
 
-class QubesConversionStartFailed(ConversionException):
+class QubesQrexecFailed(ConversionException):
     error_code = 126  # No ERROR_SHIFT since this is a qrexec error
     error_message = (
         "Could not start a disposable qube for the file conversion. "

--- a/tests/isolation_provider/test_qubes.py
+++ b/tests/isolation_provider/test_qubes.py
@@ -83,6 +83,6 @@ class TestQubes(IsolationProviderTest):
 
         monkeypatch.setattr(provider, "qrexec_subprocess", qrexec_subprocess)
 
-        with pytest.raises(errors.QubesNotEnoughRAMError) as e:
+        with pytest.raises(errors.QubesQrexecFailed) as e:
             doc = Document(sample_doc)
             provider._convert(doc, ocr_lang=None)


### PR DESCRIPTION
When qrexec-client-vm fails, it could be a symptom of various issues:
  - the system being out of RAM
  - dz-dvm not existing

The exit code is the same in all cases (126), which makes it particularly tricky to solve in the client application. For this reason the approach is now to tell the user to see the Qubes error notification on the top right of their screen.