### PR TITLE
ci: Start an Xvfb server in our CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ env:
   REGISTRY_USER: ${{ github.actor }}
   REGISTRY_PASSWORD: ${{ github.token }}
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  # This is required for running GUI tests on Github Actions
-  DISPLAY: ":99.0"
   QT_SELECT: "qt6"
 
 # Disable multiple concurrent runs on the same branch
@@ -354,15 +352,23 @@ jobs:
             share/image-id.txt
           fail-on-cache-miss: true
 
-      - name: Setup xvfb (Linux)
-        run: |
-          # Stuff copied wildly from several stackoverflow posts
-          sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
-
-          # start xvfb in the background
-          sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
-
       - name: Run CI tests
         run: |-
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} run --dev \
+          # Pass the -ac Xserver flag, to disable host-based access controls.
+          # This should be used ONLY for testing [1]. If we don't pass this
+          # flag, the Podman container is not authorized [2] to access the Xvfb
+          # server.
+          #
+          # [1] From https://www.x.org/releases/X11R6.7.0/doc/Xserver.1.html#sect4:
+          #
+          #     disables host-based access control mechanisms. Enables access by
+          #     any host, and permits any host to modify the access control
+          #     list. Use with extreme caution. This option exists primarily for
+          #     running test suites remotely.
+          #
+          # [2] Fails with "Authorization required, but no authorization
+          #     protocol specified". However, we have verified with strace(1)
+          #     that the command in the Podman container can read the Xauthority
+          #     file successfully.
+          xvfb-run -s '-ac' ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} run --dev \
               bash -c 'cd dangerzone; poetry run make test'


### PR DESCRIPTION
Remove the installation steps for Xvfb, since it's already included in GitHub actions, and fire up an Xvfb server with disabled host-based access control.

Initially, we tried to wrap our CI tests with `xvfb-run`, but any X11 client within our Podman container failed with the following error message:

    Authorization required, but no authorization protocol specified.

This error message is usually thrown when the X11 client does not provide the magic cookie in the Xauthority file back to the X11 server. In our case though, we can verify that commands in our Podman container read the Xauthority file successfully:

    socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0) = 3
    connect(3, {sa_family=AF_UNIX, sun_path=@"/tmp/.X11-unix/X99"}, 21) = -1 ECONNREFUSED (Connection refused)
    close(3)                                = 0
    socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0) = 3
    getsockopt(3, SOL_SOCKET, SO_SNDBUF, [212992], [4]) = 0
    connect(3, {sa_family=AF_UNIX, sun_path="/tmp/.X11-unix/X99"}, 110) = 0
    getpeername(3, {sa_family=AF_UNIX, sun_path="/tmp/.X11-unix/X99"}, [124->21]) = 0
    uname({sysname="Linux", nodename="dangerzone-dev", ...}) = 0
    access("/home/runner/work/dangerzone/dangerzone/cookie", R_OK) = 0
    openat(AT_FDCWD, "/home/runner/work/dangerzone/dangerzone/cookie", O_RDONLY) = 4
    fstat(4, {st_mode=S_IFREG|0600, st_size=59, ...}) = 0
    read(4, "\1\0\0\rfv-az1915-957\0\299\0\22MIT-MAGIC"..., 4096) = 59
    read(4, "", 4096)                       = 0
    close(4)                                = 0
    fcntl(3, F_GETFL)                       = 0x2 (flags O_RDWR)
    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK)    = 0
    fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
    poll([{fd=3, events=POLLIN|POLLOUT}], 1, -1) = 1 ([{fd=3, revents=POLLOUT}])
    writev(3, [{iov_base="l\0\v\0\0\0\0\0\0\0\0\0", iov_len=12}, {iov_base="", iov_len=0}], 2) = 12
    recvfrom(3, 0x55a5635c0050, 8, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
    poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
    recvfrom(3, "\0@\v\0\0\0\20\0", 8, 0, NULL, NULL) = 8
    recvfrom(3, "Authorization required, but no a"..., 64, 0, NULL, NULL) = 64
    write(2, "Authorization required, but no a"..., 64Authorization required, but no authorization protocol specified
    ) = 64

The line with the magic cookie is:

    read(4, "\1\0\0\rfv-az1915-957\0\299\0\22MIT-MAGIC"..., 4096) = 59

Since we are not sure why we are not allowed access to the X11 server from the Podman container, we decided to disable host-based access controls altogether. This is not a security concern, since this X11 session is a remote one. However, we shouldn't run tests this way in dev machines.

Fixes #949