### PR TITLE
Adds missing client-side packages to Qubes-Dangerzone

### DIFF
--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -70,9 +70,13 @@ Conflicts:      dangerzone-qubes
 BuildRequires:  python3-devel
 
 %if 0%{?_qubes}
-# Qubes-only requirements
+# Qubes-only requirements (server-side)
 Requires:       python3-magic
 Requires:       libreoffice
+# Qubes-only requirements (client-side)
+Requires:       GraphicsMagick
+Requires:       ghostscript
+Requires:       poppler-utils
 Requires:       tesseract
 # Explicitly require every tesseract model:
 # See: https://github.com/freedomofpress/dangerzone/issues/431


### PR DESCRIPTION
Dangerzone was failing to convert documents in Qubes due to missing client-side dependencies. In particular poppler-utils, ghostscript and graphicsmagick.

Fixes #647