### PR TITLE
Fix some small issues found during QA on Qubes

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -49,7 +49,7 @@ Install dependencies:
   ```bash
   sudo apt install -y python3.9
   ```
-  
+
   Poetry will automatically pick up the correct version when running.
 </details>
     </td>

--- a/BUILD.md
+++ b/BUILD.md
@@ -277,8 +277,17 @@ test it.
 1. Install the `.rpm` package you just copied
 
    ```sh
+   sudo dnf install 'dnf-command(config-manager)'
+   sudo dnf config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
    sudo dnf install ~/QubesIncoming/dz/*.rpm
    ```
+
+   In the above steps, we add the Dangerzone repo because it includes the
+   necessary PySide6 RPM in order to make Dangerzone work.
+
+   > [!NOTE]
+   > During the installation, you will be asked to
+   > [verify the Dangerzone GPG key](INSTALL.md#verifying-dangerzone-gpg-key).
 
 2. Shutdown the `fedora-40-dz` template
 

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -237,7 +237,7 @@ Install dependencies:
   ```bash
   sudo apt install -y python3.9
   ```
-  
+
   Poetry will automatically pick up the correct version when running.
 </details>
     </td>

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -892,7 +892,7 @@ class QALinux(QABase):
         self.run_tests()
         self.build_package()
         self.build_qa_image()
-        self.qa_scenarios(skip=[1, 2, 8, 9])
+        self.qa_scenarios(skip=[1, 2, 3, 10, 11])
 
 
 class QADebianBased(QALinux):

--- a/tests/isolation_provider/base.py
+++ b/tests/isolation_provider/base.py
@@ -16,7 +16,6 @@ TIMEOUT_STARTUP = 60  # Timeout in seconds until the conversion sandbox starts.
     os.environ.get("DUMMY_CONVERSION", False),
     reason="dummy conversions not supported",
 )
-@pytest.mark.skipif(not running_on_qubes(), reason="Not on a Qubes system")
 class IsolationProviderTest:
     def test_max_pages_server_enforcement(
         self,

--- a/tests/isolation_provider/test_container.py
+++ b/tests/isolation_provider/test_container.py
@@ -9,6 +9,12 @@ from dangerzone.isolation_provider.qubes import is_qubes_native_conversion
 
 from .base import IsolationProviderTermination, IsolationProviderTest
 
+# Run the tests in this module only if we can spawn containers.
+if is_qubes_native_conversion():
+    pytest.skip("Qubes native conversion is enabled", allow_module_level=True)
+elif os.environ.get("DUMMY_CONVERSION", False):
+    pytest.skip("Dummy conversion is enabled", allow_module_level=True)
+
 
 @pytest.fixture
 def provider() -> Container:
@@ -44,12 +50,5 @@ class TestContainer(IsolationProviderTest):
     pass
 
 
-@pytest.mark.skipif(
-    os.environ.get("DUMMY_CONVERSION", False),
-    reason="cannot run for dummy conversions",
-)
-@pytest.mark.skipif(
-    is_qubes_native_conversion(), reason="Qubes native conversion is enabled"
-)
 class TestContainerTermination(IsolationProviderTermination):
     pass

--- a/tests/isolation_provider/test_dummy.py
+++ b/tests/isolation_provider/test_dummy.py
@@ -11,6 +11,10 @@ from dangerzone.isolation_provider.dummy import Dummy
 
 from .base import IsolationProviderTermination
 
+# Run the tests in this module only if dummy conversion is enabled.
+if not os.environ.get("DUMMY_CONVERSION", False):
+    pytest.skip("Dummy conversion is not enabled", allow_module_level=True)
+
 
 class DummyWait(Dummy):
     """Dummy isolation provider that spawns a blocking process."""
@@ -34,10 +38,6 @@ def provider_wait() -> DummyWait:
     return DummyWait()
 
 
-@pytest.mark.skipif(
-    os.environ.get("DUMMY_CONVERSION", False) is False,
-    reason="can only run for dummy conversions",
-)
 class TestDummyTermination(IsolationProviderTermination):
     def test_failed(
         self,

--- a/tests/isolation_provider/test_qubes.py
+++ b/tests/isolation_provider/test_qubes.py
@@ -9,13 +9,15 @@ from pytest_mock import MockerFixture
 
 from dangerzone.conversion import errors
 from dangerzone.document import Document
-from dangerzone.isolation_provider.qubes import (
-    Qubes,
-    is_qubes_native_conversion,
-    running_on_qubes,
-)
+from dangerzone.isolation_provider.qubes import Qubes, is_qubes_native_conversion
 
 from .base import IsolationProviderTermination, IsolationProviderTest
+
+# Run the tests in this module only if we can spawn disposable qubes.
+if not is_qubes_native_conversion():
+    pytest.skip("Qubes native conversion is not enabled", allow_module_level=True)
+elif os.environ.get("DUMMY_CONVERSION", False):
+    pytest.skip("Dummy conversion is enabled", allow_module_level=True)
 
 
 @pytest.fixture
@@ -55,7 +57,6 @@ def provider_wait() -> QubesWait:
     return QubesWait()
 
 
-@pytest.mark.skipif(not running_on_qubes(), reason="Not on a Qubes system")
 class TestQubes(IsolationProviderTest):
     def test_out_of_ram(
         self,
@@ -82,12 +83,5 @@ class TestQubes(IsolationProviderTest):
             assert provider.get_proc_exception(proc) == errors.QubesQrexecFailed
 
 
-@pytest.mark.skipif(
-    os.environ.get("DUMMY_CONVERSION", False),
-    reason="cannot run for dummy conversions",
-)
-@pytest.mark.skipif(
-    not is_qubes_native_conversion(), reason="Qubes native conversion is not enabled"
-)
 class TestQubesTermination(IsolationProviderTermination):
     pass

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from dangerzone.isolation_provider.container import Container
+from dangerzone.isolation_provider.qubes import is_qubes_native_conversion
 from dangerzone.logic import DangerzoneCore
 
 
@@ -12,8 +13,11 @@ from dangerzone.logic import DangerzoneCore
 # NOTE: We skip running this test on Windows/MacOS, because our current CI cannot run
 # Docker in these platforms. It's not a problem anyways, because the result should be
 # the same in all container-based platforms.
-@pytest.mark.skipif(platform.system() != "Linux", reason="Container-specific")
-def test_ocr_ommisions() -> None:
+@pytest.mark.skipif(
+    platform.system() != "Linux" or is_qubes_native_conversion(),
+    reason="Container-specific",
+)
+def test_ocr_omissions() -> None:
     # Create the command that will list all the installed languages in the container
     # image.
     command = [Container.get_runtime(), "run"]


### PR DESCRIPTION
While doing QA for 0.7.0 on Qubes, we found several small issues, some Qubes-related, others not. Mainly these are:
1. Skip some container-specific tests on Qubes.
2. Fix out `qa.py` script to skip certain QA scenarios that don't apply to Linux.
3. Add some instructions to help our users download PySide6 when testing out Qubes from source.
