### PR TITLE
container: Set `container_engine_t` SELinux label

### DIFF
--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -106,6 +106,9 @@ class Container(IsolationProvider):
           running gVisor.
         * Do not allow access to the network stack.
         * Run the container as the unprivileged `dangerzone` user.
+        * Set the `container_engine_t` SELinux label, which allows gVisor to work on
+          SELinux-enforcing systems
+          (see https://github.com/freedomofpress/dangerzone/issues/880).
 
         For Podman specifically, where applicable, we also add the following:
         * Do not log the container's output.
@@ -141,6 +144,7 @@ class Container(IsolationProvider):
 
         security_args += ["--cap-drop", "all"]
         security_args += ["--cap-add", "SYS_CHROOT"]
+        security_args += ["--security-opt", "label=type:container_engine_t"]
 
         security_args += ["--network=none"]
         security_args += ["-u", "dangerzone"]


### PR DESCRIPTION
Set the `container_engine_t` SELinux on the **outer** Podman container, so that gVisor does not break on systems where SELinux is enforcing. This label is provided for container engines running within a container, which fits our `runsc` within `crun` situation.

We have considered using the more permissive `label=disable` option, to disable SELinux labels altogether, but we want to take advantage of as many SELinux protections as we can, even for the **outer** container.

Fixes #880