### PR TITLE
Fix printing of filenames with surrogate escapes

### DIFF
--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -11,7 +11,7 @@ from .isolation_provider.container import Container
 from .isolation_provider.dummy import Dummy
 from .isolation_provider.qubes import Qubes, is_qubes_native_conversion
 from .logic import DangerzoneCore
-from .util import get_version
+from .util import get_version, replace_control_chars
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -98,7 +98,7 @@ def cli_main(
     if documents_safe != []:
         print_header("Safe PDF(s) created successfully")
         for document in documents_safe:
-            click.echo(document.output_filename)
+            click.echo(replace_control_chars(document.output_filename))
 
         if archive:
             print_header(
@@ -108,7 +108,7 @@ def cli_main(
     if documents_failed != []:
         print_header("Failed to convert document(s)")
         for document in documents_failed:
-            click.echo(document.input_filename)
+            click.echo(replace_control_chars(document.input_filename))
         sys.exit(1)
     else:
         sys.exit(0)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import platform
 import sys
 import zipfile
 from pathlib import Path
@@ -115,6 +116,22 @@ def uncommon_text() -> str:
     * An emoji: Cross Mark (U+274C)
     """
     return "\033[31;1;4m BaD TeΧt \u200d ❌ \033[0m"
+
+
+@pytest.fixture
+def uncommon_filename(uncommon_text: str) -> str:
+    """Craft a filename with Unicode characters that are considered not common.
+
+    We reuse the same uncommon string as above, with a small exception for macOS.
+    Because the APFS filesystem in macOS accepts only UTF-8 encoded strings [1], we
+    cannot create a filename with invalid Unicode characters. So, in order to test the
+    rest of the corner cases, we replace U+DCF0 with an empty string.
+
+    [1]: https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
+    """
+    if platform.system() == "Darwin":
+        uncommon_text = uncommon_text.replace("\udcf0", "")
+    return uncommon_text + ".pdf"
 
 
 @pytest.fixture

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -114,8 +114,9 @@ def uncommon_text() -> str:
     * A Unicode control character that is not part of ASCII: zero-width joiner
       (U+200D)
     * An emoji: Cross Mark (U+274C)
+    * A surrogate escape used to decode an invalid UTF-8 sequence 0xF0 (U+DCF0)
     """
-    return "\033[31;1;4m BaD TeΧt \u200d ❌ \033[0m"
+    return "\033[31;1;4m BaD TeΧt \u200d ❌ \udcf0 \033[0m"
 
 
 @pytest.fixture
@@ -136,5 +137,9 @@ def uncommon_filename(uncommon_text: str) -> str:
 
 @pytest.fixture
 def sanitized_text() -> str:
-    """Return a sanitized version of the uncommon_text."""
-    return "_[31;1;4m BaD Te_t _ _ _[0m"
+    """Return a sanitized version of the uncommon_text.
+
+    Take the uncommon text string and replace all the control/invalid characters with
+    "�". The rest of the characters (emojis and non-English leters) are retained as is.
+    """
+    return "�[31;1;4m BaD TeΧt � ❌ � �[0m"


### PR DESCRIPTION
On Unix systems a filename can be a sequence of bytes that is not valid UTF-8. Python uses[1] surrogate escapes to allow to decode such filenames to Unicode (bytes that cannot be decoded are replaced by a surrogate; upon encoding the surrogate is converted to the original byte).

From `click` docs[2]:

> Invalid bytes or surrogate escapes will raise an error when written to a stream with `errors="strict"`. This will typically happen with `stdout` when the locale is something like `en_GB.UTF-8`.

~To fix that, we use `click.format_filename`[2] before printing the filenames to `stdout` so that surrogate escapes are replaced by �.~ Update: it was decided (see comment https://github.com/freedomofpress/dangerzone/pull/769#discussion_r1557187002) to instead use `replace_control_chars()` and also update its implementation to use Unicode General Category values to decide which characters to replace.

Fixes #768

[1]: https://peps.python.org/pep-0383/
[2]: https://click.palletsprojects.com/en/8.1.x/api/#click.format_filename