### PR TITLE
Rename make lint-apply to make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ mypy: mypy-host mypy-tests ## check type hints with mypy
 lint: lint-black lint-isort mypy ## check the code with various linters
 
 .PHONY: lint-apply
-lint-apply: lint-black-apply lint-isort-apply ## apply all the linter's suggestions
+format: lint-black-apply lint-isort-apply ## apply all the linter's suggestions
 
 .PHONY: test
 test:


### PR DESCRIPTION
We are periodically running this command to get the CVEs on track, and it is easier to have it available as `make security-scan`

Note: maybe it's worth also removing the `/tmp/container.tar` before running the command?