### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/check_push.yml
+++ b/.github/workflows/check_push.yml
@@ -11,7 +11,7 @@ jobs:
         version: bookworm
       steps:
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: prevent fixup commits
           run: |
             git fetch origin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     env:
       DUMMY_CONVERSION: 1
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - run: pip install poetry
@@ -33,8 +33,8 @@ jobs:
     env:
       DUMMY_CONVERSION: 1
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - run: pip install poetry
@@ -50,9 +50,9 @@ jobs:
       version: bookworm
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
@@ -75,7 +75,7 @@ jobs:
               run --dev --no-gui ./dangerzone/install/linux/build-deb.py
 
       - name: Upload Dangerzone .deb
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dangerzone.deb
           path: "deb_dist/dangerzone_*_all.deb"
@@ -107,14 +107,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: Download Dangerzone .deb
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dangerzone.deb
           path: "deb_dist/"
@@ -171,7 +171,7 @@ jobs:
           - version: "39"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build dev environment
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install container build dependencies
         run: sudo apt install pipx && pipx install poetry
       - name: Build container image
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # NOTE: Scan first without failing, else we won't be able to read the scan
       # report.
       - name: Scan application (no fail)

--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download container image for the latest release
         run: |
           VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | jq -r '.tag_name')
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Checkout the latest released tag


### PR DESCRIPTION
The `checkout`, `setup-python`, `upload-artifact` and `download-artifact` actions [produce warnings](https://github.com/freedomofpress/dangerzone/actions/runs/8608232242/job/23600344837) about deprecated Node.js 16:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.


All the actions add support for Node.js 20 in a new version:

- [`checkout` v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)
- [`setup-python` v5.0.0](https://github.com/actions/setup-python/releases/tag/v5.0.0)
- [`upload-artifact` v4](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new)
- [`download-artifact` v4](https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new)

`upload-artifact` and `download-artifact` have breaking changes [[1](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes), [2](https://github.com/actions/download-artifact?tab=readme-ov-file#breaking-changes)] in the new versions, but AFAICT they do not affect dangerzone workflows :crossed_fingers: 
