### PR TITLE
Fix remaining issues for 0.6.1

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,6 +4,9 @@
 
 Install dependencies:
 
+<table>
+  <tr>
+      <td>
 <details>
   <summary><i>:memo: Expand this section if you are on Ubuntu 22.04 (Jammy).</i></summary>
   </br>
@@ -20,10 +23,15 @@ Install dependencies:
   sudo cp ./dev_scripts/apt-tools-prod.pref /etc/apt/preferences.d/
   ```
 
+  The `conmon` package provided in the above repo was built with the
+  following [instructions](https://github.com/freedomofpress/maint-dangerzone-conmon/tree/ubuntu/jammy/fpf).
   Alternatively, you can install a `conmon` version higher than `v2.0.25` from
   any repo you prefer.
 
 </details>
+    </td>
+  </tr>
+</table>
 
 ```sh
 sudo apt install -y podman dh-python build-essential fakeroot make libqt6gui6 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ### Fixed
 
-- Fix "Timeout after 3 seconds" errors ([issue #749](https://github.com/freedomofpress/dangerzone/issues/749))
+- Handle timeout errors (`"Timeout after 3 seconds"`) more gracefully ([issue #749](https://github.com/freedomofpress/dangerzone/issues/749))
+- Make Dangerzone work in macOS versions prior to Ventura (13), thanks to [@maltfield](https://github.com/maltfield) ([issue #471](https://github.com/freedomofpress/dangerzone/issues/471))
 - Make OCR work again in Qubes Fedora 38 templates ([issue #737](https://github.com/freedomofpress/dangerzone/issues/737))
 - Make .svg / .bmp files selectable when browsing files via the Dangerzone GUI ([#722](https://github.com/freedomofpress/dangerzone/pull/722))
 - Linux: Show the proper application name and icon for Dangerzone, in the user's window manager, thanks to [@naglis](https://github.com/naglis) ([issue #402](https://github.com/freedomofpress/dangerzone/issues/402))
@@ -25,7 +26,9 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ### Changed
 
-- Use the newest reimplementation of the PyMuPDF rendering enging (`fitz`) ([issue #700](https://github.com/freedomofpress/dangerzone/issues/700))
+- Sign our release assets with the Dangerzone signing key, and provide
+  instructions to end-users ([issue #761](https://github.com/freedomofpress/dangerzone/issues/761)
+- Use the newest reimplementation of the PyMuPDF rendering engine (`fitz`) ([issue #700](https://github.com/freedomofpress/dangerzone/issues/700))
 - Development: Build Dangerzone using the latest Wix 3.14 release ([#746](https://github.com/freedomofpress/dangerzone/pull/746)
 
 ## Dangerzone 0.6.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,9 @@ Dangerzone is available for:
 
 ### Ubuntu, Debian
 
+<table>
+  <tr>
+    <td>
 <details>
   <summary><i>:memo: Expand this section if you are on Ubuntu 20.04 (Focal).</i></summary>
   </br>
@@ -50,6 +53,9 @@ Dangerzone is available for:
   sudo apt-get install python-all -y
   ```
 </details>
+    </td>
+  </tr>
+</table>
 
 Add our repository following these instructions:
 
@@ -80,6 +86,9 @@ sudo apt update
 sudo apt install -y dangerzone
 ```
 
+<table>
+  <tr>
+    <td>
 <details>
   <summary><i>:memo: Expand this section for a security notice on third-party Debian repos</i></summary>
   </br>
@@ -95,6 +104,9 @@ sudo apt install -y dangerzone
   run as `root` during the installation phase, so they need to place some trust
   on our signed Debian packages. This holds for any third-party Debian repo.
 </details>
+    </td>
+  </tr>
+</table>
 
 ### Fedora
 
@@ -108,8 +120,12 @@ sudo dnf install dangerzone
 
 ##### Verifying Dangerzone GPG key
 
+<table>
+  <tr>
+    <td>
 <details>
 <summary>Importing GPG key 0x22604281: ... Is this ok [y/N]:</summary>
+</br>
 
 After some minutes of running the above command (depending on your internet speed) you'll be asked to confirm the fingerprint of our signing key. This is to make sure that in the case our servers are compromised your computer stays safe. It should look like this:
 
@@ -130,8 +146,10 @@ The `Fingerprint` should be `DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281`.
 
 After confirming that it matches, type `y` (for yes) and the installation should proceed.
 
-
 </details>
+    </td>
+  </tr>
+</table>
 
 ### Qubes OS
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,6 +57,26 @@ Dangerzone is available for:
   </tr>
 </table>
 
+<table>
+  <tr>
+    <td>
+<details>
+  <summary><i>:information_source: Backport notice for Ubuntu 24.04 (Noble) users regarding the <code>conmon</code> package</i></summary>
+  </br>
+
+  The `conmon` version that Podman uses and Ubuntu Jammy ships, has a bug
+  that gets triggered by Dangerzone
+  (more details in https://github.com/freedomofpress/dangerzone/issues/685).
+  To fix this, we provide our own `conmon` package through our APT repo, which
+  was built with the following [instructions](https://github.com/freedomofpress/maint-dangerzone-conmon/tree/ubuntu/jammy/fpf).
+  This package is essentially a backport of the `conmon` package
+  [provided](https://packages.debian.org/source/oldstable/conmon) by Debian
+  Bullseye.
+</details>
+    </td>
+  </tr>
+</table>
+
 Add our repository following these instructions:
 
 Download the GPG key for the repo:
@@ -109,6 +129,23 @@ sudo apt install -y dangerzone
 </table>
 
 ### Fedora
+
+<table>
+  <tr>
+    <td>
+<details>
+  <summary><i>:information_source: Backport notice for Fedora users regarding the <code>python3-pyside6</code> package</i></summary>
+  </br>
+
+  Fedora 39+ onwards does not provide official Python bindings for Qt. For
+  this reason, we provide our own `python3-pyside6` package (see
+  [build instructions](https://github.com/freedomofpress/maint-dangerzone-pyside6))
+  from our YUM repo. For a deeper dive on this subject, you may read
+  [this issue](https://github.com/freedomofpress/dangerzone/issues/211#issuecomment-1827777122).
+</details>
+    </td>
+  </tr>
+</table>
 
 Type the following commands in a terminal:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -203,3 +203,96 @@ pass it a file to sanitize.
 ## Build from source
 
 If you'd like to build from source, follow the [build instructions](BUILD.md).
+
+## Verifying PGP signatures
+
+You can verify that the package you download is legitimate and hasn't been
+tampered with by verifying its PGP signature. For Windows and macOS, this step
+is optional and provides defense in depth: the Dangerzone binaries include
+operating system-specific signatures, and you can just rely on those alone if
+you'd like.
+
+### Obtaining signing key
+
+Our binaries are signed with a PGP key owned by Freedom of the Press Foundation:
+* Name: Dangerzone Release Key
+* PGP public key fingerprint `DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281`
+  - You can download this key [from the keys.openpgp.org keyserver](https://keys.openpgp.org/vks/v1/by-fingerprint/DE28AB241FA48260FAC9B8BAA7C9B38522604281).
+
+_(You can also cross-check this fingerprint with the fingerprint in our
+[Mastodon page](https://fosstodon.org/@dangerzone) and the fingerprint in the
+footer of our [official site](https://dangerzone.rocks))_
+
+You must have GnuPG installed to verify signatures. For macOS you probably want
+[GPGTools](https://gpgtools.org/), and for Windows you probably want
+[Gpg4win](https://www.gpg4win.org/).
+
+### Signatures
+
+Our [GitHub Releases page](https://github.com/freedomofpress/dangerzone/releases)
+hosts the following files:
+* Windows installer (`Dangerzone-<version>.msi`)
+* macOS archives (`Dangerzone-<version>-<arch>.dmg`)
+* Container image (`container.tar.gz`)
+* Source package (`dangerzone-<version>.tar.gz`)
+
+All these files are accompanied by signatures (as `.asc` files). We'll explain
+how to verify them below, using `0.6.1` as an example.
+
+### Verifying
+
+Once you have imported the Dangerzone release key into your GnuPG keychain,
+downloaded the binary and ``.asc`` signature, you can verify the binary in a
+terminal like this:
+
+For the Windows binary:
+
+```
+gpg --verify Dangerzone-0.6.1.msi.asc Dangerzone-0.6.1.msi
+```
+
+For the macOS binaries (depending on your architecture):
+
+```
+gpg --verify Dangerzone-0.6.1-arm64.dmg.asc Dangerzone-0.6.1-arm64.dmg
+gpg --verify Dangerzone-0.6.1-i686.dmg.asc Dangerzone-0.6.1-i686.dmg
+```
+
+For the container image:
+
+```
+gpg --verify container.tar.gz.asc container.tar.gz
+```
+
+We also hash all the above files with SHA-256, and provide a list of these
+hashes as a separate file (`checksums-0.6.1.txt`). This file is signed as well,
+and the signature is embedded within it. You can download this file and verify
+it with:
+
+```
+gpg --verify checksums.txt
+```
+
+The expected output looks like this:
+
+```
+gpg: Signature made Mon Apr 22 09:29:22 2024 PDT
+gpg:                using RSA key 04CABEB5DD76BACF2BD43D2FF3ACC60F62EA51CB
+gpg: Good signature from "Dangerzone Release Key <dangerzone-release-key@freedom.press>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: DE28 AB24 1FA4 8260 FAC9  B8BA A7C9 B385 2260 4281
+     Subkey fingerprint: 04CA BEB5 DD76 BACF 2BD4  3D2F F3AC C60F 62EA 51CB
+```
+
+If you don't see `Good signature from`, there might be a problem with the
+integrity of the file (malicious or otherwise), and you should not install the
+package.
+
+The `WARNING:` shown above, is not a problem with the package, it only means you
+haven't defined a level of "trust" for Dangerzone's PGP key.
+
+If you want to learn more about verifying PGP signatures, the guides for
+[Qubes OS](https://www.qubes-os.org/security/verifying-signatures/) and the
+[Tor Project](https://support.torproject.org/tbb/how-to-verify-signature/) may
+be useful.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -395,6 +395,9 @@ repo.
 To publish the release:
 
 - [ ] Run container scan on the produced container images (some time may have passed since the artifacts were built)
+- [ ] Collect the assets in a single directory, calculate their SHA-256 hashes, and sign them.
+  * You can use `./dev_scripts/sign-assets.py`, if you want to automate this
+    task.
 - [ ] Create a new **draft** release on GitHub and upload the macOS and Windows installers.
   * Copy the release notes text from the template at [`docs/templates/release-notes`](https://github.com/freedomofpress/dangerzone/tree/main/docs/templates/)
   * You can use `./dev_scripts/upload-asset.py`, if you want to upload an asset
@@ -404,7 +407,8 @@ To publish the release:
   **Important:** Make sure that it's the same container image as the ones that
   are shipped in other platforms (see our [Pre-release](#Pre-release) section)
 
-- [ ] Update the [Dangerzone website](https://github.com/freedomofpress/dangerzone.rocks) to link to the new installers
+- [ ] Upload the detached signatures (.asc) and checksum file.
+- [ ] Update the [Dangerzone website](https://github.com/freedomofpress/dangerzone.rocks) to link to the new installers and signatures
 - [ ] Update the brew cask release of Dangerzone with a [PR like this one](https://github.com/Homebrew/homebrew-cask/pull/116319)
 - [ ] Update version and download links in `README.md`
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -262,6 +262,7 @@ should point the user to the Qubes notifications in the top-right corner:
     https://developer.apple.com and login with the proper Apple ID.
 
 #### Releasing and Signing
+- [ ] Verify and install the latest supported Python version from [python.org](https://www.python.org/downloads/macos/)
 - [ ] Verify and checkout the git tag for this release
 - [ ] Run `poetry install`
 - [ ] Run `poetry run ./install/macos/build-app.py`; this will make `dist/Dangerzone.app`

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -187,6 +187,9 @@ CONTENT_BUILD_DEBIAN_UBUNTU = r"""## Debian/Ubuntu
 
 Install dependencies:
 
+<table>
+  <tr>
+      <td>
 <details>
   <summary><i>:memo: Expand this section if you are on Ubuntu 22.04 (Jammy).</i></summary>
   </br>
@@ -203,10 +206,15 @@ Install dependencies:
   sudo cp ./dev_scripts/apt-tools-prod.pref /etc/apt/preferences.d/
   ```
 
+  The `conmon` package provided in the above repo was built with the
+  following [instructions](https://github.com/freedomofpress/maint-dangerzone-conmon/tree/ubuntu/jammy/fpf).
   Alternatively, you can install a `conmon` version higher than `v2.0.25` from
   any repo you prefer.
 
 </details>
+    </td>
+  </tr>
+</table>
 
 ```sh
 sudo apt install -y podman dh-python build-essential fakeroot make libqt6gui6 \

--- a/dev_scripts/sign-assets.py
+++ b/dev_scripts/sign-assets.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import logging
+import pathlib
+import subprocess
+import sys
+
+log = logging.getLogger(__name__)
+
+
+DZ_ASSETS = [
+    "container.tar.gz",
+    "Dangerzone-{version}.msi",
+    "Dangerzone-{version}-arm64.dmg",
+    "Dangerzone-{version}-i686.dmg",
+]
+DZ_SIGNING_PUBKEY = "DE28AB241FA48260FAC9B8BAA7C9B38522604281"
+
+
+def setup_logging():
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def sign_asset(asset, detached=True):
+    """Sign a single Dangerzone asset using GPG.
+
+    By default, ask GPG to create a detached signature. Alternatively, ask it to include
+    the signature with the contents of the file.
+    """
+    _sign_opt = "--detach-sig" if detached else "--clearsign"
+    cmd = [
+        "gpg",
+        "--batch",
+        "--yes",
+        "--armor",
+        _sign_opt,
+        "-u",
+        DZ_SIGNING_PUBKEY,
+        str(asset),
+    ]
+    log.info(f"Signing '{asset}'")
+    log.debug(f"GPG command: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+
+def hash_assets(assets):
+    """Create a list of hashes for all the assets, mimicking the output of `sha256sum`.
+
+    Compute the SHA-256 hash of every asset, and create a line for each asset that
+    follows the format of `sha256sum`. From `man sha256sum`:
+
+        The  sums  are  computed as described in FIPS-180-2.  When checking, the input
+        should be a former output of this program.  The default mode is to print a
+        line with: checksum, a space, a character indicating input mode ('*' for
+        binary, ' ' for text or where binary is insignificant), and name for each
+        FILE.
+    """
+    checksums = []
+    for asset in assets:
+        log.info(f"Hashing '{asset}'")
+        with open(asset, "rb") as f:
+            hexdigest = hashlib.file_digest(f, "sha256").hexdigest()
+        checksums.append(f"{hexdigest}  {asset.name}")
+    return "\n".join(checksums)
+
+
+def ensure_assets_exist(assets):
+    """Ensure that assets dir exists, and that the assets are all there."""
+    dir = assets[0].parent
+    if not dir.exists():
+        raise ValueError(f"Path '{dir}' does not exist")
+    if not dir.is_dir():
+        raise ValueError(f"Path '{dir}' is not a directory")
+
+    for asset in assets:
+        if not asset.exists():
+            raise ValueError(
+                f"Expected asset with name '{asset}', but it does not exist"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog=sys.argv[0],
+        description="Dev script for signing Dangerzone assets",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help=f"look for assets with this Dangerzone version",
+    )
+    parser.add_argument(
+        "dir",
+        help=f"look for assets in this directory",
+    )
+    args = parser.parse_args()
+    setup_logging()
+
+    # Ensure that all the necessary assets exist in the provided directory.
+    log.info("> Ensuring that the required assets exist")
+    dir = pathlib.Path(args.dir)
+    assets = [dir / asset.format(version=args.version) for asset in DZ_ASSETS]
+    ensure_assets_exist(assets)
+
+    # Create a file that holds the SHA-256 hashes of the assets.
+    log.info("> Create a checksums file for our assets")
+    checksums = hash_assets(assets)
+    checksums_file = dir / f"checksums-{args.version}.txt"
+    with open(checksums_file, "w+") as f:
+        f.write(checksums)
+
+    # Sign every asset and create a detached signature (.asc) for each one of them. The
+    # sole exception is the checksums file, which embeds its signature within the
+    # file, and retains its original name.
+    log.info("> Sign all of our assets")
+    for asset in assets:
+        sign_asset(asset)
+    sign_asset(checksums_file, detached=False)
+    (dir / f"checksums-{args.version}.txt.asc").rename(checksums_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fix various issues that remain for 0.6.1:
* Add a script for hashing and signing our release assets
* Add end-user instructions about verifying these signatures
* Add a release note for installing the latest Python from Python.org on macOS
* Add some information in our docs about extra packages that will be installed in some user systems from our Linux repos (`python3-pyside6` / `conmon`)

Refs #471
Fixes #767
Closes #761

> [!NOTE]
> In order to visualize the changes for the verification instructions, reviewers can take into account the following:
> 1. I have updated our [v0.6.0 release page](https://github.com/freedomofpress/dangerzone/releases/tag/v0.6.0) with signatures and checksums.
> 2. I have sent a PR for our website (https://github.com/freedomofpress/dangerzone.rocks/pull/37), that shows how we can point to our verification instructions.