### PR TITLE
Add release notes template

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -419,7 +419,8 @@ repo.
 To publish the release:
 
 - [ ] Run container scan on the produced container images (some time may have passed since the artifacts were built)
-- [ ] Create a new release on GitHub, put the changelog in the description of the release, and upload the macOS and Windows installers
+- [ ] Create a new release on GitHub and upload the macOS and Windows installers.
+  * Copy the release notes text from the template at [`docs/templates/release-notes`](https://github.com/freedomofpress/dangerzone/tree/main/docs/templates/)
   * You can use `./dev_scripts/upload-asset.py`, if you want to upload an asset
     using an access token.
 - [ ] Upload the `container.tar.gz` i686 image that was created in the previous step

--- a/docs/templates/release-notes-regular.md
+++ b/docs/templates/release-notes-regular.md
@@ -1,0 +1,11 @@
+This release includes various new features, stability improvements, and security fixes **(adjust accordingly)**. If you are on a Mac or PC please also update Docker Desktop to the latest version to get the latest security fixes.
+
+The highlights for this release are:
+  - **Important accomplishment**
+    We used to do [this](https://github.com/freedomofpress/dangerzone/issues/1), but now we do [that](https://github.com/freedomofpress/dangerzone/issues/2).
+  - **Support for a new platform**
+    We added support for a new platform ([#3](https://github.com/freedomofpress/dangerzone/issues/3))
+  - **Community contributions**
+     <!-- Acknowledge all contributions and talk about highlights ->
+
+For a full list of the changes, see our [changelog](https://github.com/freedomofpress/dangerzone/blob/<RELEASE_TAG>/CHANGELOG.md#<RELEASE_ANCHOR>).

--- a/docs/templates/release-notes-security.md
+++ b/docs/templates/release-notes-security.md
@@ -1,0 +1,20 @@
+This is a security release that mainly addresses CVE-XXXX-XXX. Our [security advisory](https://github.com/freedomofpress/dangerzone/blob/<RELEASE_TAG>/docs/advisories/<YYYY-MM-DD>.md) follows:
+
+<!-- Vulnerability description for non-technical users -->
+
+**To reduce that risk, you are strongly advised to update Dangerzone to the latest version**.
+
+# Summary
+
+# How does this impact me?
+
+# What do I need to do?
+
+You are **strongly** advised to update your Dangerzone installation to <VERSION> as soon as possible.
+
+
+---
+
+On other news, this release brings a fix for ([#4](https://github.com/freedomofpress/dangerzone/issues/4)) and a fix for ([#5](https://github.com/freedomofpress/dangerzone/issues/5))
+
+For a full list of the changes, see our [changelog](https://github.com/freedomofpress/dangerzone/blob/<RELEASE_TAG>/CHANGELOG.md#<RELEASE_ANCHOR>).


### PR DESCRIPTION
Simplifies the release announcement drafting by providing some templates. It would have been preferable to be a .github config file, but GitHub does not yet support content templates for release notes.