### PR TITLE
ci: Reclaim some of the used space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,12 @@ jobs:
           ./dev_scripts/env.py --distro fedora --version ${{ matrix.version }} \
               run --dev --no-gui ./dangerzone/install/linux/build-rpm.py
 
+      # Reclaim some space in this step, now that the dev environment is no
+      # longer necessary. Previously, we encountered out-of-space issues while
+      # running this CI job.
+      - name: Reclaim some storage space
+        run: podman system reset -f
+
       - name: Build end-user environment
         run: |
           ./dev_scripts/env.py --distro fedora --version ${{ matrix.version }} \


### PR DESCRIPTION
Reclaim some storage space in the middle of the CI job that builds and installs Dangerzone in Fedora. The reason is that previously, we encountered an issues with CI runners running out of space.