### PR TITLE
Handle various termination scenarios of the conversion process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -y git make python3 python3-poetry --no-install-recommends
-            poetry install --no-ansi --only lint
+            poetry install --no-ansi --only lint,test
       - run:
           name: Run linters to enforce code style
           command: poetry run make lint

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -69,7 +69,7 @@ class IsolationProvider(ABC):
         self.progress_callback = progress_callback
         document.mark_as_converting()
         try:
-            conversion_proc = self.start_doc_to_pixels_proc()
+            conversion_proc = self.start_doc_to_pixels_proc(document)
             with tempfile.TemporaryDirectory() as t:
                 Path(f"{t}/pixels").mkdir()
                 self.doc_to_pixels(document, t, conversion_proc)
@@ -192,7 +192,7 @@ class IsolationProvider(ABC):
         return armor_start + conversion_string + armor_end
 
     @abstractmethod
-    def start_doc_to_pixels_proc(self) -> subprocess.Popen:
+    def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
         pass
 
 

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -195,6 +195,13 @@ class IsolationProvider(ABC):
     def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
         pass
 
+    @abstractmethod
+    def terminate_doc_to_pixels_proc(
+        self, document: Document, p: subprocess.Popen
+    ) -> None:
+        """Terminate gracefully the process started for the doc-to-pixels phase."""
+        pass
+
 
 # From global_common:
 

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -251,7 +251,7 @@ class Container(IsolationProvider):
             )
             shutil.move(container_output_filename, document.output_filename)
 
-    def start_doc_to_pixels_proc(self) -> subprocess.Popen:
+    def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
         # Convert document to pixels
         command = [
             "/usr/bin/python3",

--- a/dangerzone/isolation_provider/dummy.py
+++ b/dangerzone/isolation_provider/dummy.py
@@ -74,7 +74,7 @@ class Dummy(IsolationProvider):
     ) -> None:
         pass
 
-    def start_doc_to_pixels_proc(self) -> subprocess.Popen:
+    def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
         return subprocess.Popen("True")
 
     def get_max_parallel_conversions(self) -> int:

--- a/dangerzone/isolation_provider/dummy.py
+++ b/dangerzone/isolation_provider/dummy.py
@@ -77,5 +77,10 @@ class Dummy(IsolationProvider):
     def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
         return subprocess.Popen("True")
 
+    def terminate_doc_to_pixels_proc(
+        self, document: Document, p: subprocess.Popen
+    ) -> None:
+        pass
+
     def get_max_parallel_conversions(self) -> int:
         return 1

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -51,7 +51,7 @@ class Qubes(IsolationProvider):
     def get_max_parallel_conversions(self) -> int:
         return 1
 
-    def start_doc_to_pixels_proc(self) -> subprocess.Popen:
+    def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
         dev_mode = getattr(sys, "dangerzone_dev", False) == True
         if dev_mode:
             # Use dz.ConvertDev RPC call instead, if we are in development mode.

--- a/tests/isolation_provider/base.py
+++ b/tests/isolation_provider/base.py
@@ -37,7 +37,7 @@ class IsolationProviderTest:
         provider.progress_callback = mocker.MagicMock()
         doc = Document(pdf_11k_pages)
 
-        p = provider.start_doc_to_pixels_proc()
+        p = provider.start_doc_to_pixels_proc(doc)
         with pytest.raises(errors.ConverterProcException):
             provider.doc_to_pixels(doc, tmpdir, p)
             assert provider.get_proc_exception(p) == errors.MaxPagesException
@@ -54,7 +54,7 @@ class IsolationProviderTest:
             "dangerzone.conversion.errors.MAX_PAGES", 1
         )  # sample_doc has 4 pages > 1
         doc = Document(sample_doc)
-        p = provider.start_doc_to_pixels_proc()
+        p = provider.start_doc_to_pixels_proc(doc)
         with pytest.raises(errors.MaxPagesException):
             provider.doc_to_pixels(doc, tmpdir, p)
 
@@ -67,10 +67,12 @@ class IsolationProviderTest:
         tmpdir: str,
     ) -> None:
         provider.progress_callback = mocker.MagicMock()
-        p = provider.start_doc_to_pixels_proc()
+        doc = Document(sample_bad_width)
+        p = provider.start_doc_to_pixels_proc(doc)
         with pytest.raises(errors.MaxPageWidthException):
