### PR TITLE
Fix incorrect file permissions in Dangerzone RPMs

### DIFF
--- a/dangerzone/conversion/common.py
+++ b/dangerzone/conversion/common.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import asyncio
 import glob
 import json

--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import asyncio
 import glob
 import os

--- a/dangerzone/conversion/pixels_to_pdf.py
+++ b/dangerzone/conversion/pixels_to_pdf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Here are the steps, with progress bar percentages:
 

--- a/install/linux/build-rpm.py
+++ b/install/linux/build-rpm.py
@@ -3,12 +3,13 @@
 import argparse
 import inspect
 import os
-import pathlib
 import shutil
 import subprocess
 import tempfile
 
-root = pathlib.Path(__file__).parent.parent.parent
+from pathlib import Path
+
+root = Path(__file__).parent.parent.parent
 
 with open(os.path.join(root, "share", "version.txt")) as f:
     version = f.read().strip()
@@ -23,26 +24,27 @@ def remove_contents(d):
             shutil.rmtree(p)
 
 
-def build(qubes=False):
+def build(build_dir, qubes=False):
     """Build an RPM package in a temporary directory.
 
     The build process is the following:
 
     1. Clean up any stale data from previous runs under ./dist. Note that this directory
        is used by `poetry build` and `rpmbuild`.
-    2. Create the necessary RPM project structure under ./install/linux/rpm-build, and
-       use symlinks to point to ./dist, so that we don't need to move files explicitly.
+    2. Create the necessary RPM project structure under the specified build directory
+       (default: ~/rpmbuild), and use symlinks to point to ./dist, so that we don't need
+       to move files explicitly.
     3. Create a Python source distribution using `poetry build`. If we are building a
        Qubes package and there is a container image under `share/`, stash it temporarily
        under a different directory.
     4. Build both binary and source RPMs using rpmbuild. Optionally, pass to the SPEC
         `_qubes` flag, that denotes we want to build a package for Qubes.
     """
-    build_dir = root / "install" / "linux" / "rpm-build"
     dist_path = root / "dist"
     specfile_name = "dangerzone.spec"
     specfile_path = root / "install" / "linux" / specfile_name
     sdist_name = f"dangerzone-{version}.tar.gz"
+    sdist_path = dist_path / sdist_name
 
     print("* Deleting old dist")
     if os.path.exists(dist_path):
@@ -72,7 +74,11 @@ def build(qubes=False):
         container_tar_gz.rename(container_tar_gz_bak)
     try:
         subprocess.run(["poetry", "build", "-f", "sdist"], cwd=root, check=True)
-        os.rename(dist_path / sdist_name, build_dir / "SOURCES" / sdist_name)
+        # Copy and unlink the Dangerzone sdist, instead of just renaming it. If the
+        # build directory is outside the filesystem boundary (e.g., due to a container
+        # mount), then a simple rename will not work.
+        shutil.copy2(sdist_path, build_dir / "SOURCES" / sdist_name)
+        sdist_path.unlink()
     finally:
         if stash_container:
             container_tar_gz_bak.rename(container_tar_gz)
@@ -107,9 +113,14 @@ def main():
     parser.add_argument(
         "--qubes", action="store_true", help="Build RPM package for a Qubes OS system"
     )
+    parser.add_argument(
+        "--build-dir",
+        default=Path.home() / "rpmbuild",
+        help="Working directory for rpmbuild command",
+    )
     args = parser.parse_args()
 
-    build(args.qubes)
+    build(args.build_dir, args.qubes)
 
 
 if __name__ == "__main__":

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -258,6 +258,17 @@ install -m 755 -d %{buildroot}/etc/qubes-rpc
 install -m 755 qubes/* %{buildroot}/etc/qubes-rpc
 %endif
 
+%check
+# Detect if the filesystem has been affecting our file permissions.
+bad_files=$(find %{buildroot} -perm 0600)
+if [ -n "${bad_files}" ]; then
+    echo "Error while building the Dangerzone RPM. Detected the following files with wrong permissions (600):"
+    echo ${bad_files}
+    echo ""
+    echo "For more info about this error, see https://github.com/freedomofpress/dangerzone/issues/727"
+    exit 1
+fi
+
 %files -f %{pyproject_files}
 /usr/bin/dangerzone
 /usr/bin/dangerzone-cli

--- a/qubes/dz.Convert
+++ b/qubes/dz.Convert
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/sh
 python -m dangerzone.conversion.doc_to_pixels

--- a/qubes/dz.ConvertDev
+++ b/qubes/dz.ConvertDev
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import asyncio
 import glob


### PR DESCRIPTION
Switch build directory for the `rpmbuild` command from `./install/linux/rpm-build` to `~/rpmbuild`. The main reason for this is that we want a build directory that will not be mounted in the container, since we've experienced issues with file permissions.

Regarding the choice of directories, we went with `~/rpmbuild` because it's outside the Dangerzone source, and also because it's the default choice in Fedora [1].

In addition to the above fix, make the following changes:
1. Add a check to detect if a Dangezone RPM is about to be built with wrong permissions.
2. Fix some shebangs that were the cause of complaints during RPM build.

[1]: https://github.com/rsrchboy/rpmdevtools/blob/3ae1eeafeeda19e7bcb4546300fe551fd879e0ca/rpmdev-setuptree#L60
    
Closes #727