### PR TITLE
Add support for Ubuntu 24.04 (Noble) and Fedora 40

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,33 @@ jobs:
             ./dev_scripts/env.py --distro ubuntu --version 20.04 run --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
+  ci-fedora-40:
+    machine:
+      image: ubuntu-2004:202111-01
+    steps:
+      - checkout
+      - run: *install-podman
+
+      - run:
+          name: Prepare cache directory
+          command: |
+            sudo mkdir -p /caches
+            sudo chown -R $USER:$USER /caches
+      - run: *calculate-cache-key
+      - restore_cache: *restore-cache
+      - run: *copy-image
+
+      - run:
+          name: Prepare Dangerzone environment
+          command: |
+            ./dev_scripts/env.py --distro fedora --version 40 build-dev
+
+      - run:
+          name: Run CI tests
+          command: |
+            ./dev_scripts/env.py --distro fedora --version 40 run --dev \
+                bash -c 'cd dangerzone; poetry run make test'
+
   ci-fedora-39:
     machine:
       image: ubuntu-2004:202111-01
@@ -526,6 +553,19 @@ jobs:
       - run: *copy-image
       - run: *build-deb
 
+  build-fedora-40:
+    docker:
+      - image: fedora:40
+    resource_class: medium+
+    steps:
+      - run: *install-dependencies-rpm
+      - checkout
+      - run: *calculate-cache-key
+      - restore_cache: *restore-cache
+      - run: *copy-image
+      - run: *build-rpm
+      - run: *build-rpm-qubes
+
   build-fedora-39:
     docker:
       - image: fedora:39
@@ -584,6 +624,9 @@ workflows:
       - ci-debian-bullseye:
           requires:
             - build-container-image
+      - ci-fedora-40:
+          requires:
+            - build-container-image
       - ci-fedora-39:
           requires:
             - build-container-image
@@ -613,6 +656,9 @@ workflows:
           requires:
             - build-container-image
       - build-debian-bookworm:
+          requires:
+            - build-container-image
+      - build-fedora-40:
           requires:
             - build-container-image
       - build-fedora-39:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,33 @@ jobs:
           command: |
             poetry run make test
 
+  ci-ubuntu-noble:
+    machine:
+      image: ubuntu-2004:202111-01
+    steps:
+      - checkout
+      - run: *install-podman
+
+      - run:
+          name: Prepare cache directory
+          command: |
+            sudo mkdir -p /caches
+            sudo chown -R $USER:$USER /caches
+      - run: *calculate-cache-key
+      - restore_cache: *restore-cache
+      - run: *copy-image
+
+      - run:
+          name: Prepare Dangerzone environment
+          command: |
+            ./dev_scripts/env.py --distro ubuntu --version 24.04 build-dev
+
+      - run:
+          name: Run CI tests
+          command: |
+            ./dev_scripts/env.py --distro ubuntu --version 24.04 run --dev \
+                bash -c 'cd dangerzone; poetry run make test'
+
   ci-ubuntu-mantic:
     machine:
       image: ubuntu-2004:202111-01
@@ -414,6 +441,18 @@ jobs:
             ./dev_scripts/env.py --distro debian --version bullseye run --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
+  build-ubuntu-noble:
+    docker:
+      - image: ubuntu:24.04
+    resource_class: medium+
+    steps:
+      - run: *install-dependencies-deb
+      - checkout
+      - run: *calculate-cache-key
+      - restore_cache: *restore-cache
+      - run: *copy-image
+      - run: *build-deb
+
   build-ubuntu-mantic:
     docker:
       - image: ubuntu:23.10
@@ -524,6 +563,9 @@ workflows:
       - convert-test-docs:
           requires:
             - build-container-image
+      - ci-ubuntu-noble:
+          requires:
+            - build-container-image
       - ci-ubuntu-mantic:
           requires:
             - build-container-image
@@ -548,6 +590,13 @@ workflows:
       - ci-fedora-38:
           requires:
             - build-container-image
+      # FIXME: Currently disabled because `stdeb` does not work with Python
+      # 3.12, which is the default in Ubuntu Noble. See also:
+      # https://github.com/freedomofpress/dangerzone/issues/773
+      #
+      #- build-ubuntu-noble:
+      #    requires:
+      #      - build-container-image
       - build-ubuntu-mantic:
           requires:
             - build-container-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
           - target: ubuntu-23.10
             distro: ubuntu
             version: "23.10"
+          - target: ubuntu-24.04
+            distro: ubuntu
+            version: "24.04"
           - target: debian-bullseye
             distro: debian
             version: bullseye
@@ -169,6 +172,7 @@ jobs:
         include:
           - version: "38"
           - version: "39"
+          - version: "40"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## Unreleased
 
