### PR TITLE
Security: prevent dz-dvm network via dispVMs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,6 +137,10 @@ After confirming that it matches, type `y` (for yes) and the installation should
 > want to try out the stable Dangerzone version (which uses containers instead
 > of virtual machines for isolation), please follow the Fedora or Debian
 > instructions and adapt them as needed.
+>
+> **If you followed these instructions before October 25, 2023, please read [this security advisory](docs/advisories/2023-10-25.md).**
+> This notice will be removed with the 1.0.0 release of Dangerzone.
+
 
 > [!IMPORTANT]
 > This section will install Dangerzone in your **default template**
@@ -160,7 +164,7 @@ template. This will be the qube where the documents will be sanitized:
 ```
 qvm-create --class AppVM --label red --template fedora-38 \
     --prop netvm="" --prop template_for_dispvms=True \
-    dz-dvm
+    --prop default_dispvm='' dz-dvm
 ```
 
 Add an RPC policy (`/etc/qubes/policy.d/50-dangerzone.policy`) that will
@@ -191,6 +195,7 @@ column to "Selected".
 
 You can now launch Dangerzone from the list of applications for your qube, and
 pass it a file to sanitize.
+
 
 ## Build from source
 

--- a/docs/advisories/2023-10-25.md
+++ b/docs/advisories/2023-10-25.md
@@ -1,0 +1,13 @@
+# Security Advisory 2023-10-25
+
+For users testing our [new Qubes integration (beta)](https://github.com/freedomofpress/dangerzone/blob/main/INSTALL.md#qubes-os), please note that our instructions were missing a configuration detail for disposable VMs which is necessary to fully harden the configuration.
+
+These instructions apply to users who followed the setup instructions **before October 25, 2023**.
+
+**What you need to do:** run the following command in dom0:
+
+```bash
+qvm-prefs dz-dvm default_dispvm ''
+```
+
+**Explanation**: In Qubes OS, the default template for disposable VMs is network-connected. For this reason, we instruct users to create their own disposable VM (`dz-dvm`). However, adversaries with the ability to execute commands on `dz-dvm` would also be able open new disposable VMs with the default settings. By setting the default_dispvm to "none" we prevent this bypass.


### PR DESCRIPTION
In Qubes the disposable netVM is internet connected. For this reason, on Qubes we chose create our own disposable VM (dz-dvm). However, in reality this could still be bypassed since dz-dvm had the default disposable dispvm.

By setting the default_dispvm to '' we prevent this bypass. For VMs users who have already followed the setup instructions, the following command should (to be ran in dom0) will fix this issue:

>   qvm-prefs dz-dvm default_dispvm ''"