### PR TITLE
container: Avoid pop-ups on Windows

### DIFF
--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -67,7 +67,10 @@ class Container(IsolationProvider):
         cmd = [runtime, "version", "-f", query]
         try:
             version = subprocess.run(
-                cmd, capture_output=True, check=True
+                cmd,
+                startupinfo=get_subprocess_startupinfo(),
+                capture_output=True,
+                check=True,
             ).stdout.decode()
         except Exception as e:
             msg = f"Could not get the version of the {runtime.capitalize()} tool: {e}"


### PR DESCRIPTION
Avoid window pop-ups on Windows systems, by using the `startupinfo` argument of `subprocess.run`.