### PR TITLE
Add dark mode logic in our dialogs

### DIFF
--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -135,6 +135,7 @@ class Dialog(QtWidgets.QDialog):
     ) -> None:
         super().__init__()
         self.dangerzone = dangerzone
+        self.setProperty("OSColorMode", self.dangerzone.app.os_color_mode.value)
 
         self.setWindowTitle(title)
         self.setWindowIcon(self.dangerzone.get_window_icon())

--- a/share/dangerzone.css
+++ b/share/dangerzone.css
@@ -9,6 +9,10 @@ MainWindow[OSColorMode="light"] QWidget {
     color: black;
 }
 
+QDialog[OSColorMode="light"] QWidget {
+    color: black;
+}
+
 /*
  * QLabel left-adjacent to a QLineEdit to give the illusion
  * that it is part of it, but just not editable


### PR DESCRIPTION
Make our Qt dialogs set the `OSColorMode` CSS property, same as the `MainWindow` class does, so that we can properly style them.

Refs #528

## Before this change

![dark_mode_vs_updates](https://github.com/freedomofpress/dangerzone/assets/2507626/37ea753a-53a2-4f3d-8480-c822e2e18249)

## After this change

![dark_mode_correct](https://github.com/freedomofpress/dangerzone/assets/2507626/46b16bc6-a489-49c4-863e-3524bccf2847)

---

Note: I have not tested how this change affects dark mode, because I can't easily set it in my device. Given that this change mirrors what we do for `MainWindow`, I am confident that it should not cause a problem.