### PR TITLE
Get underlying error when conversion fails

### DIFF
--- a/.github/workflows/check_push.yml
+++ b/.github/workflows/check_push.yml
@@ -16,4 +16,4 @@ jobs:
           run: |
             git fetch origin
             git status
-            git log origin/main..HEAD | grep -ie '^    fixup\|^    wip' && exit 1 || true
+            git log --pretty=format:%s origin/main..HEAD | grep -ie '^fixup\|^wip' && exit 1 || true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -175,10 +175,9 @@ Dangerzone. Dangerzone should show the settings that the user chose.
 
 Run Dangerzone and convert the `tests/test_docs/sample_bad_pdf.pdf` document.
 Dangerzone should fail gracefully, by reporting that the operation failed, and
-showing the last error message.
+showing the following error message:
 
-_(Only for Qubes)_ The only message that the user should see is: "The document
-format is not supported", without any untrusted strings.
+> The document format is not supported
 
 #### 6. Dangerzone succeeds in converting multiple documents
 

--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -106,4 +106,4 @@ def exception_from_error_code(
     for cls in ConversionException.get_subclasses():
         if cls.error_code == error_code:
             return cls()
-    raise ValueError(f"Unknown error code '{error_code}'")
+    return UnexpectedConversionError(f"Unknown error code '{error_code}'")

--- a/dangerzone/conversion/errors.py
+++ b/dangerzone/conversion/errors.py
@@ -8,21 +8,11 @@ MAX_PAGE_WIDTH = 10000
 MAX_PAGE_HEIGHT = 10000
 
 
-class InterruptedConversionException(Exception):
-    """Data received was less than expected"""
-
-    def __init__(self) -> None:
-        super().__init__(
-            "Something interrupted the conversion and it could not be completed."
-        )
-
-
 class ConverterProcException(Exception):
     """Some exception occurred in the converter"""
 
-    def __init__(self, proc: subprocess.Popen) -> None:
-        self.proc = proc
-        super().__init__()
+    def __init__(self) -> None:
+        super().__init__("The process spawned for the conversion has exited early")
 
 
 class ConversionException(Exception):

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -27,7 +27,7 @@ def read_bytes(f: IO[bytes], size: int, exact: bool = True) -> bytes:
     """Read bytes from a file-like object."""
     buf = f.read(size)
     if exact and len(buf) != size:
-        raise errors.InterruptedConversionException()
+        raise errors.ConverterProcException()
     return buf
 
 
@@ -35,7 +35,7 @@ def read_int(f: IO[bytes]) -> int:
     """Read 2 bytes from a file-like object, and decode them as int."""
     untrusted_int = f.read(INT_BYTES)
     if len(untrusted_int) != INT_BYTES:
-        raise errors.InterruptedConversionException()
+        raise errors.ConverterProcException()
     return int.from_bytes(untrusted_int, "big", signed=False)
 
 
@@ -80,7 +80,7 @@ class IsolationProvider(ABC):
             if document.archive_after_conversion:
                 document.archive()
         except errors.ConverterProcException as e:
-            exception = self.get_proc_exception(e.proc)
+            exception = self.get_proc_exception(conversion_proc)
             self.print_progress(document, True, str(exception), 0)
             document.mark_as_failed()
         except errors.ConversionException as e:
@@ -103,7 +103,7 @@ class IsolationProvider(ABC):
                 p.stdin.write(f.read())
                 p.stdin.close()
             except BrokenPipeError as e:
-                raise errors.ConverterProcException(p)
+                raise errors.ConverterProcException()
 
             assert p.stdout
             n_pages = read_int(p.stdout)

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -728,6 +728,7 @@ class QAWindows(QABase):
         # NOTE: We can't use select() on Windows. See:
         # https://docs.python.org/3/library/select.html#select.select
         import msvcrt
+
         while msvcrt.kbhit():
             msvcrt.getch()
 
@@ -754,7 +755,9 @@ class QAWindows(QABase):
     @QABase.task("Run tests", ref="REF_BUILD", auto=True)
     def run_tests(self):
         # NOTE: Windows does not have Makefile by default.
-        self.run("poetry", "run", "pytest", "-v", "--ignore", r"tests\test_large_set.py")
+        self.run(
+            "poetry", "run", "pytest", "-v", "--ignore", r"tests\test_large_set.py"
+        )
 
     @QABase.task("Build Dangerzone .exe", ref="REF_BUILD", auto=True)
     def build_dangerzone_exe(self):

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -105,10 +105,9 @@ Dangerzone. Dangerzone should show the settings that the user chose.
 
 Run Dangerzone and convert the `tests/test_docs/sample_bad_pdf.pdf` document.
 Dangerzone should fail gracefully, by reporting that the operation failed, and
-showing the last error message.
+showing the following error message:
 
-_(Only for Qubes)_ The only message that the user should see is: "The document
-format is not supported", without any untrusted strings.
+> The document format is not supported
 
 #### 6. Dangerzone succeeds in converting multiple documents
 

--- a/tests/isolation_provider/base.py
+++ b/tests/isolation_provider/base.py
@@ -48,7 +48,7 @@ class IsolationProviderTest:
         monkeypatch.setattr(
             provider, "start_doc_to_pixels_proc", start_doc_to_pixels_proc
         )
-        with pytest.raises(errors.InterruptedConversionException):
+        with pytest.raises(errors.ConverterProcException):
             provider.doc_to_pixels(doc, tmpdir)
             assert provider.get_proc_exception(proc) == errors.MaxPagesException  # type: ignore [arg-type]
 

--- a/tests/isolation_provider/test_qubes.py
+++ b/tests/isolation_provider/test_qubes.py
@@ -40,25 +40,16 @@ class TestQubes(IsolationProviderTest):
     ) -> None:
         provider.progress_callback = mocker.MagicMock()
 