-            provider.doc_to_pixels(Document(sample_bad_width), tmpdir, p)
+            provider.doc_to_pixels(doc, tmpdir, p)
 
-        p = provider.start_doc_to_pixels_proc()
+        doc = Document(sample_bad_height)
+        p = provider.start_doc_to_pixels_proc(doc)
         with pytest.raises(errors.MaxPageHeightException):
-            provider.doc_to_pixels(Document(sample_bad_height), tmpdir, p)
+            provider.doc_to_pixels(doc, tmpdir, p)

--- a/tests/isolation_provider/test_container.py
+++ b/tests/isolation_provider/test_container.py
@@ -1,12 +1,17 @@
 import itertools
 import json
+import os
+import subprocess
+import time
 from typing import Any, Dict
 
 import pytest
 from pytest_mock import MockerFixture
 
 from dangerzone.document import Document
+from dangerzone.isolation_provider import base
 from dangerzone.isolation_provider.container import Container
+from dangerzone.isolation_provider.qubes import is_qubes_native_conversion
 
 # XXX Fixtures used in abstract Test class need to be imported regardless
 from .. import (
@@ -17,7 +22,7 @@ from .. import (
     sanitized_text,
     uncommon_text,
 )
-from .base import IsolationProviderTest
+from .base import IsolationProviderTermination, IsolationProviderTest
 
 
 @pytest.fixture
@@ -25,5 +30,41 @@ def provider() -> Container:
     return Container()
 
 
+class ContainerWait(Container):
+    """Container isolation provider that blocks until the container has started."""
+
+    def exec_container(self, *args, **kwargs):  # type: ignore [no-untyped-def]
+        # Check every 100ms if a container with the expected name has showed up.
+        # Else, closing the file descriptors may not work.
+        name = kwargs["name"]
+        runtime = self.get_runtime()
+        p = super().exec_container(*args, **kwargs)
+        for i in range(50):
+            containers = subprocess.run(
+                [runtime, "ps"], capture_output=True
+            ).stdout.decode()
+            if name in containers:
+                return p
+            time.sleep(0.1)
+
+        raise RuntimeError(f"Container {name} did not start within 5 seconds")
+
+
+@pytest.fixture
+def provider_wait() -> ContainerWait:
+    return ContainerWait()
+
+
 class TestContainer(IsolationProviderTest):
+    pass
+
+
+@pytest.mark.skipif(
+    os.environ.get("DUMMY_CONVERSION", False),
+    reason="cannot run for dummy conversions",
+)
+@pytest.mark.skipif(
+    is_qubes_native_conversion(), reason="Qubes native conversion is enabled"
+)
+class TestContainerTermination(IsolationProviderTermination):
     pass

--- a/tests/isolation_provider/test_dummy.py
+++ b/tests/isolation_provider/test_dummy.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+
+import pytest
+from pytest_mock import MockerFixture
+
+from dangerzone.conversion import errors
+from dangerzone.document import Document
+from dangerzone.isolation_provider.base import IsolationProvider
+from dangerzone.isolation_provider.dummy import Dummy
+
+from .base import IsolationProviderTermination, IsolationProviderTest
+
+
+class DummyWait(Dummy):
+    """Dummy isolation provider that spawns a blocking process."""
+
+    def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
+        return subprocess.Popen(
+            ["python3"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def terminate_doc_to_pixels_proc(
+        self, document: Document, p: subprocess.Popen
+    ) -> None:
+        p.terminate()
+
+
+@pytest.fixture
+def provider_wait() -> DummyWait:
+    return DummyWait()
+
+
+@pytest.mark.skipif(
+    os.environ.get("DUMMY_CONVERSION", False) == False,
+    reason="can only run for dummy conversions",
+)
+class TestDummyTermination(IsolationProviderTermination):
+
+    def test_failed(
+        self,
+        provider_wait: IsolationProvider,
+        mocker: MockerFixture,
+    ) -> None:
+        mocker.patch.object(
+            provider_wait,
+            "get_proc_exception",
+            return_value=errors.DocFormatUnsupported(),
+        )
+        super().test_failed(provider_wait, mocker)

--- a/tests/isolation_provider/test_qubes.py
+++ b/tests/isolation_provider/test_qubes.py
@@ -1,3 +1,5 @@
+import os
+import pathlib
 import signal
 import subprocess
 import time
@@ -9,7 +11,11 @@ from pytest_mock import MockerFixture
 from dangerzone.conversion import errors
 from dangerzone.document import Document
 from dangerzone.isolation_provider.base import IsolationProvider
-from dangerzone.isolation_provider.qubes import Qubes, running_on_qubes
+from dangerzone.isolation_provider.qubes import (
+    Qubes,
+    is_qubes_native_conversion,
+    running_on_qubes,
+)
 
 # XXX Fixtures used in abstract Test class need to be imported regardless
 from .. import (
@@ -20,12 +26,44 @@ from .. import (
     sanitized_text,
     uncommon_text,
 )
-from .base import IsolationProviderTest
+from .base import IsolationProviderTermination, IsolationProviderTest
 
 
 @pytest.fixture
 def provider() -> Qubes:
     return Qubes()
+
+
+class QubesWait(Qubes):
+    """Qubes isolation provider that blocks until the disposable qube has started."""
+
+    def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
+        # Check every 100ms if the disposable qube has started. Qubes gives us no
+        # way to figure this out, but `qrexec-client-vm` has an interesting
+        # property. It will start a vchan server **only** once the disposable qube
+        # has started (i.e., on MSG_SERVICE_CONNECT) [1]
+        #
+        # While `qrexec-client-vm` does not report this either, we can snoop on its
+        # open file descriptors, and see when it opens the `/dev/xen` character
+        # devices. This is super flaky and probably subject to race conditions, but
+        # since it's test code, we can live with it.
+        #
+        # [1]: https://www.qubes-os.org/doc/qrexec-internals/#domx-invoke-execution-of-qubes-service-qubesservice-in-domy
+        proc = super().start_doc_to_pixels_proc(document)
+        for i in range(300):
+            for p in pathlib.Path(f"/proc/{proc.pid}/fd").iterdir():
+                if str(p.resolve()).startswith("/dev/xen"):
+                    # The `qrexec-client-vm` process has opened a `/dev/xen` character
+                    # device. We can now yield control back to the caller.
+                    return proc
+            time.sleep(0.1)
+
+        raise RuntimeError(f"Disposable qube did not start within 30 seconds")
+
+
+@pytest.fixture
+def provider_wait() -> QubesWait:
+    return QubesWait()
 
 
 @pytest.mark.skipif(not running_on_qubes(), reason="Not on a Qubes system")
@@ -53,3 +91,14 @@ class TestQubes(IsolationProviderTest):
             doc = Document(sample_doc)
             provider.doc_to_pixels(doc, tmpdir, proc)
             assert provider.get_proc_exception(proc) == errors.QubesQrexecFailed
+
+
+@pytest.mark.skipif(
+    os.environ.get("DUMMY_CONVERSION", False),
+    reason="cannot run for dummy conversions",
+)
+@pytest.mark.skipif(
+    not is_qubes_native_conversion(), reason="Qubes native conversion is not enabled"
+)
+class TestQubesTermination(IsolationProviderTermination):
+    pass


### PR DESCRIPTION
The conversion process can encounter various issues during its lifetime, that can affect its termination. For example, it may fail early, linger for a little while, get stuck, etc. Previously, we assumed that any such scenario would simply be resolved with a 3-second wait timeout, provided that the conversion has already finished successfully. Turns out that this is not the case, and we have several users who reported timeout issues (see #749).

In this PR, we replace these arbitrary timeouts with some termination logic, that tries to terminate first the process gracefully, and if it doesn't comply, forcefully. This seems simple enough, but in  practice we have the following issues:
1. Killing the spawned container process does not always mean that the container will be killed. Take Docker for example, where the spawned process is connected to the Docker daemon. The Docker daemon is then responsible for starting the container.
2. Killing the disposable qube is not possible out of the box in vanilla Qubes. Our best bet is to close its standard streams (see https://github.com/freedomofpress/dangerzone/issues/563#issuecomment-2034803232).

Due to the finicky nature of terminating our conversion processes, and because we haven't 100% nailed the underlying reason for #749, this PR adds cross-platform tests for virtually every termination scenario that can occur. The end goal is to never let users see another timeout exception again, no matter the underlying cause.

> [!NOTE]
> This PR does not cover the termination scenarios of the pixels to PDF conversion process. That's because we're working on removing the need for a container in that phase (see #748).

Fixes #749 
Refs #563 