### PR TITLE
ci: Bump PySide6 version in Fedora end-user envs

### DIFF
--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -17,6 +17,7 @@ DEFAULT_DEV = False
 DEFAULT_SHOW_DOCKERFILE = False
 DEFAULT_DOWNLOAD_PYSIDE6 = False
 
+PYSIDE6_VERSION = "6.6.3.1"
 PYSIDE6_RPM = "python3-pyside6-{pyside6_version}-1.fc{fedora_version}.x86_64.rpm"
 PYSIDE6_URL = (
     "https://packages.freedom.press/yum-tools-prod/dangerzone/f{fedora_version}/%s"
@@ -309,8 +310,8 @@ class PySide6Manager:
     """Provision PySide6 RPMs in our Dangerzone environments.
 
     This class holds all the logic around checking and downloading PySide RPMs. It can
-    detect the PySide6 version that the project requires, check if an RPM is present
-    under "/dist", and download it.
+    check if the required RPM version is present under "/dist", and optionally download
+    it.
     """
 
     def __init__(self, distro_name, distro_version):
@@ -320,22 +321,9 @@ class PySide6Manager:
         self.distro_version = distro_version
 
     @property
-    @functools.lru_cache
     def version(self):
-        """Retrieve the PySide6 version from poetry.lock.
-
-        Read the poetry.lock file, and grep the version of the PySide6 library. The
-        results of this method call are cached, so we can call it repeatedly without any
-        performance cost.
-        """
-        # FIXME: I don't like regexes, but problem is that `tomllib` is not present in
-        # Python < 3.11. So, since we don't want to rely on an external library yet, we
-        # have to resort to regexes. Note that the regex we choose uses Shiboken6,
-        # mainly because the PySide6 package and its version are in different lines.
-        with open(git_root() / "poetry.lock") as f:
-            toml = f.read()
-            match = re.search(r'^shiboken6 = "([\d.]+)"$', toml, re.MULTILINE)
-            return match.groups()[0]
+        """The version of the PySide6 RPM."""
+        return PYSIDE6_VERSION
 
     @property
     def rpm_name(self):


### PR DESCRIPTION
Our end-user Fedora environments, that we create for testing how Dangerzone would operate on a clean Fedora system, require PySide6 to be installed. This package is not available from the official Fedora repos yet.

We have a way instead to check the poetry.lock file, grab the latest PySide6 version from there, and install it from a URL. This is no longer necessary, now that PySide6 6.7.0 will soon be available in all stable Fedora releases. Since the last release maintained by FPF will be 6.6.3.1, we should pin this version in our env.py script. This way, we can bump poetry.lock independently, and let Windows/macOS users get different versions.

Refs freedomofpress/maint-dangerzone-pyside6#5