### PR TITLE
Always use our own seccomp policy as a default.

### DIFF
--- a/docs/developer/gvisor.md
+++ b/docs/developer/gvisor.md
@@ -70,8 +70,9 @@ following changes:
   - In distributions that offer Podman version 4 or greater, we use the
     `--userns nomap` flag. This flag greatly minimizes the attack surface,
     since the host user is not mapped within the container at all.
-* In distributions that offer Podman 3.x, we add a seccomp filter that adds the
-  `ptrace` syscall, which is required for running gVisor.
+* We use our custom seccomp policy across container engines, since some do not
+  allow the `ptrace` syscall (see
+  [#846](https://github.com/freedomofpress/dangerzone/issues/846)).
 * It labels the **outer** container with the `container_engine_t` SELinux label.
   This label is reserved for running a container engine within a container, and
   is necessary in environments where SELinux is enabled in enforcing mode (see

--- a/tests/isolation_provider/test_container.py
+++ b/tests/isolation_provider/test_container.py
@@ -54,7 +54,6 @@ class TestContainer(IsolationProviderTest):
 
 
 class TestContainerTermination(IsolationProviderTermination):
-
     def test_linger_runtime_kill(
         self,
         provider_wait: base.IsolationProvider,


### PR DESCRIPTION
As per Etienne Perot's comment on #908:

> Then it seems to me like it would be easy to simply apply this seccomp profile under all container runtimes (since there's no reason why the same image and the same command-line would call different syscalls under different container runtimes).

As mentioned in the comments there, we might want to tighten the default seccomp policy, to have more control on what we accept or not.

Fixes #908 