### PR TITLE
Add a `--debug` flag to the CLI to help retrieve more logs.

### DIFF
--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -42,6 +42,12 @@ def print_header(s: str) -> None:
     type=click.UNPROCESSED,
     callback=args.validate_input_filenames,
 )
+@click.option(
+    "--debug",
+    "debug",
+    flag_value=True,
+    help="Run Dangerzone in debug mode, to get logs from gVisor.",
+)
 @click.version_option(version=get_version(), message="%(version)s")
 @errors.handle_document_errors
 def cli_main(
@@ -50,6 +56,7 @@ def cli_main(
     filenames: List[str],
     archive: bool,
     dummy_conversion: bool,
+    debug: bool,
 ) -> None:
     setup_logging()
 
@@ -58,7 +65,7 @@ def cli_main(
     elif is_qubes_native_conversion():
         dangerzone = DangerzoneCore(Qubes())
     else:
-        dangerzone = DangerzoneCore(Container())
+        dangerzone = DangerzoneCore(Container(debug=debug))
 
     display_banner()
     if len(filenames) == 1 and output_filename:

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -20,9 +20,6 @@ from ..util import get_tessdata_dir, replace_control_chars
 
 log = logging.getLogger(__name__)
 
-DOC_TO_PIXELS_LOG_START = "----- DOC TO PIXELS LOG START -----"
-DOC_TO_PIXELS_LOG_END = "----- DOC TO PIXELS LOG END -----"
-
 TIMEOUT_EXCEPTION = 15
 TIMEOUT_GRACE = 15
 TIMEOUT_FORCE = 5
@@ -359,14 +356,13 @@ class IsolationProvider(ABC):
                 debug_bytes = stderr.getvalue()
                 debug_log = sanitize_debug_text(debug_bytes)
 
-                incomplete = "(incomplete)\n" if stderr_thread.is_alive() else ""
+                incomplete = "(incomplete) " if stderr_thread.is_alive() else ""
 
                 log.info(
                     "Conversion output (doc to pixels)\n"
-                    f"{DOC_TO_PIXELS_LOG_START}\n"
+                    f"----- DOC TO PIXELS LOG START {incomplete}-----\n"
                     f"{debug_log}"  # no need for an extra newline here
-                    f"{incomplete}"
-                    f"{DOC_TO_PIXELS_LOG_END}"
+                    "----- DOC TO PIXELS LOG END -----"
                 )
 
     def start_stderr_thread(

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -168,6 +168,10 @@ class Container(IsolationProvider):
     ) -> subprocess.Popen:
         container_runtime = container_utils.get_runtime()
         security_args = self.get_runtime_security_args()
+        debug_args = []
+        if self.debug:
+            debug_args += ["-e", "RUNSC_DEBUG=1"]
+
         enable_stdin = ["-i"]
         set_name = ["--name", name]
         prevent_leakage_args = ["--rm"]
@@ -177,14 +181,14 @@ class Container(IsolationProvider):
         args = (
             ["run"]
             + security_args
+            + debug_args
             + prevent_leakage_args
             + enable_stdin
             + set_name
             + image_name
             + command
         )
-        args = [container_runtime] + args
-        return self.exec(args)
+        return self.exec([container_runtime] + args)
 
     def kill_container(self, name: str) -> None:
         """Terminate a spawned container.

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -71,6 +71,7 @@ class DangerzoneCore(object):
                     ocr_lang,
                     stdout_callback,
                 )
+
             except Exception:
                 log.exception(
                     f"Unexpected error occurred while converting '{document}'"


### PR DESCRIPTION
While adding Github Issue Templates on this repository (#939) we found that the commands we require the user to enter in their terminals can be quite complex. Some of them might require some bash-fu, for instance to define the location of the custom seccomp profile we are using, as it differs depending the OS.

This is a proposal to add a `--debug` flag to the `dangerzone-cli` to simplify the process of generating proper logs.

When the flag is set:

- The `RUNSC_DEBUG=1` environment variable is added to the outer container ;
- the stderr from the outer container is attached to the exception, and displayed to the user on failures.

Info: tests are currently failing and I didn't put too much effort in making them pass, as this is here mainly to see if it could make sense to add this in the first place.