### PR TITLE
Don't show 50% duplicated progress info

### DIFF
--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -106,7 +106,7 @@ class IsolationProvider(ABC):
             n_pages = read_int(p.stdout)
             if n_pages == 0 or n_pages > errors.MAX_PAGES:
                 raise errors.MaxPagesException()
-            percentage_per_page = 50.0 / n_pages
+            percentage_per_page = 49.0 / n_pages
 
             for page in range(1, n_pages + 1):
                 text = f"Converting page {page}/{n_pages} to pixels"


### PR DESCRIPTION
50% would show twice in the conversion progress due to an overlap in conversion progress values. The doc_to_pixels would be from 0-50% and the pixels_to_pdf from 50%-100%.

This commit makes the first part go from 0 to 49% instead.

Fixes #715