### PR TITLE
Bump CodeQL upload action to V3 due to deprecation

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -27,7 +27,7 @@ jobs:
           only-fixed: false
           severity-cutoff: critical
       - name: Upload container scan report
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan_container.outputs.sarif }}
           category: container
@@ -57,7 +57,7 @@ jobs:
           only-fixed: false
           severity-cutoff: critical
       - name: Upload application scan report
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan_app.outputs.sarif }}
           category: app

--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -26,7 +26,7 @@ jobs:
           only-fixed: false
           severity-cutoff: critical
       - name: Upload container scan report
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan_container.outputs.sarif }}
           category: container
@@ -62,7 +62,7 @@ jobs:
           only-fixed: false
           severity-cutoff: critical
       - name: Upload application scan report
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan_app.outputs.sarif }}
           category: app


### PR DESCRIPTION
The following warning was showing up [in our conversion logs](https://github.com/freedomofpress/dangerzone/actions/runs/7916735564/job/21611227503?pr=718):

> Warning: CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/