### PR TITLE
Allow user to override update checking on Linux

### DIFF
--- a/dangerzone/gui/updater.py
+++ b/dangerzone/gui/updater.py
@@ -164,8 +164,9 @@ class UpdaterThread(QtCore.QThread):
         # TODO: Disable updates for Homebrew installations.
         if platform.system() == "Linux" and not getattr(sys, "dangerzone_dev", False):
             log.debug("Running on Linux, disabling updates")
-            self.check = False
-            return False
+            if not self.check:  # if not overidden by user
+                self.check = False
+                return False
 
         log.debug("Checking if first run of Dangerzone")
         if self.dangerzone.settings.get("updater_last_check") is None:


### PR DESCRIPTION
The original intention of leaving the update checkbox in the hamburger menu was to let non-supported Linux distros (e.g. compiled from source) to check for updates. However, on Linux it ended up being disabled forcefully by default on startup.

This takes into account an overriden update checkbox.

Fixes #596