### PR TITLE
Simplify QA for Scenario 10

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -158,20 +158,50 @@ _(Only for MacOS / Windows)_
 Stop the Docker Desktop application. Then run Dangerzone. Dangerzone should
 prompt the user to start Docker Desktop.
 
-#### 3. Dangerzone successfully installs the container image
 
-_(Not for Qubes)_
+#### 3. Updating Dangerzone handles external state correctly.
+
+_(Applies to Windows/MacOS)_
+
+Install the previous version of Dangerzone, downloaded from the website.
+
+Open the Dangerzone application and enable some non-default settings.
+**If there are new settings, make sure to change those as well**.
+
+Close the Dangerzone application and get the container image for that
+version. For example:
+
+```
+$ docker images dangerzone.rocks/dangerzone:latest
+REPOSITORY                   TAG         IMAGE ID      CREATED       SIZE
+dangerzone.rocks/dangerzone  latest      <image ID>    <date>        <size>
+```
+
+Then run the version under QA and ensure that the settings remain changed.
+
+Afterwards check that new docker image was installed by running the same command
+and seeing the following differences:
+
+```
+$ docker images dangerzone.rocks/dangerzone:latest
+REPOSITORY                   TAG         IMAGE ID        CREATED       SIZE
+dangerzone.rocks/dangerzone  latest      <different ID>  <newer date>  <different size>
+```
+
+#### 4. Dangerzone successfully installs the container image
+
+_(Linux)_
 
 Remove the Dangerzone container image from Docker/Podman. Then run Dangerzone.
 Dangerzone should install the container image successfully.
 
-#### 4. Dangerzone retains the settings of previous runs
+#### 5. Dangerzone retains the settings of previous runs
 
 Run Dangerzone and make some changes in the settings (e.g., change the OCR
 language, toggle whether to open the document after conversion, etc.). Restart
 Dangerzone. Dangerzone should show the settings that the user chose.
 
-#### 5. Dangerzone reports failed conversions
+#### 6. Dangerzone reports failed conversions
 
 Run Dangerzone and convert the `tests/test_docs/sample_bad_pdf.pdf` document.
 Dangerzone should fail gracefully, by reporting that the operation failed, and
@@ -179,7 +209,7 @@ showing the following error message:
 
 > The document format is not supported
 
-#### 6. Dangerzone succeeds in converting multiple documents
+#### 7. Dangerzone succeeds in converting multiple documents
 
 Run Dangerzone against a list of documents, and tick all options. Ensure that:
 * Conversions take place sequentially.
@@ -193,21 +223,21 @@ Run Dangerzone against a list of documents, and tick all options. Ensure that:
   location.
 * The original files have been saved in the `unsafe/` directory.
 
-#### 7. Dangerzone CLI succeeds in converting multiple documents
+#### 8. Dangerzone CLI succeeds in converting multiple documents
 
 _(Only for Windows and Linux)_
 
 Run Dangerzone CLI against a list of documents. Ensure that conversions happen
 sequentially, are completed successfully, and we see their progress.
 
-#### 8. Dangerzone can open a document for conversion via right-click -> "Open With"
+#### 9. Dangerzone can open a document for conversion via right-click -> "Open With"
 
 _(Only for Windows, MacOS and Qubes)_
 
 Go to a directory with office documents, right-click on one, and click on "Open
 With". We should be able to open the file with Dangerzone, and then convert it.
 
-#### 9. Dangerzone shows helpful errors for setup issues on Qubes
+#### 10. Dangerzone shows helpful errors for setup issues on Qubes
 
 _(Only for Qubes)_
 
@@ -221,46 +251,6 @@ should point the user to the Qubes notifications in the top-right corner:
 3. The `dz-dvm` disposable Qube cannot start due to insufficient resources. We
    can trigger this scenario by temporarily increasing the minimum required RAM
    of the `dz-dvm` template to more than the available amount.
