### PR TITLE
Quote command in installation instructions

### DIFF
--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Add packages.freedom.press to our APT sources
         run: |
           . /etc/os-release
-          echo deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
-              https://packages.freedom.press/apt-tools-prod ${VERSION_CODENAME?} main \
+          echo "deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
+              https://packages.freedom.press/apt-tools-prod ${VERSION_CODENAME?} main" \
               | tee /etc/apt/sources.list.d/fpf-apt-tools.list
 
       - name: Install Dangerzone

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,8 +94,8 @@ Add the URL of the repo in your APT sources:
 
 ```sh
 . /etc/os-release
-echo deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
-    https://packages.freedom.press/apt-tools-prod ${VERSION_CODENAME?} main \
+echo "deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
+    https://packages.freedom.press/apt-tools-prod ${VERSION_CODENAME?} main" \
     | sudo tee /etc/apt/sources.list.d/fpf-apt-tools.list
 ```
 


### PR DESCRIPTION
Zsh users that attempt to run the following command in our Ubuntu/Debian installation instructions:

    echo deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
        https://packages.freedom.press/apt-tools-prod ${VERSION_CODENAME?} main \
            | sudo tee /etc/apt/sources.list.d/fpf-apt-tools.list

encounter the following error:

    zsh: no matches found:
    [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg]

Quote this command to ensure compatibility with other shells, and update our CI checks.

Fixes #805