### PR TITLE
Set the desktop filename of the Qt application

### DIFF
--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -56,6 +56,21 @@ class Application(QtWidgets.QApplication):
         with open(get_resource_path("dangerzone.css"), "r") as f:
             style = f.read()
         self.setStyleSheet(style)
+
+        # Needed under certain windowing systems to match the application to the
+        # desktop entry in order to display the correct application name and icon
+        # and to allow identifying windows that belong to the application (e.g.
+        # under Wayland it sets the correct app ID). The value is the name of the
+        # Dangerzone .desktop file.
+        self.setDesktopFileName("press.freedom.dangerzone")
+
+        # In some combinations of window managers and OSes, if we don't set an
+        # application name, then the window manager may report it as `python3` or
+        # `__init__.py`. Always set this to `dangerzone`, which corresponds to the
+        # executable name as well.
+        # See: https://github.com/freedomofpress/dangerzone/issues/402
+        self.setApplicationName("dangerzone")
+
         self.original_event = self.event
 
         def monkeypatch_event(arg__1: QtCore.QEvent) -> bool:


### PR DESCRIPTION
Currently, the app ID of the Dangerzone GUI application when running under Wayland is `python3`, which is not very useful if one wants to automate some action related to the Dangerzone application window (e.g. to always start Dangerzone window in floating mode under Sway WM; to inspect the app ID values of currently running application windows under sway run `swaymsg -t get_tree`).

Setting the desktop filename property also sets the app ID of the application under Wayland. According to [Qt documentation](https://doc.qt.io/qt-6/qguiapplication.html#desktopFileName-prop), the property value should be the name of the application's .desktop file but without the extension.

Qt documentation also states:

> This property gives a precise indication of what desktop entry > represents the application and it is needed by the windowing system to retrieve such information without resorting to imprecise heuristics.

Therefore I also think that setting this property is needed to display the correct application name and icon (taken from the .desktop entry) when running under certain windowing systems (like Wayland) (see also #402, after testing locally under Gnome I believe this should fix it).

### PR questions

According to [Qt 5 docs](https://doc.qt.io/qt-5/qguiapplication.html#desktopFileName-prop) this property was introduced in Qt 5.7. IIUC [PySide2](https://pypi.org/project/PySide2/) is Qt 5.12+, so it should be ok to set it without wrapping it in `try/except AttributeError`? Please correct me if I am mistaken.

Also, I am not sure if perhaps [`Application`'s `__init__`](https://github.com/freedomofpress/dangerzone/blob/7c4e62954f4ee71726de0a23655c8f791f05f290/dangerzone/gui/__init__.py#L55) is the more suitable/correct place for setting it. Please let me know if it should be moved there.