### PR TITLE
Fix failing RPM builds due to files ignored by Git

### DIFF
--- a/install/linux/build-rpm.py
+++ b/install/linux/build-rpm.py
@@ -51,6 +51,7 @@ def build(qubes=False):
         dist_path.mkdir()
 
     print(f"* Creating RPM project structure under {build_dir}")
+    build_dir.mkdir(exist_ok=True)
     for d in ["BUILD", "BUILDROOT", "RPMS", "SOURCES", "SPECS"]:
         subdir = build_dir / d
         subdir.mkdir(exist_ok=True)

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -254,13 +254,6 @@ install -m 755 -d %{buildroot}/etc/qubes-rpc
 install -m 755 qubes/* %{buildroot}/etc/qubes-rpc
 %endif
 
-# The following files are included in the top level of the Python source
-# distribution, but they are moved in other places in the final RPM package.
-# They are considered stale, so remove them to appease the RPM check that
-# ensures there are no unhandled files.
-rm %{buildroot}/%{python3_sitelib}/README.md
-rm -r %{buildroot}%{python3_sitelib}/install
-
 %files -f %{pyproject_files}
 /usr/bin/dangerzone
 /usr/bin/dangerzone-cli

--- a/install/linux/rpm-build/.gitignore
+++ b/install/linux/rpm-build/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,12 @@ version = "0.5.1"
 description = "Take potentially dangerous PDFs, office documents, or images and convert them to safe PDFs"
 authors = ["Freedom of the Press Foundation <info@freedom.press>", "Micah Lee <micah.lee@theintercept.com>"]
 license = "AGPL-3.0"
+# NOTE: See also https://github.com/freedomofpress/dangerzone/issues/677
 include = [
-    "share/",
-    "qubes/",
-    "install/linux/press.freedom.dangerzone.*",
-    "README.md"
+    { path = "share/*", format = "sdist" },
+    { path = "qubes/*", format = "sdist" },
+    { path = "install/linux/press.freedom.dangerzone.*", format = "sdist" },
+    { path = "README.md", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Fix failing RPM builds by doing the following:

1. Remove .gitignore from a dir where Poetry would ultimately build our Python wheel.
2. Include data files only on sdist, and in a way that Poetry understands.

Fixes #678
Refs #677