### PR TITLE
Drop support for Fedora 38

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,33 +327,6 @@ jobs:
             ./dev_scripts/env.py --distro fedora --version 39 run --dev \
                 bash -c 'cd dangerzone; poetry run make test'
 
-  ci-fedora-38:
-    machine:
-      image: ubuntu-2004:202111-01
-    steps:
-      - checkout
-      - run: *install-podman
-
-      - run:
-          name: Prepare cache directory
-          command: |
-            sudo mkdir -p /caches
-            sudo chown -R $USER:$USER /caches
-      - run: *calculate-cache-key
-      - restore_cache: *restore-cache
-      - run: *copy-image
-
-      - run:
-          name: Prepare Dangerzone environment
-          command: |
-            ./dev_scripts/env.py --distro fedora --version 38 build-dev
-
-      - run:
-          name: Run CI tests
-          command: |
-            ./dev_scripts/env.py --distro fedora --version 38 run --dev \
-                bash -c 'cd dangerzone; poetry run make test'
-
   ci-debian-trixie:
     machine:
       image: ubuntu-2004:202111-01
@@ -579,20 +552,6 @@ jobs:
       - run: *build-rpm
       - run: *build-rpm-qubes
 
-  build-fedora-38:
-    docker:
-      - image: fedora:38
-    resource_class: medium+
-    steps:
-      - run: *install-dependencies-rpm
-      - checkout
-      - run: *calculate-cache-key
-      - restore_cache: *restore-cache
-      - run: *copy-image
-      - run: *build-rpm
-      - run: *build-rpm-qubes
-
-
 workflows:
   version: 2
 
@@ -630,9 +589,6 @@ workflows:
       - ci-fedora-39:
           requires:
             - build-container-image
-      - ci-fedora-38:
-          requires:
-            - build-container-image
       # FIXME: Currently disabled because `stdeb` does not work with Python
       # 3.12, which is the default in Ubuntu Noble. See also:
       # https://github.com/freedomofpress/dangerzone/issues/773
@@ -662,8 +618,5 @@ workflows:
           requires:
             - build-container-image
       - build-fedora-39:
-          requires:
-            - build-container-image
-      - build-fedora-38:
           requires:
             - build-container-image

--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -75,8 +75,6 @@ jobs:
       matrix:
         include:
           - distro: fedora
-            version: 38
-          - distro: fedora
             version: 39
           - distro: fedora
             version: 40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: "38"
           - version: "39"
           - version: "40"
     steps:

--- a/BUILD.md
+++ b/BUILD.md
@@ -196,27 +196,27 @@ Overview of the qubes you'll create:
 |--------------|----------|---------|
 | dz           | app qube | Dangerzone development |
 | dz-dvm       | app qube | offline disposable template for performing conversions |
-| fedora-38-dz | template | template for the other two qubes |
+| fedora-40-dz | template | template for the other two qubes |
 
 #### In `dom0`:
 
 The following instructions require typing commands in a terminal in dom0.
 
-1. Create a new Fedora **template** (`fedora-38-dz`) for Dangerzone development:
+1. Create a new Fedora **template** (`fedora-40-dz`) for Dangerzone development:
 
    ```
-   qvm-clone fedora-38 fedora-38-dz
+   qvm-clone fedora-40 fedora-40-dz
    ```
 
-   > :bulb: Alternatively, you can use your base Fedora 38 template in the
+   > :bulb: Alternatively, you can use your base Fedora 40 template in the
    > following instructions. In that case, skip this step and replace
-   > `fedora-38-dz` with `fedora-38` in the steps below.
+   > `fedora-40-dz` with `fedora-40` in the steps below.
 
-2. Create an offline disposable template (app qube) called `dz-dvm`, based on the `fedora-38-dz`
+2. Create an offline disposable template (app qube) called `dz-dvm`, based on the `fedora-40-dz`
    template. This will be the qube where the documents will be sanitized:
 
    ```
-   qvm-create --class AppVM --label red --template fedora-38-dz \
+   qvm-create --class AppVM --label red --template fedora-40-dz \
        --prop netvm="" --prop template_for_dispvms=True \
        --prop default_dispvm='' dz-dvm
    ```
@@ -225,7 +225,7 @@ The following instructions require typing commands in a terminal in dom0.
    and initiating the sanitization process:
 
    ```
-   qvm-create --class AppVM --label red --template fedora-38-dz dz
+   qvm-create --class AppVM --label red --template fedora-40-dz dz
    ```
 
    > :bulb: Alternatively, you can use a different app qube for Dangerzone
