### PR TITLE
ci: Update WiX Toolset path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: poetry run make test
       # Taken from: https://github.com/orgs/community/discussions/27149#discussioncomment-3254829
       - name: Set path for candle and light
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
+        run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
         shell: bash
       - name: Build the MSI installer
         # NOTE: This also builds the .exe internally.


### PR DESCRIPTION
Update the WiX Toolset from 3.11 to 3.14, since the former is no longer available in GitHub CI runners.