### PR TITLE
Provide a seccomp policy on docker if using "old" version of runc

### DIFF
--- a/tests/isolation_provider/test_container.py
+++ b/tests/isolation_provider/test_container.py
@@ -22,7 +22,7 @@ class ContainerWait(Container):
         # Check every 100ms if a container with the expected name has showed up.
         # Else, closing the file descriptors may not work.
         name = kwargs["name"]
-        runtime = self.get_runtime()
+        runtime = self.get_container_engine()
         p = super().exec_container(*args, **kwargs)
         for i in range(50):
             containers = subprocess.run(

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -16,7 +16,7 @@ from dangerzone.logic import DangerzoneCore
 def test_ocr_ommisions() -> None:
     # Create the command that will list all the installed languages in the container
     # image.
-    command = [Container.get_runtime(), "run"]
+    command = [Container.get_container_engine(), "run"]
     command += Container.get_runtime_security_args()
     command += [
         Container.CONTAINER_NAME,


### PR DESCRIPTION
That's what I have, @apyrgio. I renamed the "runtime" references to "container_engine" in the hopes of making it clearer, and added a "get_runtime_version" static method.

Not much, but that's a start :-)