### PR TITLE
Bump Python system path to 3.12 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apk --no-cache -U upgrade && \
     py3-magic \
     font-noto-cjk
 
-COPY --from=pymupdf-build /usr/lib/python3.11/site-packages/fitz/ /usr/lib/python3.11/site-packages/fitz
+COPY --from=pymupdf-build /usr/lib/python3.12/site-packages/fitz/ /usr/lib/python3.12/site-packages/fitz
 COPY --from=tessdata-dl /usr/share/tessdata/ /usr/share/tessdata
 COPY --from=h2orestart-dl /libreoffice_ext/ /libreoffice_ext
 


### PR DESCRIPTION
Alpine Linux 3.20 was released recently [1]. As a result, the `alpine:latest` image ref, that our Dockerfile uses, switched from the 3.19 to the 3.20 Alpine Linux release. This release has Python 3.12, meaning that the following line in our Dockerfile now fails:

    COPY --from=pymupdf-build /usr/lib/python3.11/site-packages/fitz/ /usr/lib/python3.11/site-packages/fitz

Bump the Python version in the Python system path to 3.12, so that we can successfully build the container image.

[1]: https://alpinelinux.org/posts/Alpine-3.20.0-released.html