### PR TITLE
Windows installer: Allow choosing installation directory during install

### DIFF
--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -199,7 +199,13 @@ def main():
         Id="ARPURLINFOABOUT",
         Value="https://freedom.press",
     )
-    ET.SubElement(product_el, "UIRef", Id="WixUI_Minimal")
+    ET.SubElement(
+        product_el,
+        "Property",
+        Id="WIXUI_INSTALLDIR",
+        Value="INSTALLDIR",
+    )
+    ET.SubElement(product_el, "UIRef", Id="WixUI_InstallDir")
     ET.SubElement(product_el, "UIRef", Id="WixUI_ErrorProgressText")
     ET.SubElement(
         product_el,


### PR DESCRIPTION
Switch to using `WixUI_InstallDir` dialog set in the windows installer and add the `WIXUI_INSTALLDIR` property it needs to let user choose where Dangerzone is installed.

I've tested that installing Dangerzone and converting a test document works by:

- Installing Dangerzone into the default `C:\Program Files (x86)\Dangerzone`.
- Installing Dangerzone into `D:\Program Files (x86)\Dangerzone`.
- Installing Dangerzone with the official installer and then upgrading using an installer built from this branch with a minor version bump into `D:\Program Files (x86)\Dangerzone`.

resolves #148

Also, as a bonus, the `WixUI_Minimal` dialog set used currently seems to have a bug where the license text isn't visible before scrolling down in the window. Scrolling also chops a corner off the Dangerzone logo. The `WixUI_InstallDir` dialog set shows the license in a different way and doesn't have these two issues.

Also, I'd like to try tackling #602 next and the way to use installer dialog sets has changed a bit in Wix 4 onwards, but that's a much larger change so this can be merged first.