### PR TITLE
Add link to Tails website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/freedomofpress/dangerzone/compare/v0.7.0...HEAD)
+
+### Added
+
+- Point to the installation instructions that the Tails team maintains for Dangerzone ([announcement](https://tails.net/news/dangerzone/index.en.html))
+
 ## [0.7.0](https://github.com/freedomofpress/dangerzone/compare/v0.7.0...v0.6.1)
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,7 @@ Dangerzone is available for:
 - Debian 11 (bullseye)
 - Fedora 40
 - Fedora 39
+- Tails
 - Qubes OS (beta support)
 
 ### Ubuntu, Debian
@@ -253,6 +254,12 @@ column to "Selected".
 You can now launch Dangerzone from the list of applications for your qube, and
 pass it a file to sanitize.
 
+## Tails
+
+Dangerzone is not yet available by default in Tails, but we have collaborated
+with the Tails team to offer manual
+[installation instructions](https://tails.net/doc/persistent_storage/additional_software/dangerzone/index.en.html)
+for Tails users.
 
 ## Build from source
 


### PR DESCRIPTION
Point users to the installation instructions of Dangerzone in the Tails website. These instructions were recently added to Tails, and we have worked with the Tails developers to make this integration happen.

See also:
* https://tails.net/news/dangerzone/index.en.html
* https://gitlab.tails.boum.org/tails/tails/-/issues/20355