-
-#### 10. Updating Dangerzone handles external state correctly.
-
-_(Applies to Linux/Windows/MacOS. For MacOS/Windows, it requires an installer
-for the new version)_
-
-Install the previous version of Dangerzone system-wide:
-
-* For MacOS/Windows, use the version from the website.
-* For Linux, uninstall Dangerzone from your test environment, and install the
-  previous version using our [installation instructions](INSTALL.md). Also,
-  keep in mind the following:
-  - In order to run commands as root, execute into the container as root with
-    `podman exec -it -u root <container ID> bash`.
-  - If you encounter a GPG error, run the `dirmngr` command to create the
-    necessary directories.
-
-Open the Dangerzone application and enable some non-default settings. Close the
-Dangerzone application and get the container image for that version. For
-example:
-
-```
-$ podman images dangerzone.rocks/dangerzone:latest
-REPOSITORY                   TAG         IMAGE ID      CREATED       SIZE
-dangerzone.rocks/dangerzone  latest      <image ID>    <date>        <size>
-```
-
-_(use `docker` on Windows/MacOS)_
-
-Install the new version of Dangerzone system-wide. For Linux, copy the package
-back into the container. Open the Dangerzone application and make sure that the
-previously enabled settings still show up.  Also, ensure that Dangerzone reports
-that the new image has been installed, and verify that it's different from the
-old one by doing:
-
-```
-$ podman images dangerzone.rocks/dangerzone:latest
-REPOSITORY                   TAG         IMAGE ID        CREATED       SIZE
-dangerzone.rocks/dangerzone  latest      <different ID>  <newer date>  <different size>
-```
 
 ## Release
 

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -47,7 +47,10 @@ class Settings:
         return self.settings[key]
 
     def set(self, key: str, val: Any, autosave: bool = False) -> None:
-        old_val = self.get(key)
+        try:
+            old_val = self.get(key)
+        except KeyError:
+            old_val = None
         self.settings[key] = val
         if autosave and val != old_val:
             self.save()

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -13,6 +13,8 @@ log = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from .logic import DangerzoneCore
 
+SETTINGS_FILENAME: str = "settings.json"
+
 
 class Settings:
     settings: Dict[str, Any]
@@ -20,7 +22,7 @@ class Settings:
     def __init__(self, dangerzone: "DangerzoneCore") -> None:
         self.dangerzone = dangerzone
         self.settings_filename = os.path.join(
-            self.dangerzone.appdata_path, "settings.json"
+            self.dangerzone.appdata_path, SETTINGS_FILENAME
         )
         self.default_settings: Dict[str, Any] = self.generate_default_settings()
         self.load()

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -88,20 +88,50 @@ _(Only for MacOS / Windows)_
 Stop the Docker Desktop application. Then run Dangerzone. Dangerzone should
 prompt the user to start Docker Desktop.
 
-#### 3. Dangerzone successfully installs the container image
 
-_(Not for Qubes)_
+#### 3. Updating Dangerzone handles external state correctly.
+
+_(Applies to Windows/MacOS)_
+
+Install the previous version of Dangerzone, downloaded from the website.
+
+Open the Dangerzone application and enable some non-default settings.
+**If there are new settings, make sure to change those as well**.
+
+Close the Dangerzone application and get the container image for that
+version. For example:
+
+```
+$ docker images dangerzone.rocks/dangerzone:latest
+REPOSITORY                   TAG         IMAGE ID      CREATED       SIZE
+dangerzone.rocks/dangerzone  latest      <image ID>    <date>        <size>
+```
+
+Then run the version under QA and ensure that the settings remain changed.
+
+Afterwards check that new docker image was installed by running the same command
+and seeing the following differences:
+
+```
+$ docker images dangerzone.rocks/dangerzone:latest
+REPOSITORY                   TAG         IMAGE ID        CREATED       SIZE
+dangerzone.rocks/dangerzone  latest      <different ID>  <newer date>  <different size>
+```
+
+#### 4. Dangerzone successfully installs the container image
+
+_(Linux)_
 
 Remove the Dangerzone container image from Docker/Podman. Then run Dangerzone.
 Dangerzone should install the container image successfully.
 
-#### 4. Dangerzone retains the settings of previous runs
+#### 5. Dangerzone retains the settings of previous runs
 
 Run Dangerzone and make some changes in the settings (e.g., change the OCR
 language, toggle whether to open the document after conversion, etc.). Restart
 Dangerzone. Dangerzone should show the settings that the user chose.
 
-#### 5. Dangerzone reports failed conversions
+#### 6. Dangerzone reports failed conversions
 
 Run Dangerzone and convert the `tests/test_docs/sample_bad_pdf.pdf` document.
 Dangerzone should fail gracefully, by reporting that the operation failed, and
@@ -109,7 +139,7 @@ showing the following error message:
 
 > The document format is not supported
 
