### PR TITLE
Preparations for the on-host conversion PR

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *     text=auto
+*.py  text eol=lf
 *.jpg -text
 *.gif -text
 *.png -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,15 @@ jobs:
         run: poetry run .\install\windows\build-app.bat
 
   macOS:
-    runs-on: macos-latest
+    name: "macOS (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest  # CPU type: Apple Silicon (M1)
+            arch: arch64
+          - runner: macos-13  # CPU type: Intel x86_64
+            arch: x86_64
     env:
       DUMMY_CONVERSION: 1
     steps:

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -259,6 +259,11 @@ class IsolationProvider(ABC):
     ) -> Iterator[subprocess.Popen]:
         """Start a conversion process, pass it to the caller, and then clean it up."""
         p = self.start_doc_to_pixels_proc(document)
+        if platform.system() != "Windows":
+            assert os.getpgid(p.pid) != os.getpgid(
+                os.getpid()
+            ), "Parent shares same PGID with child"
+
         try:
             yield p
         except errors.ConverterProcException as e:

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -13,7 +13,12 @@ from ..conversion import errors
 from ..document import Document
 from ..util import get_tmp_dir  # NOQA : required for mocking in our tests.
 from ..util import get_resource_path, get_subprocess_startupinfo
-from .base import PIXELS_TO_PDF_LOG_END, PIXELS_TO_PDF_LOG_START, IsolationProvider
+from .base import (
+    PIXELS_TO_PDF_LOG_END,
+    PIXELS_TO_PDF_LOG_START,
+    IsolationProvider,
+    terminate_process_group,
+)
 
 TIMEOUT_KILL = 5  # Timeout in seconds until the kill command returns.
 
@@ -436,7 +441,7 @@ class Container(IsolationProvider):
         #
         # See also https://github.com/freedomofpress/dangerzone/issues/791
         self.kill_container(self.doc_to_pixels_container_name(document))
