### PR TITLE
Add some articles about the Dangerzone project

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Licensed under the AGPLv3: [https://opensource.org/licenses/agpl-3.0](https://op
 Copyright (c) 2022-2024 Freedom of the Press Foundation and Dangerzone contributors
 Copyright (c) 2020-2021 First Look Media
 
+## See also
+
+* [GIJN Toolbox: Cutting-Edge — and Free — Online Investigative Tools You Can Try Right Now](https://gijn.org/stories/cutting-edge-free-online-investigative-tools/)
+* [When security matters: working with Qubes OS at the Guardian](https://www.theguardian.com/info/2024/apr/04/when-security-matters-working-with-qubes-os-at-the-guardian)
+
 ## FAQ
 
 ### "I'm experiencing an issue while using Dangerzone."

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Copyright (c) 2020-2021 First Look Media
 
 ## FAQ
 
+### Has Dangerzone received a security audit?
+
+Yes, Dangerzone received its [first security audit](https://freedom.press/news/dangerzone-receives-favorable-audit/) by [Include Security](https://includesecurity.com/) in December 2023. The audit was generally favorable, as it didn't identify any high-risk findings, except for 3 low-risk and 7 informational findings.
+
 ### "I'm experiencing an issue while using Dangerzone."
 
 Dangerzone gets updates to improve its features _and_ to fix problems. So, updating may be the simplest path to resolving the issue which brought you here. Here is how to update:


### PR DESCRIPTION
Add some articles about the Dangerzone project that may be useful for those evaluating this tool. This article list is not complete, and has been sampled from various links we have encountered in the past.

Also, add a mention to our security audit, since lots of people may not have heard about it.