### PR TITLE
Disable gVisor's DirectFS feature

### DIFF
--- a/dangerzone/gvisor_wrapper/entrypoint.py
+++ b/dangerzone/gvisor_wrapper/entrypoint.py
@@ -142,6 +142,9 @@ runsc_argv = [
     "--rootless=true",
     "--network=none",
     "--root=/home/dangerzone/.containers",
+    # Disable DirectFS for to make the seccomp filter even stricter,
+    # at some performance cost.
+    "--directfs=false",
 ]
 if os.environ.get("RUNSC_DEBUG"):
     runsc_argv += ["--debug=true", "--alsologtostderr=true"]


### PR DESCRIPTION
DirectFS is enabled by default in gVisor to improve I/O performance, but comes at the cost of enabling the `openat(2)` syscall (with [severe restrictions](https://gvisor.dev/blog/2023/06/27/directfs/), but still). As Dangerzone is not performance-sensitive, and that it is desirable to guarantee for the document conversion process to not open any files (to mimic some of what SELinux provides), might as well disable it by default.

See #226.