### PR TITLE
Minor Wix-related fixes

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -393,8 +393,8 @@ poetry shell
 ### If you want to build the installer
 
 * Go to https://dotnet.microsoft.com/download/dotnet-framework and download and install .NET Framework 3.5 SP1 Runtime. I downloaded `dotnetfx35.exe`.
-* Go to https://wixtoolset.org/releases/ and download and install WiX toolset. I downloaded `wix311.exe`.
-* Add `C:\Program Files (x86)\WiX Toolset v3.11\bin` to the path ([instructions](https://web.archive.org/web/20230221104142/https://windowsloop.com/how-to-add-to-windows-path/)).
+* Go to https://wixtoolset.org/releases/ and download and install WiX toolset. I downloaded `wix314.exe`.
+* Add `C:\Program Files (x86)\WiX Toolset v3.14\bin` to the path ([instructions](https://web.archive.org/web/20230221104142/https://windowsloop.com/how-to-add-to-windows-path/)).
 
 ### If you want to sign binaries with Authenticode
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can also install Dangerzone for Mac using [Homebrew](https://brew.sh/): `bre
 
 ### Windows
 
-- Download [Dangerzone 0.6.0 for Windows](https://github.com/freedomofpress/dangerzone/releases/download/v0.6.0/Dangerzone-0.6.0.msi)
+- Download [Dangerzone 0.6.0 for Windows](https://github.com/freedomofpress/dangerzone/releases/download/v0.6.0/Dangerzone-0.6.0-1.msi)
 
 > **Note**: you will also need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 > This program needs to run alongside Dangerzone at all times, since it is what allows Dangerzone to


### PR DESCRIPTION
Fix an outdated instruction for installing WiX, and point to the correct executable for Windows, which was rebuilt for the new WiX version.