### PR TITLE
Use PyMupPDF to solve most congestions issues in /tmp (client & Server) 

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -194,7 +194,7 @@ Overview of the qubes you'll create:
    ```
    sudo dnf install -y rpm-build podman python3 python3-devel \
        python3-poetry-core pipx qt6-qtbase-gui libreoffice python3-magic \
-       python3-keyring tesseract*
+       python3-PyMuPDF python3-keyring tesseract*
    ```
 
 2. Shutdown the `fedora-38-dz` template:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ARG H2ORESTART_CHECKSUM=5db816a1e57b510456633f55e693cb5ef3675ef8b35df4f31c90ab9d
 RUN apk --no-cache -U upgrade && \
     apk --no-cache add \
     ghostscript \
-    graphicsmagick \
     libreoffice \
     openjdk8 \
     poppler-utils \
@@ -16,6 +15,10 @@ RUN apk --no-cache -U upgrade && \
     py3-magic \
     tesseract-ocr \
     font-noto-cjk
+
+RUN apk add g++ gcc make python3-dev py3-pip
+RUN pip install --upgrade PyMuPDF # FIXME freeze w/ hashes
+RUN apk del g++ gcc make python3-dev py3-pip
 
 # Download the trained models from the latest GitHub release of Tesseract, and
 # store them under /usr/share/tessdata. This is basically what distro packages

--- a/dangerzone/conversion/common.py
+++ b/dangerzone/conversion/common.py
@@ -44,6 +44,13 @@ def calculate_timeout(size: float, pages: Optional[float] = None) -> float:
     return timeout
 
 
+def get_tessdata_dir() -> str:
+    if running_on_qubes():
+        return "/usr/share/tesseract/tessdata/"
+    else:
+        return "/usr/share/tessdata/"
+
+
 class DangerzoneConverter:
     def __init__(self, progress_callback: Optional[Callable] = None) -> None:
         self.percentage: float = 0.0

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -258,8 +258,6 @@ class DocumentToPixels(DangerzoneConverter):
             raise errors.MaxPagesException()
         await self.write_page_count(doc.page_count)
 
-        # Get a more precise timeout, based on the number of pages
-        timeout = self.calculate_timeout(size, doc.page_count)
         percentage_per_page = 45.0 / doc.page_count
         page_base = "/tmp/page"
         for page in doc:

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -147,14 +147,14 @@ class DocumentToPixels(DangerzoneConverter):
                 "type": "libreoffice",
             },
             # .jpg
-            "image/jpeg": {"type": "convert"},
+            "image/jpeg": {"type": None},
             # .gif
-            "image/gif": {"type": "convert"},
+            "image/gif": {"type": None},
             # .png
-            "image/png": {"type": "convert"},
+            "image/png": {"type": None},
             # .tif
-            "image/tiff": {"type": "convert"},
-            "image/x-tiff": {"type": "convert"},
+            "image/tiff": {"type": None},
+            "image/x-tiff": {"type": None},
         }
 
         # Detect MIME type
@@ -183,7 +183,7 @@ class DocumentToPixels(DangerzoneConverter):
         # Convert input document to PDF
         conversion = conversions[mime_type]
         if conversion["type"] is None:
-            pdf_filename = "/tmp/input_file"
+            doc = fitz.open("/tmp/input_file", filetype=mime_type)
         elif conversion["type"] == "libreoffice":
             libreoffice_ext = conversion.get("libreoffice_ext", None)
             # Disable conversion for HWP/HWPX on specific platforms. See:
@@ -228,24 +228,7 @@ class DocumentToPixels(DangerzoneConverter):
             #     https://github.com/freedomofpress/dangerzone/issues/494
             if not os.path.exists(pdf_filename):
                 raise errors.LibreofficeFailure()
