### PR TITLE
Ignore CVE-2024-5535 from our security scans

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -23,3 +23,23 @@ ignore:
   #      > A registered data source is a connection to data held in a database
   #      > outside of LibreOffice.
   - vulnerability: CVE-2023-7104
+  # CVE-2024-5535
+  # =============
+  #
+  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2024-5535
+  # Verdict: Dangerzone is not affected. The rationale is the following:
+  #
+  #   1. This CVE affects applications that make network calls. The Dangerzone
+  #      container does not perform any such calls, and has no access to the
+  #      internet.
+  #   2. The OpenSSL devs have marked this issue as low severity [1].
+  #
+  # [1]: From https://www.openssl.org/news/secadv/20240627.txt:
+  #
+  #      > This issue has been assessed as Low severity because applications are
+  #      > most likely to be vulnerable if they are using NPN instead of ALPN -
+  #      > but NPN is not widely used. It also requires an application
+  #      > configuration or programming error. Finally, this issue would not
+  #      > typically be under attacker control making active exploitation
+  #      > unlikely.
+  - vulnerability: CVE-2024-5535


### PR DESCRIPTION
We believe that Dangerzone is not affected by CVE-2024-5535 for the following reasons:

1. This CVE affects applications that make network calls. The Dangerzone container does not perform any such calls, and has no access to the internet.
2. The OpenSSL devs have marked this issue as low severity.