### PR TITLE
Windows Installer: Upgrade to WiX Toolset 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,14 @@ jobs:
           key: v1-tessdata-${{ hashFiles('./install/common/download-tessdata.py') }}
       - name: Run CLI tests
         run: poetry run make test
-      # Taken from: https://github.com/orgs/community/discussions/27149#discussioncomment-3254829
-      - name: Set path for candle and light
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
-        shell: bash
+      - name: Set up .NET CLI environment
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.x"
+      - name: Install WiX Toolset
+        run: dotnet tool install --global wix
+      - name: Add WiX UI extension
+        run: wix extension add --global WixToolset.UI.wixext
       - name: Build the MSI installer
         # NOTE: This also builds the .exe internally.
         run: poetry run .\install\windows\build-app.bat

--- a/BUILD.md
+++ b/BUILD.md
@@ -471,11 +471,24 @@ poetry shell
 .\dev_scripts\dangerzone.bat
 ```
 
-### If you want to build the installer
+### If you want to build the Windows installer
 
-* Go to https://dotnet.microsoft.com/download/dotnet-framework and download and install .NET Framework 3.5 SP1 Runtime. I downloaded `dotnetfx35.exe`.
-* Go to https://wixtoolset.org/releases/ and download and install WiX toolset. I downloaded `wix314.exe`.
-* Add `C:\Program Files (x86)\WiX Toolset v3.14\bin` to the path ([instructions](https://web.archive.org/web/20230221104142/https://windowsloop.com/how-to-add-to-windows-path/)).
+Install [.NET SDK](https://dotnet.microsoft.com/en-us/download) version 6 or later. Then, open a terminal and install the latest version of [WiX Toolset .NET tool](https://wixtoolset.org/) **v5** with:
+
+```sh
+dotnet tool install --global wix --version 5.*
+```
+
+Install the WiX UI extension. You may need to open a new terminal in order to use the newly installed `wix` .NET tool:
+
+```sh
+wix extension add --global WixToolset.UI.wixext/5.x.y
+```
+
+> [!IMPORTANT]  
+> To avoid compatibility issues, ensure the WiX UI extension version matches the version of the WiX Toolset.
+> 
+> Run `wix --version` to check the version of WiX Toolset you have installed and replace `5.x.y` with the full version number without the Git revision.
 
 ### If you want to sign binaries with Authenticode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 - Platform support: Drop support for Fedora 39, since it's end-of-life ([#999](https://github.com/freedomofpress/dangerzone/pull/999))
 
+### Development changes
+
+- Build Dangerzone MSI with Wix Toolset 5 ([#929](https://github.com/freedomofpress/dangerzone/pull/929)).
+  Thanks [@jkarasti](https://github.com/jkarasti) for the contribution.
+
 ## [0.8.0](https://github.com/freedomofpress/dangerzone/compare/v0.8.0...0.7.1)
 
 ### Added

--- a/install/windows/build-app.bat
+++ b/install/windows/build-app.bat
@@ -22,7 +22,7 @@ python install\windows\build-wxs.py
 
 REM build the msi package
 cd build
-wix build -ext WixToolset.UI.wixext .\Dangerzone.wxs -out Dangerzone.msi
+wix build -arch x64 -ext WixToolset.UI.wixext .\Dangerzone.wxs -out Dangerzone.msi
 
 REM validate Dangerzone.msi
 wix msi validate Dangerzone.msi

--- a/install/windows/build-app.bat
+++ b/install/windows/build-app.bat
@@ -17,22 +17,23 @@ signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd
 REM verify the signature of dangerzone-cli.exe
 signtool.exe verify /pa build\exe.win-amd64-3.12\dangerzone-cli.exe
 
-REM build the wix file
-python install\windows\build-wxs.py > build\Dangerzone.wxs
+REM build the wxs file
+python install\windows\build-wxs.py
 
 REM build the msi package
 cd build
-candle.exe Dangerzone.wxs
-light.exe -ext WixUIExtension Dangerzone.wixobj
+wix build -ext WixToolset.UI.wixext .\Dangerzone.wxs -out Dangerzone.msi
+
+REM validate Dangerzone.msi
+wix msi validate Dangerzone.msi
 
 REM code sign Dangerzone.msi
-insignia.exe -im Dangerzone.msi
 signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha256 /t http://time.certum.pl/ Dangerzone.msi
 
 REM verify the signature of Dangerzone.msi
 signtool.exe verify /pa Dangerzone.msi
 
-REM moving Dangerzone.msi to dist
+REM move Dangerzone.msi to dist
 cd ..
 mkdir dist
 move build\Dangerzone.msi dist

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -17,7 +17,7 @@ def build_data(dirname, dir_prefix, id_, name):
         if os.path.isfile(filename):
             data["files"].append(os.path.join(dir_prefix, basename))
         elif os.path.isdir(filename):
-            if id_ == "INSTALLDIR":
+            if id_ == "INSTALLFOLDER":
                 id_prefix = "Folder"
             else:
                 id_prefix = id_
@@ -42,7 +42,7 @@ def build_data(dirname, dir_prefix, id_, name):
             )
 
     if len(data["files"]) > 0:
-        if id_ == "INSTALLDIR":
+        if id_ == "INSTALLFOLDER":
             data["component_id"] = "ApplicationFiles"
         else:
             data["component_id"] = "FolderComponent" + id_[len("Folder") :]
@@ -75,8 +75,8 @@ def build_dir_xml(root, data):
             Id="ApplicationShortcut1",
             Name="Dangerzone",
             Description="Dangerzone",
-            Target="[INSTALLDIR]dangerzone.exe",
-            WorkingDirectory="INSTALLDIR",
+            Target="[INSTALLFOLDER]dangerzone.exe",
+            WorkingDirectory="INSTALLFOLDER",
         )
         ET.SubElement(
             component_el,
@@ -153,7 +153,7 @@ def main():
         build_data(
             dist_dir,
             "exe.win-amd64-3.12",
-            "INSTALLDIR",
+            "INSTALLFOLDER",
             "Dangerzone",
         )
     )
@@ -204,7 +204,7 @@ def main():
         product_el,
         "Property",
         Id="WIXUI_INSTALLDIR",
-        Value="INSTALLDIR",
+        Value="INSTALLFOLDER",
     )
     ET.SubElement(product_el, "UIRef", Id="WixUI_InstallDir")
     ET.SubElement(product_el, "UIRef", Id="WixUI_ErrorProgressText")

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -118,17 +118,17 @@ def main():
         "Package",
         Name="Dangerzone",
         Manufacturer="Freedom of the Press Foundation",
-        UpgradeCode="$(var.ProductUpgradeCode)",
+        UpgradeCode="12b9695c-965b-4be0-bc33-21274e809576",
         Language="1033",
         Compressed="yes",
         Codepage="1252",
-        Version="$(var.ProductVersion)",
+        Version=version,
     )
     ET.SubElement(
         package_el,
         "SummaryInformation",
         Keywords="Installer",
-        Description="Dangerzone $(var.ProductVersion) Installer",
+        Description="Dangerzone " + version + " Installer",
         Codepage="1252",
     )
     ET.SubElement(package_el, "MediaTemplate", EmbedCab="yes")
@@ -225,8 +225,6 @@ def main():
     ET.SubElement(feature_el, "ComponentGroupRef", Id="ApplicationComponents")
     ET.SubElement(feature_el, "ComponentRef", Id="ApplicationShortcuts")
 
-    print(f'<?define ProductVersion = "{version}"?>')
-    print('<?define ProductUpgradeCode = "12b9695c-965b-4be0-bc33-21274e809576"?>')
     ET.indent(wix_el, space="    ")
     print(ET.tostring(wix_el).decode())
 

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -220,7 +220,6 @@ def main():
     ET.SubElement(
         package_el,
         "MajorUpgrade",
-        AllowSameVersionUpgrades="yes",
         DowngradeErrorMessage="A newer version of [ProductName] is already installed. If you are sure you want to downgrade, remove the existing installation via Programs and Features.",
     )
 

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -82,7 +82,7 @@ def build_dir_xml(root, data):
             component_el,
             "RegistryValue",
             Root="HKCU",
-            Key="Software\Freedom of the Press Foundation\Dangerzone",
+            Key="Software\\Freedom of the Press Foundation\\Dangerzone",
             Name="installed",
             Type="integer",
             Value="1",

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -114,7 +114,13 @@ def main():
     )
 
     # Add the Wix root element
-    wix_el = ET.Element("Wix", xmlns="http://wixtoolset.org/schemas/v4/wxs")
+    wix_el = ET.Element(
+        "Wix",
+        {
+            "xmlns": "http://wixtoolset.org/schemas/v4/wxs",
+            "xmlns:ui": "http://wixtoolset.org/schemas/v4/wxs/ui",
+        },
+    )
 
     # Add the Package element
     package_el = ET.SubElement(
@@ -153,12 +159,8 @@ def main():
         Value="https://freedom.press",
     )
     ET.SubElement(
-        package_el,
-        "Property",
-        Id="WIXUI_INSTALLDIR",
-        Value="INSTALLFOLDER",
+        package_el, "ui:WixUI", Id="WixUI_InstallDir", InstallDirectory="INSTALLFOLDER"
     )
-    ET.SubElement(package_el, "UIRef", Id="WixUI_InstallDir")
     ET.SubElement(package_el, "UIRef", Id="WixUI_ErrorProgressText")
     ET.SubElement(
         package_el,

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -64,26 +64,17 @@ def build_dir_xml(root, data):
 
 
 def build_components_xml(root, data):
-    component_ids = []
-    if "component_id" in data:
-        component_ids.append(data["component_id"])
-
-        if "component_guid" in data:
-            dir_ref_el = ET.SubElement(root, "DirectoryRef", Id=data["directory_id"])
-            component_el = ET.SubElement(
-                dir_ref_el,
-                "Component",
-                Id=data["component_id"],
-                Guid=data["component_guid"],
-            )
-            for filename in data["files"]:
-                file_el = ET.SubElement(
-                    component_el, "File", Source=filename, Id="file_" + uuid.uuid4().hex
-                )
+    component_el = ET.SubElement(
+        root,
+        "Component",
+        Id=data["component_id"],
+        Guid=data["component_guid"],
+        Directory=data["directory_id"],
+    )
+    for filename in data["files"]:
+        ET.SubElement(component_el, "File", Source=filename)
     for subdata in data["dirs"]:
-        component_ids += build_components_xml(root, subdata)
-
-    return component_ids
+        build_components_xml(root, subdata)
 
 
 def main():
@@ -233,8 +224,7 @@ def main():
 
     # Add the Feature element
     feature_el = ET.SubElement(package_el, "Feature", Id="DefaultFeature", Level="1")
-    for component_id in component_ids:
-        ET.SubElement(feature_el, "ComponentRef", Id=component_id)
+    ET.SubElement(feature_el, "ComponentGroupRef", Id="ApplicationComponents")
     ET.SubElement(feature_el, "ComponentRef", Id="ApplicationShortcuts")
 
     print(f'<?define ProductVersion = "{version}"?>')

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -141,7 +141,7 @@ def main():
         Description="Dangerzone $(var.ProductVersion) Installer",
         Codepage="1252",
     )
-    ET.SubElement(package_el, "Media", Id="1", Cabinet="product.cab", EmbedCab="yes")
+    ET.SubElement(package_el, "MediaTemplate", EmbedCab="yes")
     ET.SubElement(
         package_el, "Icon", Id="ProductIcon", SourceFile="..\\share\\dangerzone.ico"
     )

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -16,7 +16,7 @@ def build_data(base_path, path_prefix, dir_id, dir_name):
         data["component_id"] = "ApplicationFiles"
     else:
         data["component_id"] = "Component" + dir_id
-    data["component_guid"] = str(uuid.uuid4())
+    data["component_guid"] = str(uuid.uuid4()).upper()
 
     for entry in os.listdir(base_path):
         entry_path = os.path.join(base_path, entry)
@@ -118,7 +118,7 @@ def main():
         "Package",
         Name="Dangerzone",
         Manufacturer="Freedom of the Press Foundation",
-        UpgradeCode="12b9695c-965b-4be0-bc33-21274e809576",
+        UpgradeCode="12B9695C-965B-4BE0-BC33-21274E809576",
         Language="1033",
         Compressed="yes",
         Codepage="1252",
@@ -181,7 +181,7 @@ def main():
         programmenufolder_el,
         "Component",
         Id="ApplicationShortcuts",
-        Guid="539e7de8-a124-4c09-aa55-0dd516aad7bc",
+        Guid="539E7DE8-A124-4C09-AA55-0DD516AAD7BC",
     )
     ET.SubElement(
         shortcut_el,

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -234,7 +234,6 @@ def main():
         ET.SubElement(feature_el, "ComponentRef", Id=component_id)
     ET.SubElement(feature_el, "ComponentRef", Id="ApplicationShortcuts")
 
-    print('<?xml version="1.0" encoding="utf-8"?>')
     print(f'<?define ProductVersion = "{version}"?>')
     print('<?define ProductUpgradeCode = "12b9695c-965b-4be0-bc33-21274e809576"?>')
     ET.indent(root_el, space="    ")

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -61,34 +61,6 @@ def build_dir_xml(root, data):
     for subdata in data["dirs"]:
         build_dir_xml(el, subdata)
 
-    # If this is the ProgramMenuFolder, add the menu component
-    if "id" in data and data["id"] == "ProgramMenuFolder":
-        component_el = ET.SubElement(
-            el,
-            "Component",
-            Id="ApplicationShortcuts",
-            Guid="539e7de8-a124-4c09-aa55-0dd516aad7bc",
-        )
-        ET.SubElement(
-            component_el,
-            "Shortcut",
-            Id="ApplicationShortcut1",
-            Name="Dangerzone",
-            Description="Dangerzone",
-            Target="[INSTALLFOLDER]dangerzone.exe",
-            WorkingDirectory="INSTALLFOLDER",
-        )
-        ET.SubElement(
-            component_el,
-            "RegistryValue",
-            Root="HKCU",
-            Key="Software\\Freedom of the Press Foundation\\Dangerzone",
-            Name="installed",
-            Type="integer",
-            Value="1",
-            KeyPath="yes",
-        )
-
 
 def build_components_xml(root, data):
     component_ids = []
@@ -140,10 +112,6 @@ def main():
         "dirs": [
             {
                 "id": "ProgramFilesFolder",
-                "dirs": [],
-            },
-            {
-                "id": "ProgramMenuFolder",
                 "dirs": [],
             },
         ],
@@ -221,6 +189,39 @@ def main():
         package_el,
         "MajorUpgrade",
         DowngradeErrorMessage="A newer version of [ProductName] is already installed. If you are sure you want to downgrade, remove the existing installation via Programs and Features.",
+    )
+
+    # Add the ProgramMenuFolder StandardDirectory
+    programmenufolder_el = ET.SubElement(
+        package_el,
+        "StandardDirectory",
+        Id="ProgramMenuFolder",
+    )
+    # Add a shortcut for Dangerzone in the Start menu
+    shortcut_el = ET.SubElement(
+        programmenufolder_el,
+        "Component",
+        Id="ApplicationShortcuts",
+        Guid="539e7de8-a124-4c09-aa55-0dd516aad7bc",
+    )
+    ET.SubElement(
+        shortcut_el,
+        "Shortcut",
+        Id="DangerzoneStartMenuShortcut",
+        Name="Dangerzone",
+        Description="Dangerzone",
+        Target="[INSTALLFOLDER]dangerzone.exe",
+        WorkingDirectory="INSTALLFOLDER",
+    )
+    ET.SubElement(
+        shortcut_el,
+        "RegistryValue",
+        Root="HKCU",
+        Key="Software\\Freedom of the Press Foundation\\Dangerzone",
+        Name="installed",
+        Type="integer",
+        Value="1",
+        KeyPath="yes",
     )
 
     build_dir_xml(package_el, data)

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -234,10 +234,10 @@ def main():
         ET.SubElement(feature_el, "ComponentRef", Id=component_id)
     ET.SubElement(feature_el, "ComponentRef", Id="ApplicationShortcuts")
 
-    print('<?xml version="1.0" encoding="windows-1252"?>')
+    print('<?xml version="1.0" encoding="utf-8"?>')
     print(f'<?define ProductVersion = "{version}"?>')
     print('<?define ProductUpgradeCode = "12b9695c-965b-4be0-bc33-21274e809576"?>')
-    ET.indent(root_el)
+    ET.indent(root_el, space="    ")
     print(ET.tostring(root_el).decode())
 
 

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -211,7 +211,7 @@ def main():
     programfilesfolder_el = ET.SubElement(
         package_el,
         "StandardDirectory",
-        Id="ProgramFilesFolder",
+        Id="ProgramFiles64Folder",
     )
 
     # Create the directory structure for the installed product

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -86,11 +86,15 @@ def main():
         # -rc markers.
         version = f.read().strip().split("-")[0]
 
-    dist_dir = os.path.join(
+    build_dir = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
         "build",
-        "exe.win-amd64-3.12",
     )
+
+    cx_freeze_dir = "exe.win-amd64-3.12"
+
+    dist_dir = os.path.join(build_dir, cx_freeze_dir)
+
     if not os.path.exists(dist_dir):
         print("You must build the dangerzone binary before running this")
         return
@@ -98,7 +102,7 @@ def main():
     # Prepare data for WiX file harvesting from the output of cx_Freeze
     data = build_data(
         dist_dir,
-        "exe.win-amd64-3.12",
+        cx_freeze_dir,
         "INSTALLFOLDER",
         "Dangerzone",
     )
@@ -226,7 +230,9 @@ def main():
     ET.SubElement(feature_el, "ComponentRef", Id="ApplicationShortcuts")
 
     ET.indent(wix_el, space="    ")
-    print(ET.tostring(wix_el).decode())
+
+    with open(os.path.join(build_dir, "Dangerzone.wxs"), "w") as wxs_file:
+        wxs_file.write(ET.tostring(wix_el).decode())
 
 
 if __name__ == "__main__":

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -52,15 +52,13 @@ def build_data(base_path, path_prefix, dir_id, dir_name):
     return data
 
 
-def build_dir_xml(root, data):
+def build_directory_xml(root, data):
     attrs = {}
-    if "id" in data:
-        attrs["Id"] = data["directory_id"]
-    if "name" in data:
-        attrs["Name"] = data["directory_name"]
-    el = ET.SubElement(root, "Directory", attrs)
+    attrs["Id"] = data["directory_id"]
+    attrs["Name"] = data["directory_name"]
+    directory_el = ET.SubElement(root, "Directory", attrs)
     for subdata in data["dirs"]:
-        build_dir_xml(el, subdata)
+        build_directory_xml(directory_el, subdata)
 
 
 def build_components_xml(root, data):
@@ -213,7 +211,7 @@ def main():
     )
 
     # Create the directory structure for the installed product
-    build_dir_xml(programfilesfolder_el, data)
+    build_directory_xml(programfilesfolder_el, data)
 
     # Create a component group for application components
     applicationcomponents_el = ET.SubElement(

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -158,9 +158,10 @@ def main():
         )
     )
 
-    root_el = ET.Element("Wix", xmlns="http://schemas.microsoft.com/wix/2006/wi")
+    # Add the Wix root element
+    wix_el = ET.Element("Wix", xmlns="http://wixtoolset.org/schemas/v4/wxs")
     product_el = ET.SubElement(
-        root_el,
+        wix_el,
         "Product",
         Name="Dangerzone",
         Manufacturer="Freedom of the Press Foundation",
@@ -236,8 +237,8 @@ def main():
 
     print(f'<?define ProductVersion = "{version}"?>')
     print('<?define ProductUpgradeCode = "12b9695c-965b-4be0-bc33-21274e809576"?>')
-    ET.indent(root_el, space="    ")
-    print(ET.tostring(root_el).decode())
+    ET.indent(wix_el, space="    ")
+    print(ET.tostring(wix_el).decode())
 
 
 if __name__ == "__main__":

--- a/install/windows/build-wxs.py
+++ b/install/windows/build-wxs.py
@@ -160,77 +160,75 @@ def main():
 
     # Add the Wix root element
     wix_el = ET.Element("Wix", xmlns="http://wixtoolset.org/schemas/v4/wxs")
-    product_el = ET.SubElement(
+
+    # Add the Package element
+    package_el = ET.SubElement(
         wix_el,
-        "Product",
+        "Package",
         Name="Dangerzone",
         Manufacturer="Freedom of the Press Foundation",
-        Id="*",
         UpgradeCode="$(var.ProductUpgradeCode)",
         Language="1033",
+        Compressed="yes",
         Codepage="1252",
         Version="$(var.ProductVersion)",
     )
     ET.SubElement(
-        product_el,
-        "Package",
-        Id="*",
+        package_el,
+        "SummaryInformation",
         Keywords="Installer",
         Description="Dangerzone $(var.ProductVersion) Installer",
-        Manufacturer="Freedom of the Press Foundation",
-        InstallerVersion="100",
-        Languages="1033",
-        Compressed="yes",
-        SummaryCodepage="1252",
+        Codepage="1252",
     )
-    ET.SubElement(product_el, "Media", Id="1", Cabinet="product.cab", EmbedCab="yes")
+    ET.SubElement(package_el, "Media", Id="1", Cabinet="product.cab", EmbedCab="yes")
     ET.SubElement(
-        product_el, "Icon", Id="ProductIcon", SourceFile="..\\share\\dangerzone.ico"
+        package_el, "Icon", Id="ProductIcon", SourceFile="..\\share\\dangerzone.ico"
     )
-    ET.SubElement(product_el, "Property", Id="ARPPRODUCTICON", Value="ProductIcon")
+    ET.SubElement(package_el, "Property", Id="ARPPRODUCTICON", Value="ProductIcon")
     ET.SubElement(
-        product_el,
+        package_el,
         "Property",
         Id="ARPHELPLINK",
         Value="https://dangerzone.rocks",
     )
     ET.SubElement(
-        product_el,
+        package_el,
         "Property",
         Id="ARPURLINFOABOUT",
         Value="https://freedom.press",
     )
     ET.SubElement(
-        product_el,
+        package_el,
         "Property",
         Id="WIXUI_INSTALLDIR",
         Value="INSTALLFOLDER",
     )
-    ET.SubElement(product_el, "UIRef", Id="WixUI_InstallDir")
-    ET.SubElement(product_el, "UIRef", Id="WixUI_ErrorProgressText")
+    ET.SubElement(package_el, "UIRef", Id="WixUI_InstallDir")
+    ET.SubElement(package_el, "UIRef", Id="WixUI_ErrorProgressText")
     ET.SubElement(
-        product_el,
+        package_el,
         "WixVariable",
         Id="WixUILicenseRtf",
         Value="..\\install\\windows\\license.rtf",
     )
     ET.SubElement(
-        product_el,
+        package_el,
         "WixVariable",
         Id="WixUIDialogBmp",
         Value="..\\install\\windows\\dialog.bmp",
     )
     ET.SubElement(
-        product_el,
+        package_el,
         "MajorUpgrade",
         AllowSameVersionUpgrades="yes",
         DowngradeErrorMessage="A newer version of [ProductName] is already installed. If you are sure you want to downgrade, remove the existing installation via Programs and Features.",
     )
 
-    build_dir_xml(product_el, data)
-    component_ids = build_components_xml(product_el, data)
+    build_dir_xml(package_el, data)
+    component_ids = build_components_xml(package_el, data)
 
-    feature_el = ET.SubElement(product_el, "Feature", Id="DefaultFeature", Level="1")
+    # Add the Feature element
+    feature_el = ET.SubElement(package_el, "Feature", Id="DefaultFeature", Level="1")
     for component_id in component_ids:
         ET.SubElement(feature_el, "ComponentRef", Id=component_id)
     ET.SubElement(feature_el, "ComponentRef", Id="ApplicationShortcuts")


### PR DESCRIPTION
This upgrades tooling used to build the Dangerzone.msi installer to WiX Toolset 5.

The Major change in this, apart from what running `wix convert` on the old generated WiX authoring, is that the target directory for each component gets set in the `Directory` attribute of the component instead of a separate `Directory` element one level above in the XML hierarchy. All components get grouped under a `ComponentGroup` that gets referenced in the `Feature` tree, which makes things much simpler aswell.

There are still a couple of open questions:

#### Should `AllowSameVersionUpgrades="yes"` be removed?

According to the [documentation](https://wixtoolset.org/docs/schema/wxs/majorupgrade/#attributes) setting it useful if the installer uses a fourth version number. But Dangerzone doesn't use one so it should be save to remove it. Running `wix msi validate` on the built msi also prints a warning about this.

#### What to set the value of  `InstallerVersion` to?

In this its set to `200` to make 64 bit installer work, but it could also be removed or set to the default  `500`, which would cap the lowest version of windows Dangerzone supports to Windows 7.

#### Should Dangerzone also set a desktop icon?

This is also a possibility, but opinions vary is this is good practice or not. Also this should come with an option to not install the icon, but that would require developing some custom dialogs for the installer.

#### Customise the installer theming more?

This should probably be its own issue. The installer, while limited, allows for a bit customization, mainly by addind a banner image that would replace the red cd icon shown during install currently. The installer already uses a custom image shown at the start of the installation . For more, see:

https://wixtoolset.org/docs/tools/wixext/wixui/#replacing-the-default-bitmaps
https://stackoverflow.com/questions/48713061/how-do-you-change-the-red-cd-icon-on-wix

> [!CAUTION]
> One unfortunate side effect this has is that installing the newer installer does not uninstall older versions of Dangerzone.
> The root cause for this is a changed default for the `Scope` attribute in the `Package` element. In WiX 3 it was apparently
> set to `perUser` by mistake and in WiX 4 its set to `perMachine`

One workaround for the uninstallation issue would be to set `Scope="perUser"` attribute in the `Package` element. But MSIs apparently have poor support for per user packages, though I havent figured out how exactly just yet.

Another solution could be to bite the bullet this once and guide users on Windows into uninstalling the older version of Dangerzone somehow, for example a blog post or a pinned issue, or maybe within Dangerzone itself. SInce this pull request also makes Dangerzone a proper 64 bit installation, the new version should install itself alongside the old one just fine without breaking anything. Though it'll show up twice in installed programs and the start menu, leaving it up to the user to discover older version is still installed and uninstall it. Not exactly the best user experience.

closes #602 