-        proc = None
-
-        def start_doc_to_pixels_proc() -> subprocess.Popen:
-            proc = subprocess.Popen(
-                # XXX error 126 simulates a qrexec-policy failure. Source:
-                # https://github.com/QubesOS/qubes-core-qrexec/blob/fdcbfd7/daemon/qrexec-daemon.c#L1022
-                ["exit 126"],
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                shell=True,
-            )
-            return proc
-
-        monkeypatch.setattr(
-            provider, "start_doc_to_pixels_proc", start_doc_to_pixels_proc
+        proc = subprocess.Popen(
+            # XXX error 126 simulates a qrexec-policy failure. Source:
+            # https://github.com/QubesOS/qubes-core-qrexec/blob/fdcbfd7/daemon/qrexec-daemon.c#L1022
+            ["exit 126"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
         )
-
         with pytest.raises(errors.ConverterProcException) as e:
             doc = Document(sample_doc)
-            provider.doc_to_pixels(doc, tmpdir)
-            assert provider.get_proc_exception(proc) == errors.QubesQrexecFailed  # type: ignore [arg-type]
+            provider.doc_to_pixels(doc, tmpdir, proc)
+            assert provider.get_proc_exception(proc) == errors.QubesQrexecFailed

--- a/tests/isolation_provider/test_qubes.py
+++ b/tests/isolation_provider/test_qubes.py
@@ -58,7 +58,7 @@ class TestQubes(IsolationProviderTest):
             provider, "start_doc_to_pixels_proc", start_doc_to_pixels_proc
         )
 
-        with pytest.raises(errors.InterruptedConversionException) as e:
+        with pytest.raises(errors.ConverterProcException) as e:
             doc = Document(sample_doc)
             provider.doc_to_pixels(doc, tmpdir)
             assert provider.get_proc_exception(proc) == errors.QubesQrexecFailed  # type: ignore [arg-type]


### PR DESCRIPTION
When we get an early EOF from the converter process, we should
immediately get the exit code of that process, to find out the actual
underlying error. Currently, the exception we raise masks the underlying
error.

Raise a ConverterProcException, that in turns makes our error handling
code read the exit code of the spawned process, and converts it to a
helpful error message.

Fixes #714
