### PR TITLE
Qubes: Fix issues with RPM packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,12 @@ aliases:
       PATH=/root/.local/bin:$PATH ./install/linux/build-rpm.py
       ls -lh dist/
 
+  - &build-rpm-qubes
+    name: Build the Qubes .rpm package
+    command: |
+      PATH=/root/.local/bin:$PATH ./install/linux/build-rpm.py --qubes
+      ls -lh dist/
+
   - &calculate-cache-key
     name: Caculating container cache key
     command: |
@@ -488,6 +494,7 @@ jobs:
       - restore_cache: *restore-cache
       - run: *copy-image
       - run: *build-rpm
+      - run: *build-rpm-qubes
 
   build-fedora-37:
     docker:
@@ -500,6 +507,7 @@ jobs:
       - restore_cache: *restore-cache
       - run: *copy-image
       - run: *build-rpm
+      - run: *build-rpm-qubes
 
 workflows:
   version: 2

--- a/BUILD.md
+++ b/BUILD.md
@@ -97,6 +97,10 @@ poetry shell
 ./dev_scripts/dangerzone
 ```
 
+> [!NOTE]
+> Prefer running the following command in a Fedora development environment,
+> created by `./dev_script/env.py`.
+
 Create a .rpm:
 
 ```sh
@@ -258,6 +262,10 @@ QUBES_CONVERSION=1 ./dev_scripts/dangerzone
 ```
 
 Create a .rpm:
+
+> [!NOTE]
+> Prefer running the following command in a Fedora development environment,
+> created by `./dev_script/env.py`.
 
 ```sh
 ./install/linux/build-rpm.py --qubes

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -282,6 +282,10 @@ poetry shell
 ./dev_scripts/dangerzone
 ```
 
+> [!NOTE]
+> Prefer running the following command in a Fedora development environment,
+> created by `./dev_script/env.py`.
+
 Create a .rpm:
 
 ```sh

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -92,6 +92,8 @@ prompt the user to start Docker Desktop.
 
 #### 3. Dangerzone successfully installs the container image
 
+_(Not for Qubes)_
+
 Remove the Dangerzone container image from Docker/Podman. Then run Dangerzone.
 Danerzone should install the container image successfully.
 
@@ -107,6 +109,9 @@ Run Dangerzone and convert the `tests/test_docs/sample_bad_pdf.pdf` document.
 Dangerzone should fail gracefully, by reporting that the operation failed, and
 showing the last error message.
 
+_(Only for Qubes)_ The only message that the user should see is: "The document
+format is not supported", without any untrusted strings.
+
 #### 6. Dangerzone succeeds in converting multiple documents
 
 Run Dangerzone against a list of documents, and tick all options. Ensure that:
@@ -114,7 +119,7 @@ Run Dangerzone against a list of documents, and tick all options. Ensure that:
 * Attempting to close the window while converting asks the user if they want to
   abort the conversions.
 * Conversions are completed successfully.
-* Conversions show individual progress.
+* Conversions show individual progress in real-time (double-check for Qubes).
 * _(Only for Linux)_ The resulting files open with the PDF viewer of our choice.
 * OCR seems to have detected characters in the PDF files.
 * The resulting files have been saved with the proper suffix, in the proper
@@ -135,7 +140,22 @@ _(Only for Windows and MacOS)_
 Go to a directory with office documents, right-click on one, and click on "Open
 With". We should be able to open the file with Dangerzone, and then convert it.
 
-#### 9. Updating Dangerzone handles external state correctly.
+#### 9. Dangerzone shows helpful errors for setup issues on Qubes
+
+_(Only for Qubes)_
+
+Check what errors does Dangerzone throw in the following scenarios. The errors
+should point the user to the Qubes notifications in the top-right corner:
+
+1. The `dz-dvm` template does not exist. We can trigger this scenario by
+   temporarily renaming this template.
+2. The Dangerzone RPC policy does not exist. We can trigger this scenario by
+   temporarily renaming the `dz.Convert` policy.
+3. The `dz-dvm` disposable Qube cannot start due to insufficient resources. We
+   can trigger this scenario by temporarily increasing the minimum required RAM
+   of the `dz-dvm` template to more than the available amount.
+
+#### 10. Updating Dangerzone handles external state correctly.
 
 _(Applies to Linux/Windows/MacOS. For MacOS/Windows, it requires an installer
 for the new version)_

--- a/install/linux/build-rpm.py
+++ b/install/linux/build-rpm.py
@@ -59,8 +59,7 @@ def build(qubes=False):
     shutil.copy2(specfile_path, build_dir / "SPECS")
     rpm_dir = build_dir / "RPMS" / "x86_64"
     srpm_dir = build_dir / "SRPMS"
-    if srpm_dir.exists():
-        os.unlink(srpm_dir)
+    srpm_dir.unlink(missing_ok=True)
     os.symlink(dist_path, rpm_dir)
     os.symlink(dist_path, srpm_dir)
 

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -268,7 +268,7 @@ install -m 644 share/* %{buildroot}/usr/share/dangerzone
 # /etc/qubes-rpc.
 %if 0%{?_qubes}
 install -m 755 -d %{buildroot}/etc/qubes-rpc
-install -m 644 qubes/* %{buildroot}/etc/qubes-rpc
+install -m 755 qubes/* %{buildroot}/etc/qubes-rpc
 %endif
 
 # The following files are included in the top level of the Python source

--- a/qubes/dz.ConvertDev
+++ b/qubes/dz.ConvertDev
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import asyncio
 import glob


### PR DESCRIPTION
This PR fixes 3 small issues with the way we produce our Qubes RPM:

1. The `.exists()` method follows symlinks by default, whereas we want
   to check if a symlink exists. This functionality has been added in
   Python
   3.12.

   Instead of checking if a symlink exists and then removing it, simply
   remove it and don't throw an error if it doesn't exist in the first
   place.

2. The `dz.Convert*` policies were not installed with the executable bit
   set, therefore the qube could not start.

3. The `dz.ConvertDev` policy in particular had an ambiguous shebang,
   thus we change it to explicitly call Python3

Also, it introduces a CI action for checking if Qubes RPM packaging works.