@@ -267,12 +267,12 @@ test it.
    ./install/linux/build-rpm.py --qubes
    ```
 
-4. Copy the produced `.rpm` file into `fedora-38-dz`
+4. Copy the produced `.rpm` file into `fedora-40-dz`
    ```sh
    qvm-copy dist/*.x86_64.rpm
    ```
 
-#### In the `fedora-38-dz` template
+#### In the `fedora-40-dz` template
 
 1. Install the `.rpm` package you just copied
 
@@ -280,7 +280,7 @@ test it.
    sudo dnf install ~/QubesIncoming/dz/*.rpm
    ```
 
-2. Shutdown the `fedora-38-dz` template
+2. Shutdown the `fedora-40-dz` template
 
 ### Developing Dangerzone
 
@@ -311,7 +311,7 @@ For changes in the server side components, you can simply edit them locally,
 and they will be mirrored to the disposable qube through the `dz.ConvertDev`
 RPC call.
 
-The only reason to build a new Qubes RPM and install it in the `fedora-38-dz`
+The only reason to build a new Qubes RPM and install it in the `fedora-40-dz`
 template for development is if:
 1. The project requires new server-side components.
 2. The code for `qubes/dz.ConvertDev` needs to be updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
   * Use a restricted seccomp profile ([#225](https://github.com/freedomofpress/dangerzone/issues/225))
   * Make use of user namespaces ([#228](https://github.com/freedomofpress/dangerzone/issues/228))
 
+## Removed
+
+- Platform support: Drop Fedora 38, since it's end-of-life ([issue #840](https://github.com/freedomofpress/dangerzone/pull/840))
+
 ## Dangerzone 0.6.1
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,6 @@ Dangerzone is available for:
 - Debian 11 (bullseye)
 - Fedora 40
 - Fedora 39
-- Fedora 38
 - Qubes OS (beta support)
 
 ### Ubuntu, Debian
@@ -202,8 +201,8 @@ After confirming that it matches, type `y` (for yes) and the installation should
 
 > [!IMPORTANT]
 > This section will install Dangerzone in your **default template**
-> (`fedora-38` as of writing this). If you want to install it in a different
-> one, make sure to replace `fedora-38` with the template of your choice.
+> (`fedora-40` as of writing this). If you want to install it in a different
+> one, make sure to replace `fedora-40` with the template of your choice.
 
 The following steps must be completed once. Make sure you run them in the
 specified qubes.
@@ -220,7 +219,7 @@ Create a **disposable**, offline app qube (`dz-dvm`), based on your default
 template. This will be the qube where the documents will be sanitized:
 
 ```
-qvm-create --class AppVM --label red --template fedora-38 \
+qvm-create --class AppVM --label red --template fedora-40 \
     --prop netvm="" --prop template_for_dispvms=True \
     --prop default_dispvm='' dz-dvm
 ```
@@ -233,7 +232,7 @@ document, with the following contents:
 dz.Convert         *       @anyvm       @dispvm:dz-dvm  allow
 ```
 
-#### In the `fedora-38` template
+#### In the `fedora-40` template
 
 Install Dangerzone:
 

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -618,26 +618,23 @@ class Env:
             # NOTE: For Fedora 39+ onward, we check if a PySide6 RPM package exists in
             # the user's system. If not, we either throw an error or download it from
             # FPF's repo, according to the user's choice.
-            # FIXME: Unconditionally check for PySide6, once Fedora 38 is no longer
-            # supported.
-            if self.version != "38":
-                pyside6 = PySide6Manager(self.distro, self.version)
-                if not pyside6.is_rpm_present:
-                    if download_pyside6:
-                        pyside6.download_rpm()
-                    else:
-                        print(
-                            PYSIDE6_NOT_FOUND_ERROR.format(
-                                pyside6_local_path=pyside6.rpm_local_path,
-                                pyside6_url=pyside6.rpm_url,
-                            ),
-                            file=sys.stderr,
-                        )
-                        return 1
-                shutil.copy(pyside6.rpm_local_path, build_dir / pyside6.rpm_name)
-                install_deps = (
-                    DOCKERFILE_BUILD_FEDORA_DEPS + DOCKERFILE_BUILD_FEDORA_39_DEPS
-                ).format(pyside6_rpm=pyside6.rpm_name)
+            pyside6 = PySide6Manager(self.distro, self.version)
+            if not pyside6.is_rpm_present:
+                if download_pyside6:
+                    pyside6.download_rpm()
+                else:
+                    print(
+                        PYSIDE6_NOT_FOUND_ERROR.format(
+                            pyside6_local_path=pyside6.rpm_local_path,
+                            pyside6_url=pyside6.rpm_url,
+                        ),
+                        file=sys.stderr,
+                    )
+                    return 1
+            shutil.copy(pyside6.rpm_local_path, build_dir / pyside6.rpm_name)
+            install_deps = (
+                DOCKERFILE_BUILD_FEDORA_DEPS + DOCKERFILE_BUILD_FEDORA_39_DEPS
+            ).format(pyside6_rpm=pyside6.rpm_name)
         else:
             install_deps = DOCKERFILE_BUILD_DEBIAN_DEPS
             if self.distro == "ubuntu" and self.version in ("20.04", "focal"):

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -964,10 +964,6 @@ class QAFedora39(QAFedora):
     VERSION = "39"
 
 
-class QAFedora38(QAFedora):
-    VERSION = "38"
-
-
 def parse_args():
     parser = argparse.ArgumentParser(
         prog=sys.argv[0],

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -221,16 +221,6 @@ convert the documents within a secure sandbox.
 %prep
 %autosetup -p1 -n dangerzone-%{version}
 
-# XXX: Replace the PySide6 dependency in the pyproject.toml file with PySide2,
-# since the former did not exist until Fedora 39, where we packaged PySide6 [1].
-# Once Fedora 38 is no longer supported, we should remove this.
-#
-# [1]: https://github.com/freedomofpress/dangerzone/issues/606
-%if 0%{?fedora} == 38
-sed -i 's/^PySide6.*$/PySide2 = "*"/' pyproject.toml
-%endif
-
-
 %generate_buildrequires
 %pyproject_buildrequires -R
 


### PR DESCRIPTION
Fedora 38 is EOL since 21 May 2024, so this removes the specific branches we had checking for it, and updates the related instructions.