-#### 6. Dangerzone succeeds in converting multiple documents
+#### 7. Dangerzone succeeds in converting multiple documents
 
 Run Dangerzone against a list of documents, and tick all options. Ensure that:
 * Conversions take place sequentially.
@@ -123,21 +153,21 @@ Run Dangerzone against a list of documents, and tick all options. Ensure that:
   location.
 * The original files have been saved in the `unsafe/` directory.
 
-#### 7. Dangerzone CLI succeeds in converting multiple documents
+#### 8. Dangerzone CLI succeeds in converting multiple documents
 
 _(Only for Windows and Linux)_
 
 Run Dangerzone CLI against a list of documents. Ensure that conversions happen
 sequentially, are completed successfully, and we see their progress.
 
-#### 8. Dangerzone can open a document for conversion via right-click -> "Open With"
+#### 9. Dangerzone can open a document for conversion via right-click -> "Open With"
 
 _(Only for Windows, MacOS and Qubes)_
 
 Go to a directory with office documents, right-click on one, and click on "Open
 With". We should be able to open the file with Dangerzone, and then convert it.
 
-#### 9. Dangerzone shows helpful errors for setup issues on Qubes
+#### 10. Dangerzone shows helpful errors for setup issues on Qubes
 
 _(Only for Qubes)_
 
@@ -151,46 +181,6 @@ should point the user to the Qubes notifications in the top-right corner:
 3. The `dz-dvm` disposable Qube cannot start due to insufficient resources. We
    can trigger this scenario by temporarily increasing the minimum required RAM
    of the `dz-dvm` template to more than the available amount.
-
-#### 10. Updating Dangerzone handles external state correctly.
-
-_(Applies to Linux/Windows/MacOS. For MacOS/Windows, it requires an installer
-for the new version)_
-
-Install the previous version of Dangerzone system-wide:
-
-* For MacOS/Windows, use the version from the website.
-* For Linux, uninstall Dangerzone from your test environment, and install the
-  previous version using our [installation instructions](INSTALL.md). Also,
-  keep in mind the following:
-  - In order to run commands as root, execute into the container as root with
-    `podman exec -it -u root <container ID> bash`.
-  - If you encounter a GPG error, run the `dirmngr` command to create the
-    necessary directories.
-
-Open the Dangerzone application and enable some non-default settings. Close the
-Dangerzone application and get the container image for that version. For
-example:
-
-```
-$ podman images dangerzone.rocks/dangerzone:latest
-REPOSITORY                   TAG         IMAGE ID      CREATED       SIZE
-dangerzone.rocks/dangerzone  latest      <image ID>    <date>        <size>
-```
-
-_(use `docker` on Windows/MacOS)_
-
-Install the new version of Dangerzone system-wide. For Linux, copy the package
-back into the container. Open the Dangerzone application and make sure that the
-previously enabled settings still show up.  Also, ensure that Dangerzone reports
-that the new image has been installed, and verify that it's different from the
-old one by doing:
-
-```
-$ podman images dangerzone.rocks/dangerzone:latest
-REPOSITORY                   TAG         IMAGE ID        CREATED       SIZE
-dangerzone.rocks/dangerzone  latest      <different ID>  <newer date>  <different size>
-```
 """
 
 CONTENT_BUILD_DEBIAN_UBUNTU = r"""## Debian/Ubuntu

--- a/tests/gui/test_updater.py
+++ b/tests/gui/test_updater.py
@@ -18,6 +18,7 @@ from dangerzone.gui import updater as updater_module
 from dangerzone.gui.updater import UpdateReport, UpdaterThread
 from dangerzone.util import get_version
 
+from ..test_settings import default_settings_0_4_1, save_settings
 from . import generate_isolated_updater, qt_updater, updater
 
 
@@ -32,26 +33,6 @@ def default_updater_settings() -> dict:
         for key, val in settings.Settings.generate_default_settings().items()
         if key.startswith("updater_")
     }
-
-
-def default_settings_0_4_1() -> dict:
-    """Get the default settings for the 0.4.1 Dangerzone release."""
-    return {
-        "save": True,
-        "archive": True,
-        "ocr": True,
-        "ocr_language": "English",
-        "open": True,
-        "open_app": None,
-        "safe_extension": "-safe.pdf",
-    }
-
-
-def save_settings(tmp_path: Path, settings: dict) -> None:
-    """Mimic the way Settings save a dictionary to a settings.json file."""
-    settings_filename = tmp_path / "settings.json"
-    with open(settings_filename, "w") as settings_file:
-        json.dump(settings, settings_file, indent=4)
 
 
 def assert_report_equal(report1: UpdateReport, report2: UpdateReport) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,103 @@
