### PR TITLE
ci: Disable Debian Trixie builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -608,9 +608,13 @@ workflows:
       - build-debian-bullseye:
           requires:
             - build-container-image
-      - build-debian-trixie:
-          requires:
-            - build-container-image
+      # FIXME: Currently disabled because `stdeb` does not work with Python
+      # 3.12, which has become the default in Debian Trixie. See also:
+      # https://github.com/freedomofpress/dangerzone/issues/773
+      #
+      #- build-debian-trixie:
+      #    requires:
+      #      - build-container-image
       - build-debian-bookworm:
           requires:
             - build-container-image


### PR DESCRIPTION
Disable building packages in Debian Trixie, since it's Python version has changed to 3.12, which is not compatible with `stdeb`.

Refs #773