### PR TITLE
Properly add new file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Dangerzone can convert these types of document into safe PDFs:
 - GIF (`.gif`)
 - PNG (`.png`)
 - SVG (`.svg`)
-- other image formats (`.bmp`, `.pnm`, `pbm`, `ppm`)
+- other image formats (`.bmp`, `.pnm`, `.pbm`, `.ppm`)
 
 Dangerzone was inspired by [Qubes trusted PDF](https://blog.invisiblethings.org/2013/02/21/converting-untrusted-pdfs-into-trusted.html), but it works in non-Qubes operating systems. It uses containers as sandboxes instead of virtual machines (using Docker for macOS and Windows, and [podman](https://podman.io/) on Linux).
 

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -562,7 +562,9 @@ class DocSelectionWidget(QtWidgets.QWidget):
             hwp_filters = ""
         self.file_dialog.setNameFilters(
             [
-                f"Documents (*.pdf *.docx *.doc *.docm *.xlsx *.xls *.pptx *.ppt *.odt *.odg *.odp *.ods {hwp_filters} *.epub *.jpg *.jpeg *.gif *.png *.tif *.tiff *.bpm *.pnm *.pbm *.ppm)"
+                "Documents (*.pdf *.docx *.doc *.docm *.xlsx *.xls *.pptx *.ppt *.odt"
+                f" *.odg *.odp *.ods {hwp_filters} *.epub *.jpg *.jpeg *.gif *.png"
+                " *.tif *.tiff *.bmp *.pnm *.pbm *.ppm *.svg)"
             ]
         )
 


### PR DESCRIPTION
Accept `.svg` and `.bmp` files when browsing via the Dangerzone GUI. Support for these extensions has already been added in the converter code that runs in the sandbox (cd9912238575051bf7649a7bafc9f911efff4197) but they were erroneously left out from the filter in the Dangerzone main window.