### PR TITLE
Use more descriptive button labels in update check prompt

### DIFF
--- a/dangerzone/gui/updater.py
+++ b/dangerzone/gui/updater.py
@@ -32,11 +32,11 @@ log = logging.getLogger(__name__)
 
 
 MSG_CONFIRM_UPDATE_CHECKS = """\
-<p><b>Do you want to be notified about new Dangerzone releases?</b></p>
+<p><b>Do you want Dangerzone to automatically check for updates?</b></p>
 
-<p>If <i>"Yes"</i>, Dangerzone will check the
+<p>If you accept, Dangerzone will check the
 <a href="https://github.com/freedomofpress/dangerzone/releases">latest releases page</a>
-in github.com on startup. If <i>"No"</i>, Dangerzone will make no network requests and
+in github.com on startup. Otherwise it will make no network requests and
 won't inform you about new releases.</p>
 
 <p>If you prefer another way of getting notified about new releases, we suggest adding
@@ -140,8 +140,8 @@ class UpdaterThread(QtCore.QThread):
         prompt = UpdateCheckPrompt(
             self.dangerzone,
             message=MSG_CONFIRM_UPDATE_CHECKS,
-            ok_text="Yes",
-            cancel_text="No",
+            ok_text="Check Automatically",
+            cancel_text="Don't Check",
         )
         check = prompt.launch()
         if not check and prompt.x_pressed:

--- a/tests/gui/test_updater.py
+++ b/tests/gui/test_updater.py
@@ -400,8 +400,22 @@ def test_update_check_prompt(
     qt_updater.dangerzone.settings.set("updater_last_check", 0)
 
     # Test 1 - Check that on the second run of Dangerzone, the user is prompted to
-    # choose if they want to enable update checks. By clicking on, we store this
-    # decision in the settings.
+    # choose if they want to enable update checks.
+    def check_button_labels() -> None:
+        dialog = qt_updater.dangerzone.app.activeWindow()
+        assert dialog.ok_button.text() == "Check Automatically"  # type: ignore [attr-defined]
+        assert dialog.cancel_button.text() == "Don't Check"  # type: ignore [attr-defined]
+        dialog.ok_button.click()  # type: ignore [attr-defined]
+
+    QtCore.QTimer.singleShot(500, check_button_labels)
+    res = qt_updater.should_check_for_updates()
+
+    assert res == True
+
+    # Test 2 - Check that when the user chooses to enable update checks, we
+    # store that decision in the settings.
+    qt_updater.check = None
+
     def click_ok() -> None:
         dialog = qt_updater.dangerzone.app.activeWindow()
         dialog.ok_button.click()  # type: ignore [attr-defined]
@@ -412,7 +426,7 @@ def test_update_check_prompt(
     assert res == True
     assert qt_updater.check == True
 
-    # Test 2 - Same as the previous test, but check that clicking on cancel stores the
+    # Test 3 - Same as the previous test, but check that clicking on cancel stores the
     # opposite decision.
     qt_updater.check = None
 
@@ -426,7 +440,7 @@ def test_update_check_prompt(
     assert res == False
     assert qt_updater.check == False
 
-    # Test 3 - Same as the previous test, but check that clicking on "X" does not store
+    # Test 4 - Same as the previous test, but check that clicking on "X" does not store
     # any decision.
     qt_updater.check = None
 


### PR DESCRIPTION
Adds a test case to `tests/gui/test_updater.py::test_update_check_prompt` to check the button labels.

Here is a screenshot of the updated prompt: 
<img width="600" alt="Screenshot 2023-10-16 at 13 40 05" src="https://github.com/freedomofpress/dangerzone/assets/407302/d38ec32b-f2ba-486b-81d7-52da7599aecc">

I wonder if this change should also change the wording of `MSG_CONFIRM_UPDATE_CHECKS` so it reinforces the new button labels. Maybe we should change

> Do you want to be notified about new Dangerzone releases?

to

> Do you want Dangerzone to automatically check for updates?

Suggestions welcome!

Closes #527.