-        elif conversion["type"] == "convert":
-            self.update_progress("Converting to PDF using GraphicsMagick")
-            args = [
-                "gm",
-                "convert",
-                "/tmp/input_file",
-                "/tmp/input_file.pdf",
-            ]
-            await self.run_command(
-                args,
-                error_message="Conversion to PDF with GraphicsMagick failed",
-                timeout_message=(
-                    "Error converting document to PDF, GraphicsMagick timed out after"
-                    f" {timeout} seconds"
-                ),
-                timeout=timeout,
-            )
-            pdf_filename = "/tmp/input_file.pdf"
+            doc = fitz.open(pdf_filename)
         else:
             raise errors.InvalidGMConversion(
                 f"Invalid conversion type {conversion['type']} for MIME type {mime_type}"
@@ -253,7 +236,6 @@ class DocumentToPixels(DangerzoneConverter):
         self.percentage += 3
 
         # Obtain number of pages
-        doc = fitz.open(pdf_filename)
         if doc.page_count > errors.MAX_PAGES:
             raise errors.MaxPagesException()
         await self.write_page_count(doc.page_count)

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 from typing import Dict, List, Optional
 
+import fitz
 import magic
 
 from . import errors
@@ -275,87 +276,23 @@ class DocumentToPixels(DangerzoneConverter):
 
         # Get a more precise timeout, based on the number of pages
         timeout = self.calculate_timeout(size, num_pages)
-
-        async def pdftoppm_progress_callback(line: bytes) -> None:
-            """Function called for every line the 'pdftoppm' command outputs
-
-            Sample pdftoppm output:
-
-                $ pdftoppm sample.pdf  /tmp/safe -progress
-                1 4 /tmp/safe-1.ppm
-                2 4 /tmp/safe-2.ppm
-                3 4 /tmp/safe-3.ppm
-                4 4 /tmp/safe-4.ppm
-
-            Each successful line is in the format "{page} {page_num} {ppm_filename}"
-            """
-            try:
-                (page_str, num_pages_str, _) = line.decode().split()
-                num_pages = int(num_pages_str)
-                page = int(page_str)
-            except ValueError as e:
-                # Ignore all non-progress related output, since pdftoppm sends
-                # everything to stderr and thus, errors can't be distinguished
-                # easily. We rely instead on the exit code.
-                return
-
-            percentage_per_page = 45.0 / num_pages
-            self.percentage += percentage_per_page
-            self.update_progress(f"Converting page {page}/{num_pages} to pixels")
-
-            zero_padding = "0" * (len(num_pages_str) - len(page_str))
-            ppm_filename = f"{page_base}-{zero_padding}{page}.ppm"
-            rgb_filename = f"{page_base}-{page}.rgb"
-            width_filename = f"{page_base}-{page}.width"
-            height_filename = f"{page_base}-{page}.height"
-            filename_base = f"{page_base}-{page}"
-
-            with open(ppm_filename, "rb") as f:
-                # NOTE: PPM files have multiple ways of writing headers.
-                # For our specific case we parse it expecting the header format that ppmtopdf produces
-                # More info on PPM headers: https://people.uncw.edu/tompkinsj/112/texnh/assignments/imageFormat.html
-
-                # Read the header
-                header = f.readline().decode().strip()
-                if header != "P6":
-                    raise errors.PDFtoPPMInvalidHeader()
-
-                # Save the width and height
-                dims = f.readline().decode().strip()
-                width, height = dims.split()
-                await self.write_page_width(int(width), width_filename)
-                await self.write_page_height(int(height), height_filename)
-
-                maxval = int(f.readline().decode().strip())
-                # Check that the depth is 8
-                if maxval != 255:
-                    raise errors.PDFtoPPMInvalidDepth()
-
-                data = f.read()
-
-            # Save pixel data
-            await self.write_page_data(data, rgb_filename)
-
-            # Delete the ppm file
-            os.remove(ppm_filename)
-
+        percentage_per_page = 45.0 / num_pages
         page_base = "/tmp/page"
+        doc = fitz.open(pdf_filename)
+        for page in doc:
+            # TODO check if page.number is doc-controlled
+            page_num = page.number + 1  # pages start in 1
+            rgb_filename = f"{page_base}-{page_num}.rgb"
+            width_filename = f"{page_base}-{page_num}.width"
+            height_filename = f"{page_base}-{page_num}.height"
 
-        await self.run_command(
-            [
-                "pdftoppm",
-                pdf_filename,
-                page_base,
-                "-progress",
-            ],
-            error_message="Conversion from PDF to PPM failed",
-            timeout_message=(
-                f"Error converting from PDF to PPM, pdftoppm timed out after {timeout}"
-                " seconds"
-            ),
-            stderr_callback=pdftoppm_progress_callback,
-            timeout=timeout,
-        )
+            self.percentage += percentage_per_page
+            self.update_progress(f"Converting page {page_num}/{num_pages} to pixels")
+            pix = page.get_pixmap(dpi=150)
+            rgb_buf = pix.samples
+            await self.write_page_width(pix.width, width_filename)
+            await self.write_page_height(pix.height, height_filename)
+            await self.write_page_data(rgb_buf, rgb_filename)
 
         final_files = (
             glob.glob("/tmp/page-*.rgb")

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -253,32 +253,15 @@ class DocumentToPixels(DangerzoneConverter):
         self.percentage += 3
 
         # Obtain number of pages
-        self.update_progress("Calculating number of pages")
-        stdout, _ = await self.run_command(
-            ["pdfinfo", pdf_filename],
-            error_message="PDF file is corrupted",
-            timeout_message=(
-                f"Extracting metadata from PDF timed out after {timeout} second"
-            ),
-            timeout=timeout,
-        )
-
-        search = re.search(r"^Pages:\s*(\d+)\s*\n", stdout.decode(), re.MULTILINE)
-        if search is not None:
-            num_pages: int = int(search.group(1))
-        else:
-            raise errors.NoPageCountException()
-
-        if num_pages > errors.MAX_PAGES:
+        doc = fitz.open(pdf_filename)
+        if doc.page_count > errors.MAX_PAGES:
             raise errors.MaxPagesException()
-
-        await self.write_page_count(num_pages)
+        await self.write_page_count(doc.page_count)
 
         # Get a more precise timeout, based on the number of pages
-        timeout = self.calculate_timeout(size, num_pages)
-        percentage_per_page = 45.0 / num_pages
+        timeout = self.calculate_timeout(size, doc.page_count)
+        percentage_per_page = 45.0 / doc.page_count
         page_base = "/tmp/page"
-        doc = fitz.open(pdf_filename)
         for page in doc:
             # TODO check if page.number is doc-controlled
             page_num = page.number + 1  # pages start in 1
@@ -287,7 +270,9 @@ class DocumentToPixels(DangerzoneConverter):
             height_filename = f"{page_base}-{page_num}.height"
 
             self.percentage += percentage_per_page
-            self.update_progress(f"Converting page {page_num}/{num_pages} to pixels")
+            self.update_progress(
+                f"Converting page {page_num}/{doc.page_count} to pixels"
+            )
             pix = page.get_pixmap(dpi=150)
             rgb_buf = pix.samples
             await self.write_page_width(pix.width, width_filename)
@@ -301,7 +286,7 @@ class DocumentToPixels(DangerzoneConverter):
         )
 
         # XXX: Sanity check to avoid situations like #560.
-        if not running_on_qubes() and len(final_files) != 3 * num_pages:
+        if not running_on_qubes() and len(final_files) != 3 * doc.page_count:
             raise errors.PageCountMismatch()
 
         # Move converted files into /tmp/dangerzone

--- a/dangerzone/conversion/pixels_to_pdf.py
+++ b/dangerzone/conversion/pixels_to_pdf.py
@@ -13,7 +13,9 @@ import shutil
 import sys
 from typing import Optional
 
-from .common import DangerzoneConverter, running_on_qubes
+import fitz
+
+from .common import DangerzoneConverter, get_tessdata_dir, running_on_qubes
 
 
 class PixelsToPDF(DangerzoneConverter):
@@ -27,90 +29,55 @@ class PixelsToPDF(DangerzoneConverter):
         num_pages = len(glob.glob(f"{tempdir}/dangerzone/page-*.rgb"))
         total_size = 0.0
 
+        safe_doc = fitz.Document()
+
         # Convert RGB files to PDF files
         percentage_per_page = 45.0 / num_pages
-        for page in range(1, num_pages + 1):
-            filename_base = f"{tempdir}/dangerzone/page-{page}"
+        for page_num in range(1, num_pages + 1):
+            filename_base = f"{tempdir}/dangerzone/page-{page_num}"
             rgb_filename = f"{filename_base}.rgb"
             width_filename = f"{filename_base}.width"
             height_filename = f"{filename_base}.height"
-            png_filename = f"{tempdir}/page-{page}.png"
-            ocr_filename = f"{tempdir}/page-{page}"
-            pdf_filename = f"{tempdir}/page-{page}.pdf"
 
             with open(width_filename) as f:
-                width = f.read().strip()
+                width = int(f.read().strip())
             with open(height_filename) as f:
-                height = f.read().strip()
-
+                height = int(f.read().strip())
+            with open(rgb_filename, "rb") as rgb_f:
+                untrusted_rgb_data = rgb_f.read()
             # The first few operations happen on a per-page basis.
             page_size = os.path.getsize(filename_base + ".rgb") / 1024**2
             total_size += page_size
             timeout = self.calculate_timeout(page_size, 1)
 
+            self.update_progress(
+                f"Converting page {page_num}/{num_pages} from pixels to PDF"
+            )
+            pixmap = fitz.Pixmap(
+                fitz.Colorspace(fitz.CS_RGB), width, height, untrusted_rgb_data, False
+            )
             if ocr_lang:  # OCR the document
-                self.update_progress(
-                    f"Converting page {page}/{num_pages} from pixels to searchable PDF"
-                )
-                await self.run_command(
-                    [
-                        "gm",
-                        "convert",
-                        "-size",
-                        f"{width}x{height}",
-                        "-depth",
-                        "8",
-                        f"rgb:{rgb_filename}",
-                        f"png:{png_filename}",
-                    ],
-                    error_message=f"Page {page}/{num_pages} conversion to PNG failed",
-                    timeout_message=(
-                        "Error converting pixels to PNG, convert timed out after"
-                        f" {timeout} seconds"
-                    ),
-                    timeout=timeout,
-                )
-                await self.run_command(
-                    [
-                        "tesseract",
-                        png_filename,
-                        ocr_filename,
-                        "-l",
-                        ocr_lang,
-                        "--dpi",
-                        "70",
-                        "pdf",
-                    ],
-                    error_message=f"Page {page}/{num_pages} OCR failed",
-                    timeout_message=(
-                        "Error converting PNG to searchable PDF, tesseract timed out"
-                        f" after {timeout} seconds"
-                    ),
-                    timeout=timeout,
-                )
-
+                try:
+                    ocr_pdf_bytes = pixmap.pdfocr_tobytes(
+                        compress=True,
+                        language=ocr_lang,
+                        tessdata=get_tessdata_dir(),
+                    )
+                except:  # containers' verison has old API without tessdata
+                    ocr_pdf_bytes = pixmap.pdfocr_tobytes(
+                        compress=True,
+                        language=ocr_lang,
+                    )
+                ocr_pdf = fitz.open("pdf", ocr_pdf_bytes)
+                safe_doc.insert_pdf(ocr_pdf)
             else:  # Don't OCR
-                self.update_progress(
-                    f"Converting page {page}/{num_pages} from pixels to PDF"
-                )
-                await self.run_command(
-                    [
-                        "gm",
-                        "convert",
-                        "-size",
-                        f"{width}x{height}",
-                        "-depth",
-                        "8",
-                        f"rgb:{rgb_filename}",
-                        f"pdf:{pdf_filename}",
-                    ],
-                    error_message=f"Page {page}/{num_pages} conversion to PDF failed",
-                    timeout_message=(
-                        "Error converting RGB to PDF, convert timed out after"
-                        f" {timeout} seconds"
-                    ),
-                    timeout=timeout,
-                )
+                try:
+                    safe_doc.insert_file(pixmap)
+                except:  # remove after PyMuPDF 22 (Document.insert_file available)
+                    blank_page = safe_doc.new_page(width=width, height=height)
+                    blank_page.insert_image(
+                        fitz.Rect(0, 0, width, height), pixmap=pixmap
+                    )
 
             self.percentage += percentage_per_page
 
@@ -118,46 +85,16 @@ class PixelsToPDF(DangerzoneConverter):
         # timeout.
         timeout = self.calculate_timeout(total_size, num_pages)
 
-        # Merge pages into a single PDF
-        self.update_progress(f"Merging {num_pages} pages into a single PDF")
-        args = ["pdfunite"]
-        for page in range(1, num_pages + 1):
-            args.append(f"{tempdir}/page-{page}.pdf")
-        args.append(f"{tempdir}/safe-output.pdf")
-        await self.run_command(
-            args,
-            error_message="Merging pages into a single PDF failed",
-            timeout_message=(
-                "Error merging pages into a single PDF, pdfunite timed out after"
-                f" {timeout} seconds"
-            ),
-            timeout=timeout,
-        )
-
-        self.percentage += 2
-
-        # Compress
-        self.update_progress("Compressing PDF")
-        await self.run_command(
-            [
-                "ps2pdf",
-                f"{tempdir}/safe-output.pdf",
-                f"{tempdir}/safe-output-compressed.pdf",
-            ],
-            error_message="Compressing PDF failed",
-            timeout_message=(
-                f"Error compressing PDF, ps2pdf timed out after {timeout} seconds"
-            ),
-            timeout=timeout,
-        )
-
         self.percentage = 100.0
         self.update_progress("Safe PDF created")
 
         # Move converted files into /safezone
-        if not running_on_qubes():
-            shutil.move(f"{tempdir}/safe-output.pdf", "/safezone")
-            shutil.move(f"{tempdir}/safe-output-compressed.pdf", "/safezone")
+        if running_on_qubes():
+            safe_pdf_path = f"{tempdir}/safe-output-compressed.pdf"
+        else:
+            safe_pdf_path = f"/safezone/safe-output-compressed.pdf"
+
+        safe_doc.save(safe_pdf_path, deflate_images=True)
 
 
 async def main() -> int:

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -324,6 +324,8 @@ class Container(IsolationProvider):
                 "-v",
                 f"{safe_dir}:/safezone:Z",
                 "-e",
+                "TESSDATA_PREFIX=/usr/share/tessdata",
+                "-e",
                 f"OCR={ocr}",
                 "-e",
                 f"OCR_LANGUAGE={ocr_lang}",

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -72,6 +72,7 @@ BuildRequires:  python3-devel
 %if 0%{?_qubes}
 # Qubes-only requirements
 Requires:       python3-magic
+Requires:       python3-PyMuPDF
 Requires:       libreoffice
 Requires:       tesseract
 # Explicitly require every tesseract model:

--- a/poetry.lock
+++ b/poetry.lock
@@ -63,7 +63,6 @@ packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -195,7 +194,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -406,7 +404,6 @@ files = [
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -555,7 +552,6 @@ files = [
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=4.1.0"
 
 [package.extras]
@@ -608,9 +604,6 @@ files = [
     {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.7.1", markers = "python_version < \"3.8\""}
-
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
@@ -625,9 +618,6 @@ files = [
     {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
     {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -656,7 +646,6 @@ files = [
 
 [package.dependencies]
 altgraph = "*"
-importlib-metadata = {version = ">=1.4", markers = "python_version < \"3.8\""}
 macholib = {version = ">=1.8", markers = "sys_platform == \"darwin\""}
 pyinstaller-hooks-contrib = ">=2021.4"
 setuptools = ">=42.0.0"
@@ -674,6 +663,64 @@ python-versions = ">=3.7"
 files = [
     {file = "pyinstaller-hooks-contrib-2023.9.tar.gz", hash = "sha256:76084b5988e3957a9df169d2a935d65500136967e710ddebf57263f1a909cd80"},
     {file = "pyinstaller_hooks_contrib-2023.9-py2.py3-none-any.whl", hash = "sha256:f34f4c6807210025c8073ebe665f422a3aa2ac5f4c7ebf4c2a26cc77bebf63b5"},
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.23.6"
+description = "A high performance Python library for data extraction, analysis, conversion & manipulation of PDF (and other) documents."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "PyMuPDF-1.23.6-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:c4eb71b88a22c1008f764b3121b36a9d25340f9920b870508356050a365d9ca1"},
+    {file = "PyMuPDF-1.23.6-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:3ce2d3678dbf822cff213b1902f2e59756313e543efd516a2b4f15bb0353bd6c"},
+    {file = "PyMuPDF-1.23.6-cp310-none-manylinux2014_aarch64.whl", hash = "sha256:2e27857a15c8a810d0b66455b8c8a79013640b6267a9b4ea808a5fe1f47711f2"},
+    {file = "PyMuPDF-1.23.6-cp310-none-manylinux2014_x86_64.whl", hash = "sha256:5cd05700c8f18c9dafef63ac2ed3b1099ca06017ca0c32deea13093cea1b8671"},
+    {file = "PyMuPDF-1.23.6-cp310-none-win32.whl", hash = "sha256:951d280c1daafac2fd6a664b031f7f98b27eb2def55d39c92a19087bd8041c5d"},
+    {file = "PyMuPDF-1.23.6-cp310-none-win_amd64.whl", hash = "sha256:19d1711d5908c4527ad2deef5af2d066649f3f9a12950faf30be5f7251d18abc"},
+    {file = "PyMuPDF-1.23.6-cp311-none-macosx_10_9_x86_64.whl", hash = "sha256:3f0f9b76bc4f039e7587003cbd40684d93a98441549dd033cab38ca07d61988d"},
+    {file = "PyMuPDF-1.23.6-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:e047571d799b30459ad7ee0bc6e68900a7f6b928876f956c976f279808814e72"},
+    {file = "PyMuPDF-1.23.6-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:1cbcf05c06f314fdf3042ceee674e9a0ac7fae598347d5442e2138c6046d4e82"},
+    {file = "PyMuPDF-1.23.6-cp311-none-manylinux2014_x86_64.whl", hash = "sha256:e33f8ec5ba7265fe78b30332840b8f454184addfa79f9c27f160f19789aa5ffd"},
+    {file = "PyMuPDF-1.23.6-cp311-none-win32.whl", hash = "sha256:2c141f33e2733e48de8524dfd2de56d889feef0c7773b20a8cd216c03ab24793"},
+    {file = "PyMuPDF-1.23.6-cp311-none-win_amd64.whl", hash = "sha256:8fd9c4ee1dd4744a515b9190d8ba9133348b0d94c362293ed77726aa1c13b0a6"},
+    {file = "PyMuPDF-1.23.6-cp312-none-macosx_10_9_x86_64.whl", hash = "sha256:4d06751d5cd213e96f84f2faaa71a51cf4d641851e07579247ca1190121f173b"},
+    {file = "PyMuPDF-1.23.6-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:526b26a5207e923aab65877ad305644402851823a352cb92d362053426899354"},
+    {file = "PyMuPDF-1.23.6-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:0f852d125defc26716878b1796f4d68870e9065041d00cf46bde317fd8d30e68"},
+    {file = "PyMuPDF-1.23.6-cp312-none-manylinux2014_x86_64.whl", hash = "sha256:5bdf7020b90987412381acc42427dd1b7a03d771ee9ec273de003e570164ec1a"},
+    {file = "PyMuPDF-1.23.6-cp312-none-win32.whl", hash = "sha256:e2d64799c6d9a3735be9e162a5d11061c0b7fbcb1e5fc7446e0993d0f815a93a"},
+    {file = "PyMuPDF-1.23.6-cp312-none-win_amd64.whl", hash = "sha256:c8ea81964c1433ea163ad4b53c56053a87a9ef6e1bd7a879d4d368a3988b60d1"},
+    {file = "PyMuPDF-1.23.6-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:761501a4965264e81acdd8f2224f993020bf24474e9b34fcdb5805a6826eda1c"},
+    {file = "PyMuPDF-1.23.6-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:fd8388e82b6045807d19addf310d8119d32908e89f76cc8bbf8cf1ec36fce947"},
+    {file = "PyMuPDF-1.23.6-cp38-none-manylinux2014_aarch64.whl", hash = "sha256:4ac9673a6d6ee7e80cb242dacb43f9ca097b502d9c5e44687dbdffc2bce7961a"},
+    {file = "PyMuPDF-1.23.6-cp38-none-manylinux2014_x86_64.whl", hash = "sha256:6e319c1f49476e07b9a12017c2d031687617713f8a46b7adcec03c636ed04607"},
+    {file = "PyMuPDF-1.23.6-cp38-none-win32.whl", hash = "sha256:1103eea4ab727e32b9cb93347b35f71562033018c333a7f3a17d115e980fea4a"},
+    {file = "PyMuPDF-1.23.6-cp38-none-win_amd64.whl", hash = "sha256:991a37e1cba43775ce094da87cf0bf72172a5532a09644003276bc8bfdfe9f1a"},
+    {file = "PyMuPDF-1.23.6-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:57725e15872f7ab67a9fb3e06e5384d1047b2121e85755c93a6d4266d3ca8983"},
+    {file = "PyMuPDF-1.23.6-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:224c341fe254adda97c8f06a4c5838cdbcf609fa89e70b1fb179752533378f2f"},
+    {file = "PyMuPDF-1.23.6-cp39-none-manylinux2014_aarch64.whl", hash = "sha256:271bdf6059bb8347f9c9c6b721329bd353a933681b1fc62f43241b410e7ab7ae"},
+    {file = "PyMuPDF-1.23.6-cp39-none-manylinux2014_x86_64.whl", hash = "sha256:57e22bea69690450197b34dcde16bd9fe0265ac4425b4033535ccc5c044246fb"},
+    {file = "PyMuPDF-1.23.6-cp39-none-win32.whl", hash = "sha256:2885a26220a32fb45ea443443b72194bb7107d6862d8d546b59e4ad0c8a1f2c9"},
+    {file = "PyMuPDF-1.23.6-cp39-none-win_amd64.whl", hash = "sha256:361cab1be45481bd3dc4e00ec82628ebc189b4f4b6fd9bd78a00cfeed54e0034"},
+    {file = "PyMuPDF-1.23.6.tar.gz", hash = "sha256:618b8e884190ac1cca9df1c637f87669d2d532d421d4ee7e4763c848dc4f3a1e"},
+]
+
+[package.dependencies]
+PyMuPDFb = "1.23.6"
+
+[[package]]
+name = "pymupdfb"
+version = "1.23.6"
+description = "MuPDF shared libraries for PyMuPDF."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "PyMuPDFb-1.23.6-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:e5af77580aad3d1103aeec57009d156bfca429cecda14a17c573fcbe97bafb30"},
+    {file = "PyMuPDFb-1.23.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9925816cbe3e05e920f9be925e5752c2eef42b793885b62075bb0f6a69178598"},
+    {file = "PyMuPDFb-1.23.6-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:009e2cff166059e13bf71f93919e688f46b8fc11d122433574cfb0cc9134690e"},
+    {file = "PyMuPDFb-1.23.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7132b30e6ad6ff2013344e3a481b2287fe0be3710d80694807dd6e0d8635f085"},
+    {file = "PyMuPDFb-1.23.6-py3-none-win32.whl", hash = "sha256:9d24ddadc204e895bee5000ddc7507c801643548e59f5a56aad6d32981d17eeb"},
+    {file = "PyMuPDFb-1.23.6-py3-none-win_amd64.whl", hash = "sha256:7bef75988e6979b10ca804cf9487f817aae43b0fff1c6e315b3b9ee0cf1cc32f"},
 ]
 
 [[package]]
@@ -747,7 +794,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -918,56 +964,6 @@ files = [
 ]
 
 [[package]]
-name = "typed-ast"
-version = "1.5.5"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4bc1efe0ce3ffb74784e06460f01a223ac1f6ab31c6bc0376a21184bf5aabe3b"},
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f7a8c46a8b333f71abd61d7ab9255440d4a588f34a21f126bbfc95f6049e686"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:597fc66b4162f959ee6a96b978c0435bd63791e31e4f410622d19f1686d5e769"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d41b7a686ce653e06c2609075d397ebd5b969d821b9797d029fccd71fdec8e04"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5fe83a9a44c4ce67c796a1b466c270c1272e176603d5e06f6afbc101a572859d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d5c0c112a74c0e5db2c75882a0adf3133adedcdbfd8cf7c9d6ed77365ab90a1d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:e1a976ed4cc2d71bb073e1b2a250892a6e968ff02aa14c1f40eba4f365ffec02"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c631da9710271cb67b08bd3f3813b7af7f4c69c319b75475436fcab8c3d21bee"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b445c2abfecab89a932b20bd8261488d574591173d07827c1eda32c457358b18"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc95ffaaab2be3b25eb938779e43f513e0e538a84dd14a5d844b8f2932593d88"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61443214d9b4c660dcf4b5307f15c12cb30bdfe9588ce6158f4a005baeb167b2"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6eb936d107e4d474940469e8ec5b380c9b329b5f08b78282d46baeebd3692dc9"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e48bf27022897577d8479eaed64701ecaf0467182448bd95759883300ca818c8"},
-    {file = "typed_ast-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:83509f9324011c9a39faaef0922c6f720f9623afe3fe220b6d0b15638247206b"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:44f214394fc1af23ca6d4e9e744804d890045d1643dd7e8229951e0ef39429b5"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:118c1ce46ce58fda78503eae14b7664163aa735b620b64b5b725453696f2a35c"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4919b808efa61101456e87f2d4c75b228f4e52618621c77f1ddcaae15904fa"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:fc2b8c4e1bc5cd96c1a823a885e6b158f8451cf6f5530e1829390b4d27d0807f"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:16f7313e0a08c7de57f2998c85e2a69a642e97cb32f87eb65fbfe88381a5e44d"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:2b946ef8c04f77230489f75b4b5a4a6f24c078be4aed241cfabe9cbf4156e7e5"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2188bc33d85951ea4ddad55d2b35598b2709d122c11c75cffd529fbc9965508e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0635900d16ae133cab3b26c607586131269f88266954eb04ec31535c9a12ef1e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57bfc3cf35a0f2fdf0a88a3044aafaec1d2f24d8ae8cd87c4f58d615fb5b6311"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:fe58ef6a764de7b4b36edfc8592641f56e69b7163bba9f9c8089838ee596bfb2"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d09d930c2d1d621f717bb217bf1fe2584616febb5138d9b3e8cdd26506c3f6d4"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:d40c10326893ecab8a80a53039164a224984339b2c32a6baf55ecbd5b1df6431"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fd946abf3c31fb50eee07451a6aedbfff912fcd13cf357363f5b4e834cc5e71a"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ed4a1a42df8a3dfb6b40c3d2de109e935949f2f66b19703eafade03173f8f437"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:045f9930a1550d9352464e5149710d56a2aed23a2ffe78946478f7b5416f1ede"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:381eed9c95484ceef5ced626355fdc0765ab51d8553fec08661dce654a935db4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:bfd39a41c0ef6f31684daff53befddae608f9daf6957140228a08e51f312d7e6"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8c524eb3024edcc04e288db9541fe1f438f82d281e591c548903d5b77ad1ddd4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-win_amd64.whl", hash = "sha256:7f58fabdde8dcbe764cef5e1a7fcb440f2463c1bbbec1cf2a86ca7bc1f95184b"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:042eb665ff6bf020dd2243307d11ed626306b82812aba21836096d229fdc6a10"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:622e4a006472b05cf6ef7f9f2636edc51bda670b7bbffa18d26b255269d3d814"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1efebbbf4604ad1283e963e8915daa240cb4bf5067053cf2f0baadc4d4fb51b8"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0aefdd66f1784c58f65b502b6cf8b121544680456d1cebbd300c2c813899274"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:48074261a842acf825af1968cd912f6f21357316080ebaca5f19abbb11690c8a"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:429ae404f69dc94b9361bb62291885894b7c6fb4640d561179548c849f8492ba"},
-    {file = "typed_ast-1.5.5-cp39-cp39-win_amd64.whl", hash = "sha256:335f22ccb244da2b5c296e6f96b06ee9bed46526db0de38d2f0e5a6597b81155"},
-    {file = "typed_ast-1.5.5.tar.gz", hash = "sha256:94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd"},
-]
-
-[[package]]
 name = "types-markdown"
 version = "3.4.2.10"
 description = "Typing stubs for Markdown"
@@ -1048,5 +1044,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7,<3.12"
-content-hash = "fd4f4e9362f23cf48a16bfe8c11ed4eb68a4ae7d515c33f5e98b42ef270cac57"
+python-versions = ">=3.8,<3.12"
+content-hash = "204d9265a924cb18b153e7f9d3c3cb7b763fa56dd62b0397a6d6599328d30285"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.12"
+python = ">=3.8,<3.12"
 click = "*"
 appdirs = "*"
 PySide6 = "^6.4.1"
@@ -21,6 +21,7 @@ pyxdg = {version = "*", platform = "linux"}
 requests = "*"
 markdown = "*"
 packaging = "*"
+pymupdf = "^1.23.6"
 
 [tool.poetry.scripts]
 dangerzone = 'dangerzone:main'


### PR DESCRIPTION
Alternative to #619 but with PyMuPDF. This implements changes in the doc to pixels as well as the pixels to pdf conversion.

Missing
- [ ] assess the impact of PyMuPDF (performance, security, PDF rendering impact)
- [ ] change Dangerzone license due to PyMuPDF being AGPL