### PR TITLE
Do not allow uploading the token as an asset

### DIFF
--- a/dev_scripts/upload-asset.py
+++ b/dev_scripts/upload-asset.py
@@ -104,6 +104,8 @@ def main():
 
     if args.token:
         log.debug(f"Reading token from {args.token}")
+        # Ensure we are not uploading the token as an asset
+        assert args.file != args.token
         with open(args.token) as f:
             token = f.read().strip()
     else:


### PR DESCRIPTION
Per discussion with @adaFPF, adding a check to ensure we're not uploading the token as an asset when using this script.