### PR TITLE
Order list of PDF viewers and return default application first (Linux)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,11 @@ lint-apply: lint-black-apply lint-isort-apply ## apply all the linter's suggesti
 
 .PHONY: test
 test:
-	pytest -v --cov --ignore dev_scripts --ignore tests/test_large_set.py
+	# Make each GUI test run as a separate process, to avoid segfaults due to
+	# shared state.
+	# See more in https://github.com/freedomofpress/dangerzone/issues/493
+	pytest --co -q tests/gui | grep -v ' collected' | xargs -n 1 pytest -v
+	pytest -v --cov --ignore dev_scripts --ignore tests/gui --ignore tests/test_large_set.py
 
 
 .PHONY: test-large-requirements

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import platform
@@ -6,7 +8,7 @@ import subprocess
 import typing
 from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 from colorama import Fore
 

--- a/tests/gui/test_logic.py
+++ b/tests/gui/test_logic.py
@@ -1,0 +1,100 @@
+import platform
+import subprocess
+from unittest import mock
+
+import pytest
+
+from dangerzone.gui.logic import DangerzoneGui
+
+if platform.system() == "Linux":
+    from xdg.DesktopEntry import DesktopEntry
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Linux-only test")
+def test_order_mime_handers() -> None:
+    """
+    Given a default mime handler returned by xdg-mime,
+    ensure it is the first item available in the list
+    of compatible applications.
+    """
+    mock_app = mock.MagicMock()
+    dummy = mock.MagicMock()
+
+    mock_desktop = mock.MagicMock(spec=DesktopEntry)
+    mock_desktop.getMimeTypes.return_value = "application/pdf"
+    mock_desktop.getExec.side_effect = [
+        "/usr/bin/madeup-evince",
+        "/usr/local/bin/madeup-mupdf",
+        "/usr/local/bin/madeup-libredraw",
+    ]
+    mock_desktop.getName.side_effect = [
+        "Evince",
+        "MuPDF",
+        "LibreOffice",
+    ]
+
+    with mock.patch(
+        "subprocess.check_output", return_value=b"libreoffice-draw.desktop"
+    ) as mock_default_mime_hander, mock.patch(
+        "os.listdir",
+        side_effect=[
+            ["org.gnome.Evince.desktop"],
+            ["org.pwmt.zathura-pdf-mupdf.desktop"],
+            ["libreoffice-draw.desktop"],
+        ],
+    ) as mock_list, mock.patch(
+        "dangerzone.gui.logic.DesktopEntry", return_value=mock_desktop
+    ):
+        dz = DangerzoneGui(mock_app, dummy)
+
+        mock_default_mime_hander.assert_called_once_with(
+            ["xdg-mime", "query", "default", "application/pdf"]
+        )
+        mock_list.assert_called()
+        assert len(dz.pdf_viewers) == 3
+        assert dz.pdf_viewers.popitem(last=False)[0] == "LibreOffice"
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Linux-only test")
+def test_mime_handers_succeeds_no_default_found() -> None:
+    """
+    Given a failure to return default mime handler,
+    ensure compatible applications are still returned.
+    """
+    mock_app = mock.MagicMock()
+    dummy = mock.MagicMock()
+
+    mock_desktop = mock.MagicMock(spec=DesktopEntry)
+    mock_desktop.getMimeTypes.return_value = "application/pdf"
+    mock_desktop.getExec.side_effect = [
+        "/usr/bin/madeup-evince",
+        "/usr/local/bin/madeup-mupdf",
+        "/usr/local/bin/madeup-libredraw",
+    ]
+    mock_desktop.getName.side_effect = [
+        "Evince",
+        "MuPDF",
+        "LibreOffice",
+    ]
+
+    with mock.patch(
+        "subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "Oh no, xdg-mime error!)"),
+    ) as mock_default_mime_hander, mock.patch(
+        "os.listdir",
+        side_effect=[
+            ["org.gnome.Evince.desktop"],
+            ["org.pwmt.zathura-pdf-mupdf.desktop"],
+            ["libreoffice-draw.desktop"],
+        ],
+    ) as mock_list, mock.patch(
+        "dangerzone.gui.logic.DesktopEntry", return_value=mock_desktop
+    ):
+        dz = DangerzoneGui(mock_app, dummy)
+
+        mock_default_mime_hander.assert_called_once_with(
+            ["xdg-mime", "query", "default", "application/pdf"]
+        )
+        mock_list.assert_called()
+        assert len(dz.pdf_viewers) == 3
+        assert dz.pdf_viewers.popitem(last=False)[0] == "Evince"


### PR DESCRIPTION
- Order default list of PDF viewers (the words "first choice is picked at random" caught my attention...)  
- Query xdg-mime per #814 and display the default application first
- Add a couple tests

Closes #814 

@apyrgio : let me know if this is what you had in mind :)