### PR TITLE
Use `exec` instead of `exec_` for Qt dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## Unreleased
 
+### Fixed
+
+- Fix a deprecation warning in PySide6, thanks to [@naglis](https://github.com/naglis) ([issue #595](https://github.com/freedomofpress/dangerzone/issues/595))
+
 ## Dangerzone 0.6.1
 
 ### Added

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -198,7 +198,7 @@ class Dialog(QtWidgets.QDialog):
         self.done(int(QtWidgets.QDialog.Rejected))
 
     def launch(self) -> int:
-        return self.exec_()
+        return self.exec()
 
 
 class Alert(Dialog):

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -205,7 +205,7 @@ class MainWindow(QtWidgets.QMainWindow):
             ok_text="Ok",
             has_cancel=False,
         )
-        update_widget.exec_()
+        update_widget.launch()
 
     def show_update_error(self) -> None:
         """Inform the user about an error during update checks"""
@@ -226,7 +226,7 @@ class MainWindow(QtWidgets.QMainWindow):
             ok_text="Close",
             has_cancel=False,
         )
-        update_widget.exec_()
+        update_widget.launch()
 
     def toggle_updates_triggered(self) -> None:
         """Change the underlying update check settings based on the user's choice."""
@@ -320,7 +320,7 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 self.dangerzone.app.exit(0)
         else:
-            accept_exit = alert_widget.exec_()
+            accept_exit = alert_widget.launch()
             if not accept_exit:
                 e.ignore()
                 return
@@ -485,7 +485,7 @@ class ContentWidget(QtWidgets.QWidget):
                 self.dangerzone,
                 message="Dangerzone does not support adding documents after the conversion has started.",
                 has_cancel=False,
-            ).exec_()
+            ).launch()
             return
 
         # Ensure all files in batch are in the same directory
@@ -495,7 +495,7 @@ class ContentWidget(QtWidgets.QWidget):
                 self.dangerzone,
                 message="Dangerzone does not support adding documents from multiple locations.\n\n The newly added documents were ignored.",
                 has_cancel=False,
-            ).exec_()
+            ).launch()
             return
 
         # Clear previously selected documents
@@ -841,7 +841,7 @@ class SettingsWidget(QtWidgets.QWidget):
         dialog.setFileMode(QtWidgets.QFileDialog.Directory)
         dialog.setOption(QtWidgets.QFileDialog.ShowDirsOnly, True)
 
-        if dialog.exec_() == QtWidgets.QFileDialog.Accepted:
+        if dialog.exec() == QtWidgets.QFileDialog.Accepted:
             selected_dir = dialog.selectedFiles()[0]
             if selected_dir is not None:
                 self.dangerzone.output_dir = str(selected_dir)


### PR DESCRIPTION
`exec_()` is being deprecated in favor of `exec()`.

Also use [`launch()` helper method](https://github.com/freedomofpress/dangerzone/blob/8cdb2d572038cda19ab2c53b61abbfb9150fe6f5/dangerzone/gui/logic.py#L200) for `Dialog` subclasses.

Note: there is [one case of `exec_()` left](https://github.com/naglis/dangerzone/blob/828c04dfbb6dcfa3c0532358de35ca5650f38f51/dangerzone/gui/__init__.py#L190), however I've found that under PySide2 `QApplication` does not have an `exec()` method. Also, this use of `exec_` does not seem to produce warnings.

Fixes #595