### PR TITLE
Sign Dangerzone executables and installer with SHA256

### DIFF
--- a/install/windows/build-app.bat
+++ b/install/windows/build-app.bat
@@ -2,12 +2,14 @@ REM delete old dist and build files
 rmdir /s /q dist
 rmdir /s /q build
 
-REM build the exe
+REM build the gui and cli exe
 python .\setup-windows.py build
 
 REM code sign dangerzone.exe
-signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha1 /t http://time.certum.pl/ build\exe.win-amd64-3.12\dangerzone.exe
-signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha1 /t http://time.certum.pl/ build\exe.win-amd64-3.12\dangerzone-cli.exe
+signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha256 /t http://time.certum.pl/ build\exe.win-amd64-3.12\dangerzone.exe
+
+REM code sign dangerzone-cli.exe
+signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha256 /t http://time.certum.pl/ build\exe.win-amd64-3.12\dangerzone-cli.exe
 
 REM build the wix file
 python install\windows\build-wxs.py > build\Dangerzone.wxs
@@ -17,9 +19,9 @@ cd build
 candle.exe Dangerzone.wxs
 light.exe -ext WixUIExtension Dangerzone.wixobj
 
-REM code sign dangerzone.msi
+REM code sign Dangerzone.msi
 insignia.exe -im Dangerzone.msi
-signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha1 /t http://time.certum.pl/ Dangerzone.msi
+signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha256 /t http://time.certum.pl/ Dangerzone.msi
 
 REM moving Dangerzone.msi to dist
 cd ..

--- a/install/windows/build-app.bat
+++ b/install/windows/build-app.bat
@@ -8,8 +8,14 @@ python .\setup-windows.py build
 REM code sign dangerzone.exe
 signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha256 /t http://time.certum.pl/ build\exe.win-amd64-3.12\dangerzone.exe
 
+REM verify the signature of dangerzone.exe
+signtool.exe verify /pa build\exe.win-amd64-3.12\dangerzone.exe
+
 REM code sign dangerzone-cli.exe
 signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha256 /t http://time.certum.pl/ build\exe.win-amd64-3.12\dangerzone-cli.exe
+
+REM verify the signature of dangerzone-cli.exe
+signtool.exe verify /pa build\exe.win-amd64-3.12\dangerzone-cli.exe
 
 REM build the wix file
 python install\windows\build-wxs.py > build\Dangerzone.wxs
@@ -22,6 +28,9 @@ light.exe -ext WixUIExtension Dangerzone.wixobj
 REM code sign Dangerzone.msi
 insignia.exe -im Dangerzone.msi
 signtool.exe sign /v /d "Dangerzone" /a /n "Freedom of the Press Foundation" /fd sha256 /t http://time.certum.pl/ Dangerzone.msi
+
+REM verify the signature of Dangerzone.msi
+signtool.exe verify /pa Dangerzone.msi
 
 REM moving Dangerzone.msi to dist
 cd ..


### PR DESCRIPTION
Something I noticed while working on the windows installer is that it and executables shipped with dangerzone are still using SHA1 as the signature algorithm so let's fix that.

The first commit switches to SHA256 as recommended by the signtool.exe [docs](https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool).

A further improvement here could be changing `/t http://time.certum.pl/` to `/tr http://time.certum.pl/` and adding `/td sha256` but I have no idea if the Certum time server supports RFC 3161 time stamp protocol, it's not [documented](https://support.certum.eu/en/signing-the-code-using-tools-like-signtool-and-jarsigner-instruction/) at least. Might be something to take into consideration at some point as not using `/td` is going to cause an error in a future version of signtool, though there's no timeline provided for the change.

The second commit adds an additional step that runs `signtool verify` to verify the signature of the files after signing. Something I picked up from the docs for code signing provided by Certum. Not really a mandatory step, but better safe than sorry, especially with something like code signing.

I obviously don't have access to the Dangerzone code signing certificate, so this is very much a shot in the dark as to whether it works as intended or not. 