### PR TITLE
ci: Test official installation instructions

### DIFF
--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -1,0 +1,88 @@
+# Test official instructions for installing Dangerzone
+# ====================================================
+#
+# The installation instructions have been copied from our INSTALL.md file.
+# NOTE: When you change either place, please make sure to keep the two files in
+# sync.
+# NOTE: Because the commands run as root, the use of sudo is not necessary.
+name: Test official instructions for installing Dangerzone
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run every day at 00:00 UTC.
+
+jobs:
+  install-from-apt-repo:
+    name: "Install Dangerzone on ${{ matrix.distro}} ${{ matrix.version }}"
+    runs-on: ubuntu-latest
+    container: ${{ matrix.distro }}:${{ matrix.version }}
+    strategy:
+      matrix:
+        include:
+          - distro: ubuntu
+            version: "23.10"  # mantic
+          - distro: ubuntu
+            version: "23.04"  # lunar
+          - distro: ubuntu
+            version: "22.04"  # jammy
+          - distro: ubuntu
+            version: "20.04"  # focal
+          - distro: debian
+            version: "trixie"  # 13
+          - distro: debian
+            version: "12"  # bookworm
+          - distro: debian
+            version: "11"  # bullseye
+    steps:
+      - name: Add Podman repo for Ubuntu Focal
+        if: matrix.distro == 'ubuntu' && matrix.version == 20.04
+        run: |
+          apt-get update && apt-get -y install curl wget gnupg2
+          . /etc/os-release
+          sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' \
+            > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+          wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- \
+            | apt-key add -
+          apt update
+          apt-get install python-all -y
+
+      - name: Add GPG key for the packages.freedom.press
+        run: |
+          apt-get update && apt-get install -y gnupg2 ca-certificates
+          dirmngr  # NOTE: This is a command that's necessary only in containers
+          gpg --keyserver hkps://keys.openpgp.org \
+              --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
+              --recv-keys "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281"
+          mkdir -p /etc/apt/keyrings/
+          mv fpf-apt-tools-archive-keyring.gpg /etc/apt/keyrings
+
+      - name: Add packages.freedom.press to our APT sources
+        run: |
+          . /etc/os-release
+          echo deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
+              https://packages.freedom.press/apt-tools-prod ${VERSION_CODENAME?} main \
+              | tee /etc/apt/sources.list.d/fpf-apt-tools.list
+
+      - name: Install Dangerzone
+        run: |
+          apt update
+          apt install -y dangerzone
+
+  install-from-yum-repo:
+    name: "Install Dangerzone on ${{ matrix.distro}} ${{ matrix.version }}"
+    runs-on: ubuntu-latest
+    container: ${{ matrix.distro }}:${{ matrix.version }}
+    strategy:
+      matrix:
+        include:
+          - distro: fedora
+            version: 38
+    steps:
+      - name: Add packages.freedom.press to our YUM sources
+        run: |
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+
+      - name: Install Dangerzone
+        # FIXME: We add the `-y` flag here, in lieu of a better way to check the
+        # Dangerzone signature.
+        run: dnf install -y dangerzone

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,8 +32,8 @@ Dangerzone is available for:
   copied from the [official Podman blog](https://podman.io/new/2021/06/16/new.html):
 
   ```bash
-  sudo apt-get install curl wget gnupg2 -y
-  source /etc/os-release
+  sudo apt-get update && sudo apt-get install curl wget gnupg2 -y
+  . /etc/os-release
   sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' \
     > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
   wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- \
@@ -54,6 +54,7 @@ Add our repository following these instructions:
 Download the GPG key for the repo:
 
 ```sh
+sudo apt-get update && sudo apt-get install gnupg2 ca-certificates -y
 gpg --keyserver hkps://keys.openpgp.org \
     --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
     --recv-keys "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281"
@@ -64,7 +65,7 @@ sudo mv fpf-apt-tools-archive-keyring.gpg /etc/apt/keyrings
 Add the URL of the repo in your APT sources:
 
 ```sh
-source /etc/os-release
+. /etc/os-release
 echo deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
     https://packages.freedom.press/apt-tools-prod ${VERSION_CODENAME?} main \
     | sudo tee /etc/apt/sources.list.d/fpf-apt-tools.list
@@ -98,6 +99,7 @@ sudo apt install -y dangerzone
 Type the following commands in a terminal:
 
 ```
+sudo dnf install 'dnf-command(config-manager)'
 sudo dnf config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone
 ```


### PR DESCRIPTION
Create a new GitHub Actions workflow which aims to continuously test our official installation instructions. The way we do it is the following:

1. Create two jobs, one for the Debian-based distros, and one for Fedora ones.
2. Copy the instructions from INSTALL.md into each job.
3. Create a matrix that runs the installation jobs in parallel, for each supported distro and version.

The jobs will run only on 00:00 UTC, and not on every PR, since it wouldn't make sense otherwise.

Fix #653

NOTE: The committed code does not enable runs of this CI job on pull requests. Here's the latest successful run instead: https://github.com/freedomofpress/dangerzone/actions/runs/7168694646