### PR TITLE
Make PyMuPDF always log to stderr

### DIFF
--- a/dangerzone/conversion/doc_to_pixels.py
+++ b/dangerzone/conversion/doc_to_pixels.py
@@ -3,6 +3,17 @@ import os
 import sys
 from typing import Dict, Optional
 
+# XXX: PyMUPDF logs to stdout by default [1]. The PyMuPDF devs provide a way [2] to log to
+# stderr, but it's based on environment variables. These envvars are consulted at import
+# time [3], so we have to set them here, before we import `fitz`.
+#
+# [1] https://github.com/freedomofpress/dangerzone/issues/877
+# [2] https://github.com/pymupdf/PyMuPDF/issues/3135#issuecomment-1992625724
+# [3] https://github.com/pymupdf/PyMuPDF/blob/9717935eeb2d50d15440d62575878214226795f9/src/__init__.py#L62-L63
+os.environ["PYMUPDF_MESSAGE"] = "fd:2"
+os.environ["PYMUPDF_LOG"] = "fd:2"
+
+
 import fitz
 import magic
 

--- a/tests/test_large_set.py
+++ b/tests/test_large_set.py
@@ -75,7 +75,12 @@ class TestLargeSet(TestCli):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        out, _ = p.communicate()
+        try:
+            # Set a global timeout of 5 minutes for the processing of a document.
+            # This is hacky way to sidestep https://github.com/freedomofpress/dangerzone/issues/878
+            out, _ = p.communicate(timeout=5 * 60)
+        except subprocess.TimeoutExpired:
+            print(f"*** TIMEOUT EXCEEDED FOR DOCUMENT '{doc}' ***")
         from strip_ansi import strip_ansi
 
         print(strip_ansi(out.decode()))


### PR DESCRIPTION
PyMUPDF logs to stdout by default, which is problematic because we use the stdout of the conversion process to read the pixel stream of a document.

Make PyMuPDF always log to stderr, by setting the following environment variables: `PYMUPDF_MESSAGE` and `PYMUPDF_LOG`.

Also, set a 5 minute timeout for document processing, when we run our large tests.
    
Fixes #877
Refs #878