+import collections
+import json
+import os
+from pathlib import Path
+from unittest.mock import PropertyMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from dangerzone.settings import *
+
+
+def default_settings_0_4_1() -> dict:
+    """Get the default settings for the 0.4.1 Dangerzone release."""
+    return {
+        "save": True,
+        "archive": True,
+        "ocr": True,
+        "ocr_language": "English",
+        "open": True,
+        "open_app": None,
+        "safe_extension": "-safe.pdf",
+    }
+
+
+@pytest.fixture
+def settings(tmp_path: Path, mocker: MockerFixture) -> Settings:
+    dz_core = mocker.MagicMock()
+    type(dz_core).appdata_path = PropertyMock(return_value=tmp_path)
+    return Settings(dz_core)
+
+
+def save_settings(tmp_path: Path, settings: dict) -> None:
+    """Mimic the way Settings save a dictionary to a settings.json file."""
+    settings_filename = tmp_path / "settings.json"
+    with open(settings_filename, "w") as settings_file:
+        json.dump(settings, settings_file, indent=4)
+
+
+def test_no_settings_file_creates_new_one(settings: Settings) -> None:
+    """Default settings file is created on first run"""
+    assert os.path.isfile(settings.settings_filename)
+    new_settings_dict = json.load(open(settings.settings_filename))
+    assert sorted(new_settings_dict.items()) == sorted(
+        settings.generate_default_settings().items()
+    )
+
+
+def test_corrupt_settings(tmp_path: Path, mocker: MockerFixture) -> None:
+    # Set some broken settings file
+    corrupt_settings_dict = "{:}"
+    with open(tmp_path / SETTINGS_FILENAME, "w") as settings_file:
+        settings_file.write(corrupt_settings_dict)
+
+    # Initialize settings
+    dz_core = mocker.MagicMock()
+    type(dz_core).appdata_path = PropertyMock(return_value=tmp_path)
+    settings = Settings(dz_core)
+    assert os.path.isfile(settings.settings_filename)
+
+    # Check if settings file was reset to the default
+    new_settings_dict = json.load(open(settings.settings_filename))
+    assert new_settings_dict != corrupt_settings_dict
+    assert sorted(new_settings_dict.items()) == sorted(
+        settings.generate_default_settings().items()
+    )
+
+
+def test_new_default_setting(tmp_path: Path, mocker: MockerFixture) -> None:
+    # Initialize settings
+    dz_core = mocker.MagicMock()
+    type(dz_core).appdata_path = PropertyMock(return_value=tmp_path)
+    settings = Settings(dz_core)
+    settings.save()
+
+    # Ensure new default setting is imported into settings
+    with mocker.patch(
+        "dangerzone.settings.Settings.generate_default_settings",
+        return_value={"mock_setting": 1},
+    ):
+        settings2 = Settings(dz_core)
+        assert settings2.get("mock_setting") == 1
+
+
+def test_new_settings_added(tmp_path: Path, mocker: MockerFixture) -> None:
+    # Initialize settings
+    dz_core = mocker.MagicMock()
+    type(dz_core).appdata_path = PropertyMock(return_value=tmp_path)
+    settings = Settings(dz_core)
+
+    # Add new setting
+    settings.set("new_setting_autosaved", 20, autosave=True)
+    settings.set(
+        "new_setting", 10
+    )  # XXX has to be afterwards; otherwise this will be saved
+
+    # Simulate new app startup (settings recreation)
+    settings2 = Settings(dz_core)
+
+    # Check if new setting persisted
+    assert 20 == settings2.get("new_setting_autosaved")
+    with pytest.raises(KeyError):
+        settings2.get("new_setting")


### PR DESCRIPTION
Simplifies the QA process for the previous scenario 10, where the goal was to test how upgrades are handled.
- **Increase settings tests** (~100% coverage)
- **Remove requirement from testing on Linux** - was a bit cumbersome (increased test coverage should help mitigate this removal)
- **Change scenario 10 numbering to be one of the earliest scenarios.**
   When starting QA on windows, the user will have installed the previous version, so it makes sense test the new version install first. This also helps avoid some state changes introduced by having the new version for the first scenarios and then installing the old one and then moving forwards again.

Fixes #719