### PR TITLE
ci: Update our CircleCI machines to Ubuntu 22.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,10 +275,22 @@ jobs:
 
   ci-fedora-40:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run: *install-podman
+      - run:
+          name: Configure Podman for Ubuntu 22.04
+          command: |
+            # This config circumvents the following issues:
+            # * https://github.com/containers/podman/issues/6368
+            # * https://github.com/containers/podman/issues/10987
+            mkdir -p ~/.config/containers
+            cat > ~/.config/containers/containers.conf \<<EOF
+            [engine]
+            cgroup_manager="cgroupfs"
+            events_logger="file"
+            EOF
 
       - run:
           name: Prepare cache directory
@@ -329,10 +341,22 @@ jobs:
 
   ci-debian-trixie:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run: *install-podman
+      - run:
+          name: Configure Podman for Ubuntu 22.04
+          command: |
+            # This config circumvents the following issues:
+            # * https://github.com/containers/podman/issues/6368
+            # * https://github.com/containers/podman/issues/10987
+            mkdir -p ~/.config/containers
+            cat > ~/.config/containers/containers.conf \<<EOF
+            [engine]
+            cgroup_manager="cgroupfs"
+            events_logger="file"
+            EOF
 
       - run:
           name: Prepare cache directory


### PR DESCRIPTION
Update our CircleCI machines for specific tests (Debian Bookworm and Fedora 40). It seems that the newest Podman version (5.2.1+), when creating a container using the `--userns nomap` triggers a permission denied error in older kernels. E.g.:

    Error: crun: cannot stat `/tmp/storage-run-1000/containers/overlay-containers/d00932f2600df7b0d8f4cc78e2346487ec92bfd17307127f3ae8d4e5bbc7887b/userdata/hosts`: Permission denied: OCI permission denied

The solution that works for us is to update the machine image from Ubuntu 20.04 to Ubuntu 22.04.