### PR TITLE
dev_scripts: Download FPF's PySide6 RPM only for Fedora 39

### DIFF
--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -638,26 +638,27 @@ class Env:
             package_dst = build_dir / package
             install_cmd = "dnf install -y"
 
-            # NOTE: For Fedora 39+ onward, we check if a PySide6 RPM package exists in
+            # NOTE: For Fedora 39, we check if a PySide6 RPM package exists in
             # the user's system. If not, we either throw an error or download it from
             # FPF's repo, according to the user's choice.
-            pyside6 = PySide6Manager(self.distro, self.version)
-            if not pyside6.is_rpm_present:
-                if download_pyside6:
-                    pyside6.download_rpm()
-                else:
-                    print(
-                        PYSIDE6_NOT_FOUND_ERROR.format(
-                            pyside6_local_path=pyside6.rpm_local_path,
-                            pyside6_url=pyside6.rpm_url,
-                        ),
-                        file=sys.stderr,
-                    )
-                    return 1
-            shutil.copy(pyside6.rpm_local_path, build_dir / pyside6.rpm_name)
-            install_deps = (
-                DOCKERFILE_BUILD_FEDORA_DEPS + DOCKERFILE_BUILD_FEDORA_39_DEPS
-            ).format(pyside6_rpm=pyside6.rpm_name)
+            if self.version == "39":
+                pyside6 = PySide6Manager(self.distro, self.version)
+                if not pyside6.is_rpm_present:
+                    if download_pyside6:
+                        pyside6.download_rpm()
+                    else:
+                        print(
+                            PYSIDE6_NOT_FOUND_ERROR.format(
+                                pyside6_local_path=pyside6.rpm_local_path,
+                                pyside6_url=pyside6.rpm_url,
+                            ),
+                            file=sys.stderr,
+                        )
+                        return 1
+                shutil.copy(pyside6.rpm_local_path, build_dir / pyside6.rpm_name)
+                install_deps = (
+                    DOCKERFILE_BUILD_FEDORA_DEPS + DOCKERFILE_BUILD_FEDORA_39_DEPS
+                ).format(pyside6_rpm=pyside6.rpm_name)
         else:
             install_deps = DOCKERFILE_BUILD_DEBIAN_DEPS
             if self.distro == "ubuntu" and self.version in ("20.04", "focal"):


### PR DESCRIPTION
Download the FPF-maintained python3-pyside6 RPM [1] only when we build an end-user environment for Fedora 39. Else, from Fedora 40 onwards, we can use the official `python3-pyside6` RPM.

Refs freedomofpress/maint-dangerzone-pyside6#5

[1] https://packages.freedom.press/yum-tools-prod/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.x86_64.rpm