### PR TITLE
Ignore CVE-2024-5175 from our security scans

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -43,3 +43,16 @@ ignore:
   #      > typically be under attacker control making active exploitation
   #      > unlikely.
   - vulnerability: CVE-2024-5535
+  # CVE-2024-5171
+  # =============
+  #
+  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2024-5171
+  # Verdict: Dangerzone is not affected. The rationale is the following:
+  #
+  # The affected library, `libaom.so`, is linked by GStreamer's `libgstaom.so`
+  # library. The vulnerable `aom_img_alloc` function is only used when
+  # **encoding** a video to AV1. LibreOffce uses the **decode** path instead,
+  # when generating thumbnails.
+  #
+  # See also: https://github.com/freedomofpress/dangerzone/issues/895
+  - vulnerability: CVE-2024-5171

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -2,46 +2,6 @@
 # latest release of Dangerzone, and offer our analysis.
 
 ignore:
-  # CVE-2023-7104
-  # =============
-  #
-  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2023-7104
-  # Verdict: Dangerzone is not affected. The rationale is the following:
-  #
-  #   1. This CVE affects malicious/corrupted SQLite DBs.
-  #   2. Databases can be loaded either via LibreOffice Calc or Base. Files for
-  #      the latter are not a valid input to Dangerzone.
-  #   3. Based on the LibreOffice Calc guide [1], users can only refer to
-  #      external databases, not embed them in a spreadsheet.
-  #   4. The actual CVSS score for this vulnerability is High, according to
-  #      NIST, not Critical.
-  #
-  # [1]: From https://wiki.documentfoundation.org/images/f/f4/CG75-CalcGuide.pdf:
-  #
-  #      > The possible data sources for the pivot table are a Calc spreadsheet
-  #      > or an external data source that is registered in LibreOffice. [...]
-  #      > A registered data source is a connection to data held in a database
-  #      > outside of LibreOffice.
-  - vulnerability: CVE-2023-7104
-  # CVE-2024-5535
-  # =============
-  #
-  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2024-5535
-  # Verdict: Dangerzone is not affected. The rationale is the following:
-  #
-  #   1. This CVE affects applications that make network calls. The Dangerzone
-  #      container does not perform any such calls, and has no access to the
-  #      internet.
-  #   2. The OpenSSL devs have marked this issue as low severity [1].
-  #
-  # [1]: From https://www.openssl.org/news/secadv/20240627.txt:
-  #
-  #      > This issue has been assessed as Low severity because applications are
-  #      > most likely to be vulnerable if they are using NPN instead of ALPN -
-  #      > but NPN is not widely used. It also requires an application
-  #      > configuration or programming error. Finally, this issue would not
-  #      > typically be under attacker control making active exploitation
-  #      > unlikely.
   - vulnerability: CVE-2024-5535
   # CVE-2024-5171
   # =============


### PR DESCRIPTION
Ignore CVE-2024-5175 from our security scans, because Dangerzone is not affected by it. Our assessment follows:

The affected library, `libaom.so`, is linked by GStreamer's `libgstaom.so` library. The vulnerable `aom_img_alloc` function is only used when **encoding** a video to AV1. LibreOffce uses the **decode** path instead, when generating thumbnails.

Closes #895