-        p.terminate()
+        terminate_process_group(p)
 
     def ensure_stop_doc_to_pixels_proc(  # type: ignore [no-untyped-def]
         self, document: Document, *args, **kwargs

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -267,6 +267,9 @@ class Container(IsolationProvider):
             stdout=subprocess.PIPE,
             stderr=self.proc_stderr,
             startupinfo=startupinfo,
+            # Start the conversion process in a new session, so that we can later on
+            # kill the process group, without killing the controlling script.
+            start_new_session=True,
         )
 
     def exec_container(

--- a/dangerzone/isolation_provider/dummy.py
+++ b/dangerzone/isolation_provider/dummy.py
@@ -59,7 +59,6 @@ class Dummy(IsolationProvider):
             self.print_progress(document, error, text, percentage)  # type: ignore [arg-type]
             if error:
                 success = False
-            time.sleep(0.2)
         if success:
             shutil.copy(
                 get_resource_path("dummy_document.pdf"), document.output_filename

--- a/dangerzone/isolation_provider/dummy.py
+++ b/dangerzone/isolation_provider/dummy.py
@@ -73,7 +73,7 @@ class Dummy(IsolationProvider):
         pass
 
     def start_doc_to_pixels_proc(self, document: Document) -> subprocess.Popen:
-        return subprocess.Popen("True")
+        return subprocess.Popen("True", start_new_session=True)
 
     def terminate_doc_to_pixels_proc(
         self, document: Document, p: subprocess.Popen

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -67,6 +67,9 @@ class Qubes(IsolationProvider):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=stderr,
+            # Start the conversion process in a new session, so that we can later on
+            # kill the process group, without killing the controlling script.
+            start_new_session=True,
         )
 
         if dev_mode:

--- a/tests/isolation_provider/base.py
+++ b/tests/isolation_provider/base.py
@@ -140,14 +140,14 @@ class IsolationProviderTermination:
         terminate_proc_mock = mocker.patch.object(
             provider_wait, "terminate_doc_to_pixels_proc", return_value=None
         )
-        popen_kill_spy = mocker.spy(subprocess.Popen, "kill")
+        kill_pg_spy = mocker.spy(base, "kill_process_group")
 
         with provider_wait.doc_to_pixels_proc(doc, timeout_grace=0) as proc:
             pass
 
         get_proc_exception_spy.assert_not_called()
         terminate_proc_mock.assert_called()
-        popen_kill_spy.assert_called()
+        kill_pg_spy.assert_called()
         assert proc.poll() is not None
 
     def test_linger_unkillable(
@@ -165,8 +165,8 @@ class IsolationProviderTermination:
         terminate_proc_mock = mocker.patch.object(
             provider_wait, "terminate_doc_to_pixels_proc", return_value=None
         )
-        popen_kill_mock = mocker.patch.object(
-            subprocess.Popen, "kill", return_value=None
+        kill_pg_mock = mocker.patch(
+            "dangerzone.isolation_provider.base.kill_process_group", return_value=None
         )
 
         with provider_wait.doc_to_pixels_proc(
@@ -176,7 +176,7 @@ class IsolationProviderTermination:
 
         get_proc_exception_spy.assert_not_called()
         terminate_proc_mock.assert_called()
-        popen_kill_mock.assert_called()
+        kill_pg_mock.assert_called()
         assert proc.poll() is None
 
         # Reset the function to the original state.

--- a/tests/isolation_provider/test_container.py
+++ b/tests/isolation_provider/test_container.py
@@ -3,10 +3,7 @@ import subprocess
 import time
 
 import pytest
-from pytest_mock import MockerFixture
 
-from dangerzone.document import Document
-from dangerzone.isolation_provider import base
 from dangerzone.isolation_provider.container import Container
 from dangerzone.isolation_provider.qubes import is_qubes_native_conversion
 
@@ -54,49 +51,4 @@ class TestContainer(IsolationProviderTest):
 
 
 class TestContainerTermination(IsolationProviderTermination):
-    def test_linger_runtime_kill(
-        self,
-        provider_wait: base.IsolationProvider,
-        mocker: MockerFixture,
-    ) -> None:
-        # Check that conversions that remain stuck on `docker|podman kill` are
-        # terminated forcefully.
-        doc = Document()
-        provider_wait.progress_callback = mocker.MagicMock()
-        get_proc_exception_spy = mocker.spy(provider_wait, "get_proc_exception")
-        terminate_proc_spy = mocker.spy(provider_wait, "terminate_doc_to_pixels_proc")
-        kill_proc_spy = mocker.spy(base, "kill_process_group")
-
-        # Switch the subprocess.run() function with a patched function that
-        # intercepts the `kill` command and switches it with `wait` instead. This way,
-        # we emulate a `docker|podman kill` command that has hang.
-        orig_subprocess_run = subprocess.run
-
-        def patched_subprocess_run(*args, **kwargs):  # type: ignore [no-untyped-def]
-            assert len(args) == 1
-            cmd = args[0]
-            if cmd[1] == "kill":
-                # Switch the `kill` command with `wait`, thereby triggering a timeout.
-                cmd[1] = "wait"
-
-                # Make sure that a timeout has been specified, and make it 0, so that
-                # the test ends us quickly as possible.
-                assert "timeout" in kwargs
-                kwargs[timeout] = 0
-
-                # Make sure that the modified command times out.
-                with pytest.raises(subprocess.TimeoutExpired):
-                    orig_subprocess_run(cmd, **kwargs)
-            else:
-                return orig_subprocess_run(*args, **kwargs)
-
-        mocker.patch("subprocess.run", patched_subprocess_run)
-
-        with provider_wait.doc_to_pixels_proc(doc, timeout_grace=0) as proc:
-            # We purposefully do nothing here, so that the process remains running.
-            pass
-
-        get_proc_exception_spy.assert_not_called()
-        terminate_proc_spy.assert_called()
-        kill_proc_spy.assert_called()
-        assert proc.poll() is not None
+    pass

--- a/tests/isolation_provider/test_container.py
+++ b/tests/isolation_provider/test_container.py
@@ -65,7 +65,7 @@ class TestContainerTermination(IsolationProviderTermination):
         provider_wait.progress_callback = mocker.MagicMock()
         get_proc_exception_spy = mocker.spy(provider_wait, "get_proc_exception")
         terminate_proc_spy = mocker.spy(provider_wait, "terminate_doc_to_pixels_proc")
-        popen_kill_spy = mocker.spy(subprocess.Popen, "kill")
+        kill_proc_spy = mocker.spy(base, "kill_process_group")
 
         # Switch the subprocess.run() function with a patched function that
         # intercepts the `kill` command and switches it with `wait` instead. This way,
@@ -98,5 +98,5 @@ class TestContainerTermination(IsolationProviderTermination):
 
         get_proc_exception_spy.assert_not_called()
         terminate_proc_spy.assert_called()
-        popen_kill_spy.assert_called()
+        kill_proc_spy.assert_called()
         assert proc.poll() is not None

--- a/tests/isolation_provider/test_dummy.py
+++ b/tests/isolation_provider/test_dummy.py
@@ -25,6 +25,7 @@ class DummyWait(Dummy):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            start_new_session=True,
         )
 
     def terminate_doc_to_pixels_proc(

--- a/tests/isolation_provider/test_dummy.py
+++ b/tests/isolation_provider/test_dummy.py
@@ -28,15 +28,15 @@ class DummyWait(Dummy):
             start_new_session=True,
         )
 
-    def terminate_doc_to_pixels_proc(
-        self, document: Document, p: subprocess.Popen
-    ) -> None:
-        p.terminate()
-
 
 @pytest.fixture
 def provider_wait() -> DummyWait:
     return DummyWait()
+
+
+@pytest.fixture
+def provider() -> Dummy:
+    return Dummy()
 
 
 class TestDummyTermination(IsolationProviderTermination):
@@ -51,3 +51,12 @@ class TestDummyTermination(IsolationProviderTermination):
             return_value=errors.DocFormatUnsupported(),
         )
         super().test_failed(provider_wait, mocker)
+
+    def test_linger_unkillable(
+        self,
+        provider_wait: IsolationProvider,
+        mocker: MockerFixture,
+    ) -> None:
+        # We have to spawn a blocking process here, else we can't imitate an
+        # "unkillable" process.
+        super().test_linger_unkillable(provider_wait, mocker)


### PR DESCRIPTION
Make some preparations for the on-host conversion PR:
* Add a temporary fix for our gVisor breakage (see #928)
* Improve our `.gitattributes` file, so that Python files on Windows retain their LF line endings.
   - This broke caching in our CI for the tessdata bundle.
* Make dummy tests faster (general quality of life improvement)
* Add an Intel macOS runner (for completeness)
* Major improvements in termination logic (figured them out while working on the on-host conversion PR)