### PR TITLE
Avoid DUMMY_CONVERSION env var treated as bool in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   windows:
     runs-on: windows-latest
     env:
-      DUMMY_CONVERSION: True
+      DUMMY_CONVERSION: 1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -31,7 +31,7 @@ jobs:
   macOS:
     runs-on: macos-latest
     env:
-      DUMMY_CONVERSION: True
+      DUMMY_CONVERSION: 1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
`DUMMY_CONVERSION: True` is treated as a [boolean value](https://yaml.org/type/bool.html) in YAML. As a result, during GitHub CI the environment variable setup during tests [is formatted as `DUMMY_CONVERSION=true`](https://github.com/freedomofpress/dangerzone/actions/runs/8592550884/job/23542717894#step:6:5) (I suspect due to it being a Node environment?).

The value [is used](https://github.com/freedomofpress/dangerzone/blob/9bb1993e7768f721ab2260b407c58ec8dbb5f29c/tests/isolation_provider/base.py#L25) in tests and passed as the `condition` to the [`pytest.mark.skipif`](https://docs.pytest.org/en/stable/reference/reference.html#pytest-mark-skipif-ref) decorator. The `skipif` `condition` can be either a `bool` or `str`. When it is a `str` (our case, as we use `os.environ.get()`), it is treated as a [condition string](https://docs.pytest.org/en/stable/historical-notes.html#string-conditions) by pytest.

Since the condition string is [`eval()`ed](https://github.com/pytest-dev/pytest/blob/f75dd87eb7f31c4d14c84c18ce97353f51e801d4/src/_pytest/skipping.py#L117) by pytest, trying to evaluate `true` [results in](https://github.com/freedomofpress/dangerzone/actions/runs/8597362992/job/23555905803#step:6:391):

> Failed: Error evaluating 'skipif' condition
>     true
> NameError: name 'true' is not defined

This wraps the value in single-quotes to avoid the value being treated as boolean in YAML.

I've came across it when trying to use [this approach](https://github.com/freedomofpress/dangerzone/blob/9bb1993e7768f721ab2260b407c58ec8dbb5f29c/tests/isolation_provider/base.py#L24-L27) in another [PR](https://github.com/freedomofpress/dangerzone/pull/769). I suspect it is not failing in its current use since [the other `skipif` condition](https://github.com/freedomofpress/dangerzone/blob/9bb1993e7768f721ab2260b407c58ec8dbb5f29c/tests/isolation_provider/base.py#L28) is checked and matches first.