+### Added
+
+- Platform support: Ubuntu 24.04 and Fedora 40 ([issue #762](https://github.com/freedomofpress/dangerzone/issues/762))
+
 ## Dangerzone 0.6.0
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,12 +9,14 @@ On Linux, Dangerzone uses [Podman](https://podman.io/) instead of Docker Desktop
 an isolated environment. It will be installed automatically when installing Dangerzone.
 
 Dangerzone is available for:
+- Ubuntu 24.04 (noble)
 - Ubuntu 23.10 (mantic)
 - Ubuntu 22.04 (jammy)
 - Ubuntu 20.04 (focal)
 - Debian 13 (trixie)
 - Debian 12 (bookworm)
 - Debian 11 (bullseye)
+- Fedora 40
 - Fedora 39
 - Fedora 38
 - Qubes OS (beta support)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -115,7 +115,7 @@ and newer platforms, we have to do the following:
   - [ ] Run the Dangerzone tests.
   - [ ] Create and run an app bundle.
   - [ ] Test some QA scenarios (see [Scenarios](#Scenarios) below).
-- [ ] Create a test build in the most recent Ubuntu LTS platform (Ubuntu 22.04
+- [ ] Create a test build in the most recent Ubuntu LTS platform (Ubuntu 24.04
   as of writing this) and make sure it works:
   - [ ] Create a new development environment with Poetry.
   - [ ] Build the container image and ensure the development environment uses
@@ -123,7 +123,7 @@ and newer platforms, we have to do the following:
   - [ ] Run the Dangerzone tests.
   - [ ] Create a .deb package and install it system-wide.
   - [ ] Test some QA scenarios (see [Scenarios](#Scenarios) below).
-- [ ] Create a test build in the most recent Fedora platform (Fedora 39 as of
+- [ ] Create a test build in the most recent Fedora platform (Fedora 40 as of
   writing this) and make sure it works:
   - [ ] Create a new development environment with Poetry.
   - [ ] Build the container image and ensure the development environment uses

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -564,6 +564,8 @@ class Env:
             elif self.distro == "ubuntu" and self.version in (
                 "23.10",
                 "mantic",
+                "24.04",
+                "noble",
             ):
                 install_deps = (
                     DOCKERFILE_UBUNTU_REM_USER + DOCKERFILE_BUILD_DEV_DEBIAN_DEPS
@@ -650,6 +652,8 @@ class Env:
             elif self.distro == "ubuntu" and self.version in (
                 "23.10",
                 "mantic",
+                "24.04",
+                "noble",
             ):
                 install_deps = DOCKERFILE_UBUNTU_REM_USER + DOCKERFILE_BUILD_DEBIAN_DEPS
             package = f"dangerzone_{version}-1_all.deb"

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -902,6 +902,11 @@ class QAUbuntu2310(QADebianBased):
     VERSION = "23.10"
 
 
+class QAUbuntu2404(QADebianBased):
+    DISTRO = "ubuntu"
+    VERSION = "24.04"
+
+
 class QAFedora(QALinux):
     """Base class for Fedora distros.
 
@@ -917,6 +922,10 @@ class QAFedora(QALinux):
         self.container_run(
             "./dangerzone/install/linux/build-rpm.py",
         )
+
+
+class QAFedora40(QAFedora):
+    VERSION = "40"
 
 
 class QAFedora39(QAFedora):

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -44,7 +44,7 @@ and newer platforms, we have to do the following:
   - [ ] Run the Dangerzone tests.
   - [ ] Create and run an app bundle.
   - [ ] Test some QA scenarios (see [Scenarios](#Scenarios) below).
-- [ ] Create a test build in the most recent Ubuntu LTS platform (Ubuntu 22.04
+- [ ] Create a test build in the most recent Ubuntu LTS platform (Ubuntu 24.04
   as of writing this) and make sure it works:
   - [ ] Create a new development environment with Poetry.
   - [ ] Build the container image and ensure the development environment uses
@@ -52,7 +52,7 @@ and newer platforms, we have to do the following:
   - [ ] Run the Dangerzone tests.
   - [ ] Create a .deb package and install it system-wide.
   - [ ] Test some QA scenarios (see [Scenarios](#Scenarios) below).
-- [ ] Create a test build in the most recent Fedora platform (Fedora 39 as of
+- [ ] Create a test build in the most recent Fedora platform (Fedora 40 as of
   writing this) and make sure it works:
   - [ ] Create a new development environment with Poetry.
   - [ ] Build the container image and ensure the development environment uses


### PR DESCRIPTION
This PR adds support for Ubuntu 24.04 (Noble) and Fedora 40. Code-wise, thankfully, we don't need to make a change, but we still need to extend our CI scripts.

Unfortunately, we are unable to build Dangerzone .deb packages in Ubuntu Noble. Still, this issue does not really bite us yet, since we build production .deb packages in Debian Bookworm, and our tests already cover that.

> [!NOTE]
> This PR should be merged after #778.

Refs #773
Closes #762