### PR TITLE
Fix pytest warnings in CI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -793,13 +793,13 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 
 [[package]]
 name = "pytest-cov"
-version = "3.0.0"
+version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
-    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
 ]
 
 [package.dependencies]
@@ -807,7 +807,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-mock"
@@ -1047,4 +1047,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "bc2b77061c16fc5813b3a4bbb765f2dad5f549946bbff31b2be579c208f1d839"
+content-hash = "41fa1259c38a7b266e439f7dc1ed6a303e991a8633d2ba02624ad560b22c98f0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ types-requests = "*"
 pytest = "^7.1.2"
 pytest-mock = "^3.10.0"
 pytest-qt = "^4.2.0"
-pytest-cov = "^3.0.0"
+pytest-cov = "^5.0.0"
 strip-ansi = "*"
 
 [tool.poetry.group.qubes.dependencies]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -74,12 +74,13 @@ def test_new_default_setting(tmp_path: Path, mocker: MockerFixture) -> None:
     settings.save()
 
     # Ensure new default setting is imported into settings
-    with mocker.patch(
+    mocker.patch(
         "dangerzone.settings.Settings.generate_default_settings",
         return_value={"mock_setting": 1},
-    ):
-        settings2 = Settings(dz_core)
-        assert settings2.get("mock_setting") == 1
+    )
+
+    settings2 = Settings(dz_core)
+    assert settings2.get("mock_setting") == 1
 
 
 def test_new_settings_added(tmp_path: Path, mocker: MockerFixture) -> None:


### PR DESCRIPTION
Currently, pytest issues 3 warnings after running the tests in CI ([Linux](https://app.circleci.com/pipelines/github/freedomofpress/dangerzone/2537/workflows/fbec8358-484a-4e34-afbb-1b712babf73f/jobs/33937?invite=true#step-109-24903_80), [macOS](https://github.com/freedomofpress/dangerzone/actions/runs/8837145460/job/24265343870#step:6:340), [Windows](https://github.com/freedomofpress/dangerzone/actions/runs/8837145460/job/24265342799#step:6:340)):

```
../.cache/pypoetry/virtualenvs/dangerzone-3aSsmiER-py3.8/lib/python3.8/site-packages/pytest_cov/plugin.py:256
  /home/circleci/.cache/pypoetry/virtualenvs/dangerzone-3aSsmiER-py3.8/lib/python3.8/site-packages/pytest_cov/plugin.py:256: PytestDeprecationWarning: The hookimpl CovPlugin.pytest_configure_node uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    def pytest_configure_node(self, node):

../.cache/pypoetry/virtualenvs/dangerzone-3aSsmiER-py3.8/lib/python3.8/site-packages/pytest_cov/plugin.py:265
  /home/circleci/.cache/pypoetry/virtualenvs/dangerzone-3aSsmiER-py3.8/lib/python3.8/site-packages/pytest_cov/plugin.py:265: PytestDeprecationWarning: The hookimpl CovPlugin.pytest_testnodedown uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    def pytest_testnodedown(self, node, error):

tests/test_settings.py::test_new_default_setting
  /home/circleci/project/tests/test_settings.py:77: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    with mocker.patch(
```

The first two warnings are resolved by updating pytest-cov version ([this issue was resolved in pytest-cov 4.0.0](https://github.com/pytest-dev/pytest-cov/issues/561#issuecomment-1297143745), but I've bumped it to the latest (5.0.0)).

The last warning is resolved by not using `mocker.patch` as a context manager. There is only one such case, elsewhere ([e.g.](https://github.com/freedomofpress/dangerzone/blob/8cdb2d572038cda19ab2c53b61abbfb9150fe6f5/tests/isolation_provider/base.py#L55)) it is already used correctly.