### PR TITLE
Use `LF` line-ending for `gvisor_wrapper/entrypoint.py`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*     text=auto
+*.jpg -text
+*.gif -text
+*.png -text


### PR DESCRIPTION
Otherwise, Dangerzone images built on Windows might not be able to work, as they cannot load the entrypoint file, triggering an error.