### PR TITLE
ci: Make our security scans stricter

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           image: "dangerzone.rocks/dangerzone:latest"
           fail-build: false
-          only-fixed: true
+          only-fixed: false
           severity-cutoff: critical
       - name: Upload container scan report
         uses: github/codeql-action/upload-sarif@v2
@@ -36,7 +36,7 @@ jobs:
         with:
           image: "dangerzone.rocks/dangerzone:latest"
           fail-build: true
-          only-fixed: true
+          only-fixed: false
           severity-cutoff: critical
 
   security-scan-app:
@@ -52,7 +52,7 @@ jobs:
         with:
           path: "."
           fail-build: false
-          only-fixed: true
+          only-fixed: false
           severity-cutoff: critical
       - name: Upload application scan report
         uses: github/codeql-action/upload-sarif@v2
@@ -66,5 +66,5 @@ jobs:
         with:
           path: "."
           fail-build: true
-          only-fixed: true
+          only-fixed: false
           severity-cutoff: critical

--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           image: "dangerzone.rocks/dangerzone:latest"
           fail-build: false
-          only-fixed: true
+          only-fixed: false
           severity-cutoff: critical
       - name: Upload container scan report
         uses: github/codeql-action/upload-sarif@v2
@@ -37,7 +37,7 @@ jobs:
         with:
           image: "dangerzone.rocks/dangerzone:latest"
           fail-build: true
-          only-fixed: true
+          only-fixed: false
           severity-cutoff: critical
 
   security-scan-app:
@@ -59,7 +59,7 @@ jobs:
         with:
           path: "."
           fail-build: false
-          only-fixed: true
+          only-fixed: false
           severity-cutoff: critical
       - name: Upload application scan report
         uses: github/codeql-action/upload-sarif@v2
@@ -73,5 +73,5 @@ jobs:
         with:
           path: "."
           fail-build: true
-          only-fixed: true
+          only-fixed: false
           severity-cutoff: critical


### PR DESCRIPTION
Our security scans previously alerted us on critical CVEs that have a fix. In this commit, we ask to be alerted on CVEs that don't have a fix yet, so that we can have them in our radar.

Since the introduction of these security checks, we have only once encountered a case where our container was vulnerable to a CVE that Alpine Linux had not fixed yet. This means that the maintenance burden of this change will probably be minimal.