### PR TITLE
Prevent PDF from overwriting num_pages in Qubes

### DIFF
--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -254,7 +254,7 @@ class DocumentToPixels(DangerzoneConverter):
             timeout=timeout,
         )
 
-        search = re.search(r"Pages:\s*(\d+)\s*\n", stdout.decode())
+        search = re.search(r"^Pages:\s*(\d+)\s*\n", stdout.decode(), re.MULTILINE)
         if search is not None:
             num_pages: int = int(search.group(1))
         else:


### PR DESCRIPTION
This should only affect the alpha version of Qubes OS (in containers it only allows the attacker to control the timeout). In short, an attacker could have PDF metadata that would show before "Pages:" in the `pdfinfo` command output and this would essentially override the number of pages measured in the server. This could enable the attacker to shorten the number of pages of a document for example.

Fixes #565