### PR TITLE
Sandbox all document processing in gVisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 - Fix a deprecation warning in PySide6, thanks to [@naglis](https://github.com/naglis) ([issue #595](https://github.com/freedomofpress/dangerzone/issues/595))
 - Make update notifications work in systems with PySide2, thanks to [@naglis](https://github.com/naglis) ([issue #788](https://github.com/freedomofpress/dangerzone/issues/788))
 
+### Security
+
+- Integrate Dangerzone with gVisor, a memory-safe application kernel, thanks to [@EtiennePerot](https://github.com/EtiennePerot) ([#126](https://github.com/freedomofpress/dangerzone/issues/126))
+  As a result of this integration, we have also improved Dangerzone's security
+  in the following ways:
+  * Prevent attacker from becoming root within the container ([#224](https://github.com/freedomofpress/dangerzone/issues/224))
+  * Use a restricted seccomp profile ([#225](https://github.com/freedomofpress/dangerzone/issues/225))
+  * Make use of user namespaces ([#228](https://github.com/freedomofpress/dangerzone/issues/228))
+
 ## Dangerzone 0.6.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [installing Dangerzone](INSTALL.md#linux) for adding the Linux repositories 
 ## Some features
 
 - Sandboxes don't have network access, so if a malicious document can compromise one, it can't phone home
+- Sandboxes use [gVisor](https://gvisor.dev/), an application kernel written in Go, that implements a substantial portion of the Linux system call interface.
 - Dangerzone can optionally OCR the safe PDFs it creates, so it will have a text layer again
 - Dangerzone compresses the safe PDF to reduce file size
 - After converting, Dangerzone lets you open the safe PDF in the PDF viewer of your choice, which allows you to open PDFs and office docs in Dangerzone by default so you never accidentally open a dangerous document

--- a/dangerzone/conversion/common.py
+++ b/dangerzone/conversion/common.py
@@ -14,7 +14,9 @@ def running_on_qubes() -> bool:
 
 
 def get_tessdata_dir() -> str:
-    if running_on_qubes():
+    if os.environ.get("TESSDATA_PREFIX"):
+        return os.environ["TESSDATA_PREFIX"]
+    elif running_on_qubes():
         return "/usr/share/tesseract/tessdata/"
     else:
         return "/usr/share/tessdata/"

--- a/dangerzone/gvisor_wrapper/entrypoint.py
+++ b/dangerzone/gvisor_wrapper/entrypoint.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python3
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import typing
+
+# This script wraps the command-line arguments passed to it to run as an
+# unprivileged user in a gVisor sandbox.
+# Its behavior can be modified with the following environment variables:
+#   RUNSC_DEBUG: If set, print debug messages to stderr, and log all gVisor
+#                output to stderr.
+#   RUNSC_FLAGS: If set, pass these flags to the `runsc` invocation.
+# These environment variables are not passed on to the sandboxed process.
+
+
+def log(message: str, *values: typing.Any) -> None:
+    """Helper function to log messages if RUNSC_DEBUG is set."""
+    if os.environ.get("RUNSC_DEBUG"):
+        print(message.format(*values), file=sys.stderr)
+
+
+command = sys.argv[1:]
+if len(command) == 0:
+    log("Invoked without a command; will execute 'sh'.")
+    command = ["sh"]
+else:
+    log("Invoked with command: {}", " ".join(shlex.quote(s) for s in command))
+
+# Build and write container OCI config.
+oci_config: dict[str, typing.Any] = {
+    "ociVersion": "1.0.0",
+    "process": {
+        "user": {
+            # Hardcode the UID/GID of the container image to 1000, since we're in
+            # control of the image creation, and we don't expect it to change.
+            "uid": 1000,
+            "gid": 1000,
+        },
+        "args": command,
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "PYTHONPATH=/opt/dangerzone",
+            "TERM=xterm",
+        ],
+        "cwd": "/",
+        "capabilities": {
+            "bounding": [],
+            "effective": [],
+            "inheritable": [],
+            "permitted": [],
+        },
+        "rlimits": [
+            {"type": "RLIMIT_NOFILE", "hard": 4096, "soft": 4096},
+        ],
+    },
+    "root": {"path": "rootfs", "readonly": True},
+    "hostname": "dangerzone",
+    "mounts": [
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc",
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": ["nosuid", "noexec", "nodev"],
+        },
+        {
+            "destination": "/sys",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": ["nosuid", "noexec", "nodev", "ro"],
+        },
+        {
+            "destination": "/tmp",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": ["nosuid", "noexec", "nodev"],
+        },
+        # LibreOffice needs a writable home directory, so just mount a tmpfs
+        # over it.
+        {
+            "destination": "/home/dangerzone",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": ["nosuid", "noexec", "nodev"],
+        },
+        # Used for LibreOffice extensions, which are only conditionally
+        # installed depending on which file is being converted.
+        {
+            "destination": "/usr/lib/libreoffice/share/extensions/",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": ["nosuid", "noexec", "nodev"],
+        },
+    ],
+    "linux": {
+        "namespaces": [
+            {"type": "pid"},
+            {"type": "network"},
+            {"type": "ipc"},
+            {"type": "uts"},
+            {"type": "mount"},
+        ],
+    },
+}
+not_forwarded_env = set(
+    (
+        "PATH",
+        "HOME",
+        "SHLVL",
+        "HOSTNAME",
+        "TERM",
+        "PWD",
+        "RUNSC_FLAGS",
+        "RUNSC_DEBUG",
+    )
+)
+for key_val in oci_config["process"]["env"]:
+    not_forwarded_env.add(key_val[: key_val.index("=")])
+for key, val in os.environ.items():
+    if key in not_forwarded_env:
+        continue
+    oci_config["process"]["env"].append("%s=%s" % (key, val))
+if os.environ.get("RUNSC_DEBUG"):
+    log("Command inside gVisor sandbox: {}", command)
+    log("OCI config:")
+    json.dump(oci_config, sys.stderr, indent=2, sort_keys=True)
+    # json.dump doesn't print a trailing newline, so print one here:
+    log("")
+with open("/home/dangerzone/dangerzone-image/config.json", "w") as oci_config_out:
+    json.dump(oci_config, oci_config_out, indent=2, sort_keys=True)
+
+# Run gVisor.
+runsc_argv = [
+    "/usr/bin/runsc",
+    "--rootless=true",
+    "--network=none",
+    "--root=/home/dangerzone/.containers",
+]
+if os.environ.get("RUNSC_DEBUG"):
+    runsc_argv += ["--debug=true", "--alsologtostderr=true"]
+if os.environ.get("RUNSC_FLAGS"):
+    runsc_argv += [x for x in shlex.split(os.environ.get("RUNSC_FLAGS", "")) if x]
+runsc_argv += ["run", "--bundle=/home/dangerzone/dangerzone-image", "dangerzone"]
+log(
+    "Running gVisor with command line: {}", " ".join(shlex.quote(s) for s in runsc_argv)
+)
+runsc_process = subprocess.run(
+    runsc_argv,
+    check=False,
+)
+log("gVisor quit with exit code: {}", runsc_process.returncode)
+
+# We're done.
+sys.exit(runsc_process.returncode)

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -86,6 +86,49 @@ class Container(IsolationProvider):
         return runtime
 
     @staticmethod
+    def get_runtime_security_args() -> List[str]:
+        """Security options applicable to the outer Dangerzone container.
+
+        Our security precautions for the outer Dangerzone container are the following:
+        * Do not let the container assume new privileges.
+        * Drop all capabilities, except for CAP_SYS_CHROOT, which is necessary for
+          running gVisor.
+        * Do not allow access to the network stack.
+        * Run the container as the unprivileged `dangerzone` user.
+
+        For Podman specifically, where applicable, we also add the following:
+        * Do not log the container's output.
+        * Use a newer seccomp policy (for Podman 3.x versions only).
+        * Do not map the host user to the container, with `--userns nomap` (available
+          from Podman 4.1 onwards)
+          - This particular argument is specified in `start_doc_to_pixels_proc()`, but
+            should move here once #748 is merged.
+        """
+        if Container.get_runtime_name() == "podman":
+            security_args = ["--log-driver", "none"]
+            security_args += ["--security-opt", "no-new-privileges"]
+
+            # NOTE: Ubuntu Focal/Jammy have Podman version 3, and their seccomp policy
+            # does not include the `ptrace()` syscall. This system call is required for
+            # running gVisor, so we enforce a newer seccomp policy file in that case.
+            # This file has been copied as is [1] from the official Podman repo.
+            #
+            # [1] https://github.com/containers/common/blob/d3283f8401eeeb21f3c59a425b5461f069e199a7/pkg/seccomp/seccomp.json
+            if Container.get_runtime_version() < (4, 0):
+                seccomp_json_path = get_resource_path("seccomp.gvisor.json")
+                security_args += ["--security-opt", f"seccomp={seccomp_json_path}"]
+        else:
+            security_args = ["--security-opt=no-new-privileges:true"]
+
+        security_args += ["--cap-drop", "all"]
+        security_args += ["--cap-add", "SYS_CHROOT"]
+
+        security_args += ["--network=none"]
+        security_args += ["-u", "dangerzone"]
+
+        return security_args
+
+    @staticmethod
     def install() -> bool:
         """
         Make sure the podman container is installed. Linux only.
@@ -218,25 +261,12 @@ class Container(IsolationProvider):
         extra_args: List[str] = [],
     ) -> subprocess.Popen:
         container_runtime = self.get_runtime()
-
-        if self.get_runtime_name() == "podman":
-            security_args = ["--log-driver", "none"]
-            security_args += ["--security-opt", "no-new-privileges"]
-            security_args += ["--userns", "keep-id"]
-        else:
-            security_args = ["--security-opt=no-new-privileges:true"]
-
-        # drop all linux kernel capabilities
-        security_args += ["--cap-drop", "all"]
-        user_args = ["-u", "dangerzone"]
+        security_args = self.get_runtime_security_args()
         enable_stdin = ["-i"]
         set_name = ["--name", name]
-
         prevent_leakage_args = ["--rm"]
-
         args = (
-            ["run", "--network", "none"]
-            + user_args
+            ["run"]
             + security_args
             + prevent_leakage_args
             + enable_stdin
@@ -245,7 +275,6 @@ class Container(IsolationProvider):
             + [self.CONTAINER_NAME]
             + command
         )
-
         args = [container_runtime] + args
         return self.exec(args)
 
@@ -291,6 +320,36 @@ class Container(IsolationProvider):
             "-e",
             f"OCR_LANGUAGE={ocr_lang}",
         ]
+        # XXX: Until #748 gets merged, we have to run our pixels to PDF phase in a
+        # container, which involves mounting two temp dirs. This does not bode well with
+        # gVisor for two reasons:
+        #
+        # 1. Our gVisor integration chroot()s into /home/dangerzone/dangerzone-image/rootfs,
+        #    meaning that the location of the temp dirs must be relevant to that path.
+        # 2. Reading and writing to these temp dirs requires permissions which are not
+        #    available to the user within gVisor's user namespace.
+        #
+        # For these reasons, and because the pixels to PDF phase is more trusted (and
+        # will soon stop being containerized), we circumvent gVisor support by doing the
+        # following:
+        #
+        # 1. Override our entrypoint script with a no-op command (/usr/bin/env).
+        # 2. Set the PYTHONPATH so that we can import the Python code within
+        #    /home/dangerzone/dangerzone-image/rootfs
+        # 3. Run the container as the root user, so that it can always write to the
+        #    mounted directories. This container is trusted, so running as root has no
+        #    impact to the security of Dangerzone.
+        img_root = "/home/dangerzone/dangerzone-image/rootfs"
+        extra_args += [
+            "--entrypoint",
+            "/usr/bin/env",
+            "-e",
+            f"PYTHONPATH={img_root}/opt/dangerzone:{img_root}/usr/lib/python3.12/site-packages",
+            "-e",
+            f"TESSDATA_PREFIX={img_root}/usr/share/tessdata",
+            "-u",
+            "root",
+        ]
 
         name = self.pixels_to_pdf_container_name(document)
         pixels_to_pdf_proc = self.exec_container(command, name, extra_args)
@@ -329,8 +388,15 @@ class Container(IsolationProvider):
             "-m",
             "dangerzone.conversion.doc_to_pixels",
         ]
+        # NOTE: Using `--userns nomap` is available only on Podman >= 4.1.0.
+        # XXX: Move this under `get_runtime_security_args()` once #748 is merged.
+        extra_args = []
+        if Container.get_runtime_name() == "podman":
+            if Container.get_runtime_version() >= (4, 1):
+                extra_args += ["--userns", "nomap"]
+
         name = self.doc_to_pixels_container_name(document)
-        return self.exec_container(command, name=name)
+        return self.exec_container(command, name=name, extra_args=extra_args)
 
     def terminate_doc_to_pixels_proc(
         self, document: Document, p: subprocess.Popen

--- a/share/seccomp.gvisor.json
+++ b/share/seccomp.gvisor.json
@@ -1,0 +1,1130 @@
+{
+	"defaultAction": "SCMP_ACT_ERRNO",
+	"defaultErrnoRet": 38,
+	"defaultErrno": "ENOSYS",
+	"archMap": [
+		{
+			"architecture": "SCMP_ARCH_X86_64",
+			"subArchitectures": [
+				"SCMP_ARCH_X86",
+				"SCMP_ARCH_X32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_AARCH64",
+			"subArchitectures": [
+				"SCMP_ARCH_ARM"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_S390X",
+			"subArchitectures": [
+				"SCMP_ARCH_S390"
+			]
+		}
+	],
+	"syscalls": [
+		{
+			"names": [
+				"bdflush",
+				"cachestat",
+				"futex_requeue",
+				"futex_wait",
+				"futex_waitv",
+				"futex_wake",
+				"io_pgetevents",
+				"io_pgetevents_time64",
+				"kexec_file_load",
+				"kexec_load",
+				"map_shadow_stack",
+				"migrate_pages",
+				"move_pages",
+				"nfsservctl",
+				"nice",
+				"oldfstat",
+				"oldlstat",
+				"oldolduname",
+				"oldstat",
+				"olduname",
+				"pciconfig_iobase",
+				"pciconfig_read",
+				"pciconfig_write",
+				"sgetmask",
+				"ssetmask",
+				"swapoff",
+				"swapon",
+				"syscall",
+				"sysfs",
+				"uselib",
+				"userfaultfd",
+				"ustat",
+				"vm86",
+				"vm86old",
+				"vmsplice"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"_llseek",
+				"_newselect",
+				"accept",
+				"accept4",
+				"access",
+				"adjtimex",
+				"alarm",
+				"bind",
+				"brk",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_adjtime",
+				"clock_adjtime64",
+				"clock_getres",
+				"clock_getres_time64",
+				"clock_gettime",
+				"clock_gettime64",
+				"clock_nanosleep",
+				"clock_nanosleep_time64",
+				"clone",
+				"clone3",
+				"close",
+				"close_range",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_pwait2",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"faccessat2",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchmodat2",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsconfig",
+				"fsetxattr",
+				"fsmount",
+				"fsopen",
+				"fspick",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futex_time64",
+				"futimesat",
+				"get_mempolicy",
+				"get_robust_list",
+				"get_thread_area",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"io_destroy",
+				"io_getevents",
+				"io_setup",
+				"io_submit",
+				"ioctl",
+				"ioprio_get",
+				"ioprio_set",
+				"ipc",
+				"keyctl",
+				"kill",
+				"landlock_add_rule",
+				"landlock_create_ruleset",
+				"landlock_restrict_self",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"mbind",
+				"membarrier",
+				"memfd_create",
+				"memfd_secret",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mount",
+				"mount_setattr",
+				"move_mount",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedreceive_time64",
+				"mq_timedsend",
+				"mq_timedsend_time64",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"name_to_handle_at",
+				"nanosleep",
+				"newfstatat",
+				"open",
+				"open_tree",
+				"openat",
+				"openat2",
+				"pause",
+				"pidfd_getfd",
+				"pidfd_open",
+				"pidfd_send_signal",
+				"pipe",
+				"pipe2",
+				"pivot_root",
+				"pkey_alloc",
+				"pkey_free",
+				"pkey_mprotect",
+				"poll",
+				"ppoll",
+				"ppoll_time64",
+				"prctl",
+				"pread64",
+				"preadv",
+				"preadv2",
+				"prlimit64",
+				"process_mrelease",
+				"process_vm_readv",
+				"process_vm_writev",
+				"pselect6",
+				"pselect6_time64",
+				"ptrace",
+				"pwrite64",
+				"pwritev",
+				"pwritev2",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"reboot",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmmsg_time64",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rseq",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_sigtimedwait_time64",
+				"rt_tgsigqueueinfo",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_rr_get_interval_time64",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"semtimedop_time64",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"set_mempolicy",
+				"set_robust_list",
+				"set_thread_area",
+				"set_tid_address",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setns",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"setsid",
+				"setsockopt",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signal",
+				"signalfd",
+				"signalfd4",
+				"sigprocmask",
+				"sigreturn",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"statx",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"syslog",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_gettime64",
+				"timer_settime",
+				"timer_settime64",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_gettime64",
+				"timerfd_settime",
+				"timerfd_settime64",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"umount",
+				"umount2",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"unshare",
+				"utime",
+				"utimensat",
+				"utimensat_time64",
+				"utimes",
+				"vfork",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 0,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 8,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131072,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131080,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 4294967295,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"sync_file_range2",
+				"swapcontext"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"ppc64le"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
+				"breakpoint",
+				"cacheflush",
+				"set_tls",
+				"sync_file_range2"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"arm",
+					"arm64"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arch_prctl"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"modify_ldt"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32",
+					"x86"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"s390_pci_mmio_read",
+				"s390_pci_mmio_write",
+				"s390_runtime_instr"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"riscv_flush_icache"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"riscv64"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"bpf",
+				"fanotify_init",
+				"lookup_dcookie",
+				"quotactl",
+				"quotactl_fd",
+				"setdomainname",
+				"sethostname",
+				"setns"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"fanotify_init",
+				"lookup_dcookie",
+				"perf_event_open",
+				"quotactl",
+				"quotactl_fd",
+				"setdomainname",
+				"sethostname",
+				"setns"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"delete_module",
+				"finit_module",
+				"init_module",
+				"query_module"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"delete_module",
+				"finit_module",
+				"init_module",
+				"query_module"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"kcmp",
+				"process_madvise"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"kcmp",
+				"process_madvise"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"ioperm",
+				"iopl"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"ioperm",
+				"iopl"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"clock_settime",
+				"clock_settime64",
+				"settimeofday",
+				"stime"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"clock_settime",
+				"clock_settime64",
+				"settimeofday",
+				"stime"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				},
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			},
+			"errnoRet": 22,
+			"errno": "EINVAL"
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": null,
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"bpf"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN",
+					"CAP_BPF"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"bpf"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_BPF"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"perf_event_open"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN",
+					"CAP_BPF"
+				]
+			},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"perf_event_open"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_PERFMON"
+				]
+			},
+			"excludes": {}
+		}
+	]
+}

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -16,10 +16,9 @@ from dangerzone.logic import DangerzoneCore
 def test_ocr_ommisions() -> None:
     # Create the command that will list all the installed languages in the container
     # image.
-    runtime = Container.get_runtime()
-    command = [
-        runtime,
-        "run",
+    command = [Container.get_runtime(), "run"]
+    command += Container.get_runtime_security_args()
+    command += [
         Container.CONTAINER_NAME,
         "find",
         "/usr/share/tessdata/",


### PR DESCRIPTION
When running on Linux, Dangerzone currently uses Podman with its default `crun`/`runc` runtime. These runtimes rely on Linux's built-in containerization primitives (namespaces). These parts of the Linux kernel have historically been the target of many container escape vulnerabilities. This is due to the fact that the Linux host kernel is fully exposed to the application running inside the container.

In particular, PDF and PostScript libraries such as Ghostscript have been notorious for having been targeted to run precisely this type of exploit. For this reason, while running these tools within Linux containers is better than running them directly on the host, it does not fully shield the host kernel from the malicious code that may be running in the container.

This pull request implements optional support for the [gVisor container runtime](https://gvisor.dev), called `runsc` ("run *sandboxed* container"). gVisor is an open-source OCI-compliant container runtime. It is a userspace reimplementation of the Linux kernel in a memory-safe language.

It works by creating a sandboxed environment in which regular Linux applications run, but their system calls are intercepted by gVisor. gVisor reinterprets these system calls using the logic in its own kernel written in Go, and responds to the system call by itself, rather than passing it onto the host Linux kernel. This means the host Linux kernel is isolated from the sandboxed application, thereby providing a significant level of protection against Linux container escape attacks.

gVisor further hardens itself by using the typical container primitives (isolating its own view of the host filesystem, running in the various types of namespaces that Linux support), and also sets a restrictive `seccomp-bpf` policy that only allows basic system calls through. This way, even if its userspace kernel were to get compromised, attackers would have to additionally have a "typical" Linux container escape vector, and that exploit would have to fit within the restricted `seccomp-bpf` rules that gVisor adds on itself.

This provides a level of protection comparable to a hardened hypervisor running workloads in a VM. However, gVisor doesn't actually use virtualization, so it is portable to all Linux environments and doesn't require virtualization support. It runs on x86 and ARM.

The initial commit of this pull request only adds support for using it inside `isolation_provider/container.py`. If there is appetite for this runtime, I'm happy to add CircleCI tests to integrate it better. Let me know what you think!

Fixes #126
Fixes #224
Fixes #225
Fixes #228