### PR TITLE
Explain how to create, sign, and verify source tarballs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -319,6 +319,12 @@ For the container image:
 gpg --verify container.tar.gz.asc container.tar.gz
 ```
 
+For the source package:
+
+```
+gpg --verify dangerzone-0.6.1.tar.gz.asc dangerzone-0.6.1.tar.gz
+```
+
 We also hash all the above files with SHA-256, and provide a list of these
 hashes as a separate file (`checksums-0.6.1.txt`). This file is signed as well,
 and the signature is embedded within it. You can download this file and verify

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -395,6 +395,14 @@ repo.
 
 To publish the release:
 
+- [ ] Create an archive of the Dangerzone source in `tar.gz` format:
+  * You can use the following command:
+
+    ```
+    export DZ_VERSION=$(cat share/version.txt)
+    git archive --format=tar.gz -o dangerzone-${DZ_VERSION:?}.tar.gz --prefix=dangerzone/ v${DZ_VERSION:?}
+    ```
+
 - [ ] Run container scan on the produced container images (some time may have passed since the artifacts were built)
 - [ ] Collect the assets in a single directory, calculate their SHA-256 hashes, and sign them.
   * You can use `./dev_scripts/sign-assets.py`, if you want to automate this

--- a/dev_scripts/sign-assets.py
+++ b/dev_scripts/sign-assets.py
@@ -15,6 +15,7 @@ DZ_ASSETS = [
     "Dangerzone-{version}.msi",
     "Dangerzone-{version}-arm64.dmg",
     "Dangerzone-{version}-i686.dmg",
+    "dangerzone-{version}.tar.gz",
 ]
 DZ_SIGNING_PUBKEY = "DE28AB241FA48260FAC9B8BAA7C9B38522604281"
 


### PR DESCRIPTION
Update our docs and scripts to be able to create a source tarball for a Dangerzone version, sign it, and explain how can users verify it.

Closes #822