### PR TITLE
Revert "ci: Disable Debian Trixie builds"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -608,13 +608,9 @@ workflows:
       - build-debian-bullseye:
           requires:
             - build-container-image
-      # FIXME: Currently disabled because `stdeb` does not work with Python
-      # 3.12, which has become the default in Debian Trixie. See also:
-      # https://github.com/freedomofpress/dangerzone/issues/773
-      #
-      #- build-debian-trixie:
-      #    requires:
-      #      - build-container-image
+      - build-debian-trixie:
+          requires:
+            - build-container-image
       - build-debian-bookworm:
           requires:
             - build-container-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ aliases:
 
   - &build-deb
     name: Build the .deb package
+    no_output_timeout: 30m
     command: |
       ./install/linux/build-deb.py
       ls -lh deb_dist/


### PR DESCRIPTION
This reverts commit 162ded6a7572dd542d4b3216d449daf65377deb4.

stdeb is back in unstable and trixie now (following <https://tracker.debian.org/news/1553236/accepted-stdeb-0100-21-source-into-unstable/>).

Refs #773.