### PR TITLE
Do not show file previews in case of exceptions

### DIFF
--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -39,12 +39,13 @@ class IsolationProvider(ABC):
             success = self._convert(document, ocr_lang)
         except ConversionException as e:
             success = False
-            self.print_progress_trusted(document, True, e.error_message, 0)
+            self.print_progress_trusted(document, True, str(e), 0)
         except Exception as e:
             success = False
             log.exception(
                 f"An exception occurred while converting document '{document.id}'"
             )
+            self.print_progress_trusted(document, True, str(e), 0)
         if success:
             document.mark_as_safe()
             if document.archive_after_conversion:


### PR DESCRIPTION
If a Qubes conversion encounters an exception that is not a subclass of ConversionException, it will still show a preview of a file that does not exist.

Send an error progress report in that case, so that the GUI code can detect that an error occurred and not open a file preview

Fixes #581