### PR TITLE
build: bump CircleCI runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
 
   build-container-image:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -137,7 +137,7 @@ jobs:
 
   convert-test-docs:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -167,7 +167,7 @@ jobs:
 
   ci-ubuntu-noble:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -194,7 +194,7 @@ jobs:
 
   ci-ubuntu-mantic:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -221,7 +221,7 @@ jobs:
 
   ci-ubuntu-jammy:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -248,7 +248,7 @@ jobs:
 
   ci-ubuntu-focal:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -275,7 +275,7 @@ jobs:
 
   ci-fedora-40:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -302,7 +302,7 @@ jobs:
 
   ci-fedora-39:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -329,7 +329,7 @@ jobs:
 
   ci-fedora-38:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -356,7 +356,7 @@ jobs:
 
   ci-debian-trixie:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman
@@ -383,7 +383,7 @@ jobs:
 
   ci-debian-bookworm:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: *install-podman


### PR DESCRIPTION
Try using `:current` as specified in their documentation.

Fixes #681

If this simple approach doesn't cut it, I'm not sure it's worth digging further, as we plan to move away from CircleCI in the future, as mentioned in #674 