### PR TITLE
Update README.md to use / instead of /about.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Take potentially dangerous PDFs, office documents, or images and convert them to
 
 Dangerzone works like this: You give it a document that you don't know if you can trust (for example, an email attachment). Inside of a sandbox, Dangerzone converts the document to a PDF (if it isn't already one), and then converts the PDF into raw pixel data: a huge list of RGB color values for each page. Then, in a separate sandbox, Dangerzone takes this pixel data and converts it back into a PDF.
 
-_Read more about Dangerzone in the [official site](https://dangerzone.rocks/about.html)._
+_Read more about Dangerzone in the [official site](https://dangerzone.rocks)._
 
 ## Getting started
 


### PR DESCRIPTION
Hey!

I noticed the link to the official site is broken:
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/53d9d713-ebbd-423f-ba03-222da79a4618">

so I changed it so that it goes to / instead of about.html:
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/80030dbf-9240-4c70-b00a-1dedd0c48c8c">