### PR TITLE
qubes: Display all errors in second stage

### DIFF
--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -352,7 +352,7 @@ class Container(IsolationProvider):
                 with open(log_path, "r", encoding="ascii", errors="replace") as f:
                     text = (
                         f"Container output: (pixels to PDF)\n"
-                        f"{PIXELS_TO_PDF_LOG_START}{f.read()}{PIXELS_TO_PDF_LOG_END}"
+                        f"{PIXELS_TO_PDF_LOG_START}\n{f.read()}{PIXELS_TO_PDF_LOG_END}"
                     )
                     log.info(text)
 

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -162,9 +162,11 @@ class Qubes(IsolationProvider):
         def print_progress_wrapper(error: bool, text: str, percentage: float) -> None:
             self.print_progress_trusted(document, error, text, percentage)
 
-        asyncio.run(
-            PixelsToPDF(progress_callback=print_progress_wrapper).convert(ocr_lang)
-        )
+        converter = PixelsToPDF(progress_callback=print_progress_wrapper)
+        try:
+            asyncio.run(converter.convert(ocr_lang))
+        except (RuntimeError, TimeoutError, ValueError) as e:
+            raise errors.UnexpectedConversionError(str(e))
 
         shutil.move(CONVERTED_FILE_PATH, document.output_filename)
         success = True


### PR DESCRIPTION
If a command encounters an error or times out during the second stage of
the conversion in Qubes, handle it the same way as we would have handled
it in the first stage:

1. Get its error message.
2. Throw an UnexpectedConversionError exception, with the original
   message.

Note that, because the second stage takes place locally, users will see
the original content of the error.

Refs #567
Closes #430
