### PR TITLE
Various improvements in our release instructions and scripts

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -277,6 +277,7 @@ Once we are confident that the release will be out shortly, and doesn't need any
   brew as it is known to [cause issues](https://github.com/freedomofpress/dangerzone/issues/471))
   * In case of a new Python installation or minor version upgrade, e.g., from
     3.11 to 3.12 , reinstall Poetry with `python3 -m pip install poetry`
+  * You can verify the correct Python version is used with `poetry debug info`
 - [ ] Verify and checkout the git tag for this release
 - [ ] Run `poetry install --sync`
 - [ ] Run `poetry run ./install/macos/build-app.py`; this will make `dist/Dangerzone.app`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -207,6 +207,10 @@ Run Dangerzone against a list of documents, and tick all options. Ensure that:
 Run Dangerzone against a set of documents that you drag-n-drop. Files should be
 added and conversion should run without issue.
 
+> [!TIP]
+> On our end-user container environments for Linux, we can start a file manager
+> with `thunar &`.
+
 #### 9. Dangerzone CLI succeeds in converting multiple documents
 
 _(Only for Windows and Linux)_

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -152,7 +152,7 @@ RUN bash -c 'if [[ "$(pipx --version)" < "1" ]]; then \
                 && rm -rf /var/lib/apt/lists/*; \
               else true; fi'
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends mupdf \
+    && apt-get install -y --no-install-recommends mupdf thunar \
     && rm -rf /var/lib/apt/lists/*
 """
 
@@ -166,7 +166,7 @@ RUN dnf install -y git rpm-build podman python3 python3-devel python3-poetry-cor
 # See https://github.com/freedomofpress/dangerzone/issues/286#issuecomment-1347149783
 RUN rpm --restore shadow-utils
 
-RUN dnf install -y mupdf && dnf clean all
+RUN dnf install -y mupdf thunar && dnf clean all
 """
 
 # The Dockerfile for building a development environment for Dangerzone. Parts of the
@@ -210,7 +210,7 @@ RUN cd /home/user/dangerzone && poetry --no-ansi install
 DOCKERFILE_BUILD_DEBIAN_DEPS = r"""
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends mupdf \
+    && apt-get install -y --no-install-recommends mupdf thunar \
     && rm -rf /var/lib/apt/lists/*
 """
 
@@ -220,7 +220,7 @@ RUN dnf install -y /tmp/pyside6.rpm
 """
 
 DOCKERFILE_BUILD_FEDORA_DEPS = r"""
-RUN dnf install -y mupdf && dnf clean all
+RUN dnf install -y mupdf thunar && dnf clean all
 
 # FIXME: Drop this fix after it's resolved upstream.
 # See https://github.com/freedomofpress/dangerzone/issues/286#issuecomment-1347149783

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -158,6 +158,10 @@ Run Dangerzone against a list of documents, and tick all options. Ensure that:
 Run Dangerzone against a set of documents that you drag-n-drop. Files should be
 added and conversion should run without issue.
 
+> [!TIP]
+> On our end-user container environments for Linux, we can start a file manager
+> with `thunar &`.
+
 #### 9. Dangerzone CLI succeeds in converting multiple documents
 
 _(Only for Windows and Linux)_


### PR DESCRIPTION
Make the following improvements to our release instructions and scripts:
1. Add a way to check if the installed Python version is the expected one.
2. Install the Thunar file manager in our Dangerzone container environments.
3. Do not use the builder cache by default, when building the Dangerzone container image. Add instead the `--use-cache` flag, when the developer wants to expedite the process for non-release builds. 