### PR TITLE
Fix `test-large` phony target name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test-large-init: test-large-requirements
 	cd $(LARGE_TEST_REPO_DIR) && $(MAKE) clone-docs
 
 TEST_LARGE_RESULTS:=$(LARGE_TEST_REPO_DIR)/results/junit/commit_$(GIT_DESC).junit.xml
-.PHONY: tests-large
+.PHONY: test-large
 test-large: test-large-init  ## Run large test set
 	python -m pytest --tb=no tests/test_large_set.py::TestLargeSet -v $(JUNIT_FLAGS) --junitxml=$(TEST_LARGE_RESULTS)
 	python $(TEST_LARGE_RESULTS)/report.py $(TEST_LARGE_RESULTS)


### PR DESCRIPTION
There is an extra `s` in the `.PHONY` declaration intended for `test-large` target.