### PR TITLE
Use github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_linux.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_linux.yml
@@ -1,0 +1,67 @@
+name: Bug Report (Linux)
+description: File a bug report for Linux.
+labels: ["bug", "triage"]
+projects: ["freedomofpress/dangerzone"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi, and thanks for taking the time to open this bug report. 
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What was the expected behaviour, and what was the actual behaviour? Can you specify the steps you followed, so that we can reproduce?
+      placeholder: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: os-version
+    attributes:
+      label: Linux distribution
+      description: |
+        What is the name and version of your Linux distribution? You can find it out with `cat /etc/os-release`
+      placeholder: Ubuntu 20.04.6 LTS
+    validations:
+      required: true
+  - type: textarea
+    id: dangerzone-version
+    attributes:
+      label: Dangerzone version
+      description: Which version of Dangerzone are you using?
+    validations:
+      required: true
+  - type: textarea
+    id: podman-info
+    attributes:
+      label: Podman info
+      description: |
+        If the bug occurs during document conversion, or is otherwise related with Podman, please copy and paste the following commands in your terminal, and provide us with the output:
+
+        ```shell
+        podman version
+        podman info -f 'json'
+        podman images
+        podman run hello-world
+        ```
+
+        This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: logs
+    attributes:
+      label: Document conversion logs
+      description: |
+        If the bug occurs during document conversion, we'd like some logs from this process. Please copy and paste the following commands in your terminal, and provide us with the output (replace `/path/to/file` with the path to your document):
+
+        ```bash
+        dangerzone-cli /path/to/file
+        ```
+
+      render: shell
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional info
+      description: |
+        Please provide us with any additional info, such as logs, extra content, that may help us debug this issue.

--- a/.github/ISSUE_TEMPLATE/bug_report_macos.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_macos.yml
@@ -1,0 +1,83 @@
+name: Bug Report (MacOS)
+description: File a bug report for MacOS.
+labels: ["bug", "triage"]
+projects: ["freedomofpress/dangerzone"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi, and thanks for taking the time to open this bug report. 
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What was the expected behaviour, and what was the actual behaviour? Can you specify the steps you followed, so that we can reproduce?
+      placeholder: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: os-version
+    attributes:
+      label: operating system version
+      description: Which version of MacOS do you use? You can follow [this link](https://support.apple.com/en-us/109033) to find out more.
+      placeholder: macOS Sequoia 15
+    validations:
+      required: true
+  - type: dropdown
+    id: proc-architecture
+    attributes:
+      label: Processor type
+      description: |
+        Which kind of processor do you use?
+
+        You can follow [this link](https://support.apple.com/en-us/109033) to find out more.
+      options:
+        - Intel
+        - Apple Silicon
+    validations:
+      required: true
+  - type: textarea
+    id: dangerzone-version
+    attributes:
+      label: Dangerzone version
+      description: Which version of Dangerzone are you using?
+    validations:
+      required: true
+  - type: textarea
+    id: docker-info
+    attributes:
+      label: Docker info
+      description: |
+        If the bug occurs during document conversion, or is otherwise related
+        with Docker, please copy and paste the following commands in your
+        terminal, and provide us with the output:
+
+        ```shell
+        docker version
+        docker info -f 'json'
+        docker images
+        docker run hello-world
+        ```
+
+        This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: logs
+    attributes:
+      label: Document conversion logs
+      description: |
+
+        If the bug occurs during document conversion, we'd like some logs from this process. Please copy and paste the following commands in your terminal, and provide us with the output (replace `/path/to/file` with the path to your document):
+
+        ```bash
+
+        /Applications/Dangerzone.app/Contents/MacOS/dangerzone-cli /path/to/file
+        ```
+
+      render: shell
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional info
+      description: |
+        Please provide us with any additional info, such as logs, extra content, that may help us debug this issue.

--- a/.github/ISSUE_TEMPLATE/bug_report_windows.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_windows.yml
@@ -1,0 +1,68 @@
+name: Bug Report (Windows)
+description: File a bug report for Windows.
+labels: ["bug", "triage"]
+projects: ["freedomofpress/dangerzone"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi, and thanks for taking the time to open this bug report. 
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What was the expected behaviour, and what was the actual behaviour? Can you specify the steps you followed, so that we can reproduce?
+      placeholder: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: os-version
+    attributes:
+      label: operating system version
+      description: |
+        Which version of Windows do you use? Follow [this link](https://learn.microsoft.com/en-us/windows/client-management/client-tools/windows-version-search) to find out.
+    validations:
+      required: true
+  - type: textarea
+    id: dangerzone-version
+    attributes:
+      label: Dangerzone version
+      description: Which version of Dangerzone are you using?
+    validations:
+      required: true
+  - type: textarea
+    id: docker-info
+    attributes:
+      label: Docker info
+      description: |
+        If the bug occurs during document conversion, or is otherwise related
+        with Docker, please copy and paste the following commands in your
+        terminal, and provide us with the output:
+
+        ```shell
+        docker version
+        docker info -f 'json'
+        docker images
+        docker run hello-world
+        ```
+
+        This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: logs
+    attributes:
+      label: Document conversion logs
+      description: |
+        If the bug occurs during document conversion, we'd like some logs from this process. Please copy and paste the following commands in your terminal, and provide us with the output (replace `\path\to\file` with the path to your document):
+
+        ```bash
+        'C:\Program Files (x86)\Dangerzone\dangerzone-cli.exe' \path\to\file
+        ```
+
+      render: shell
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional info
+      description: |
+        Please provide us with any additional info, such as logs, extra content, that may help us debug this issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**What is the feature you think should be a good addition to Dangerzone?**
+
+?
+
+**Is your feature request related to a problem? Please describe.**
+
+It's always useful for us to know more about your context, and why you think
+this would be a great addition. Don't hesitate to put some details about your
+current workflow and how this could be useful to you.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This adds two issue templates, one as a form and the other as some text already filled in.

Here is what it looks like:

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/87f60d93-35e6-487c-bdf3-68bfb123633d">

---

Bug report:

![image](https://github.com/user-attachments/assets/f28084d8-f12c-4212-bc5e-06855cf91e3e)

---

Feature request:

![image](https://github.com/user-attachments/assets/8ce1ee24-d3c3-4243-9326-29af1e915809)

---

Is there any other input that could be valuable here?

Note that we could also have a specific template for "Conversion failed" issues, where we could add some more specific information about the docker / podman setup, and ask the user to run specific tasks (like add SC_DEBUG to the docker run command line to get more logs back).

I am curious what you think on this, and if you think it could be valuable? 🤔 

Edit: I realize that these screencaps are not up to date. If you want to have a look at what it looks like now for the form, look at [this link instead](https://github.com/freedomofpress/dangerzone/blob/920-gh-issue-templates/.github/ISSUE_TEMPLATE/bug_report.yml)