### PR TITLE
Improve QA script for Windows

### DIFF
--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -724,6 +724,13 @@ class QAWindows(QABase):
 
     REF_BUILD = Reference("BUILD.md", content=CONTENT_BUILD_WINDOWS)
 
+    def _consume_stdin(self):
+        # NOTE: We can't use select() on Windows. See:
+        # https://docs.python.org/3/library/select.html#select.select
+        import msvcrt
+        while msvcrt.kbhit():
+            msvcrt.getch()
+
     @QABase.task("Install and Run Docker Desktop", ref=REF_BUILD)
     def install_docker(self):
         logger.info("Checking if Docker Desktop is installed and running")

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -751,6 +751,15 @@ class QAWindows(QABase):
     def build_image(self):
         self.run("python", r".\install\common\build-image.py")
 
+    @QABase.task("Run tests", ref="REF_BUILD", auto=True)
+    def run_tests(self):
+        # NOTE: Windows does not have Makefile by default.
+        self.run("poetry", "run", "pytest", "-v", "--ignore", r"tests\test_large_set.py")
+
+    @QABase.task("Build Dangerzone .exe", ref="REF_BUILD", auto=True)
+    def build_dangerzone_exe(self):
+        self.run("poetry", "run", "python", r".\setup-windows.py", "build")
+
     @classmethod
     def get_id(cls):
         return "windows"
@@ -759,6 +768,8 @@ class QAWindows(QABase):
         self.install_docker()
         self.install_poetry()
         self.build_image()
+        self.run_tests()
+        self.build_dangerzone_exe()
 
 
 class QALinux(QABase):


### PR DESCRIPTION
Make the following changes to the QA script for Windows:
1. Fix the way we consume the process' stdin (to avoid errant keystrokes).
2. Include tests and building an .exe in the QA script.