### PR TITLE
Add support for Fedora 41

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
             version: "39"
           - distro: fedora
             version: "40"
+          - distro: fedora
+            version: "41"
 
     steps:
       - name: Checkout

--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -81,6 +81,8 @@ jobs:
             version: 39
           - distro: fedora
             version: 40
+          - distro: fedora
+            version: 41
     steps:
       - name: Add packages.freedom.press to our YUM sources
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
     strategy:
       matrix:
         distro: ["fedora"]
-        version: ["39", "40"]
+        version: ["39", "40", "41"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -325,6 +325,8 @@ jobs:
             version: "39"
           - distro: fedora
             version: "40"
+          - distro: fedora
+            version: "41"
 
     steps:
       - name: Checkout

--- a/BUILD.md
+++ b/BUILD.md
@@ -42,7 +42,7 @@ Install dependencies:
   </br>
 
   The default Python version that ships with Ubuntu Focal (3.8) is not
-  compatible with PySide6, which requires Python 3.9 of greater.
+  compatible with PySide6, which requires Python 3.9 or greater.
 
   You can install Python 3.9 using the `python3.9` package.
 
@@ -124,6 +124,28 @@ Install dependencies:
 sudo dnf install -y rpm-build podman python3 python3-devel python3-poetry-core \
     pipx qt6-qtbase-gui
 ```
+
+<table>
+  <tr>
+      <td>
+<details>
+  <summary><i>:memo: Expand this section if you are on Fedora 41.</i></summary>
+  </br>
+
+  The default Python version that ships with Fedora 41 (3.13) is not
+  compatible with PySide6, which requires Python 3.12 or earlier.
+
+  You can install Python 3.12 using the `python3.12` package.
+
+  ```bash
+  sudo dnf install -y python3.12
+  ```
+
+  Poetry will automatically pick up the correct version when running.
+</details>
+    </td>
+  </tr>
+</table>
 
 Install Poetry using `pipx`:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,7 @@ Dangerzone is available for:
 - Debian 13 (trixie)
 - Debian 12 (bookworm)
 - Debian 11 (bullseye)
+- Fedora 41
 - Fedora 40
 - Fedora 39
 - Tails

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ as a special case of Fedora, release-wise). For each of these platforms, we need
 to check if a new version has been added, or if an existing one is now EOL
 (https://endoflife.date/ is handy for this purpose).
 
-In case of a new version:
+In case of a new version (beta, RC, or official release):
 
 1. Add it in our CI workflows, to test if that version works.
    * See `.circleci/config.yml` and `.github/workflows/ci.yml`, as well as
@@ -103,7 +103,7 @@ and newer platforms, we have to do the following:
   - [ ] Run the Dangerzone tests.
   - [ ] Create a .deb package and install it system-wide.
   - [ ] Test some QA scenarios (see [Scenarios](#Scenarios) below).
-- [ ] Create a test build in the most recent Fedora platform (Fedora 40 as of
+- [ ] Create a test build in the most recent Fedora platform (Fedora 41 as of
   writing this) and make sure it works:
   - [ ] Create a new development environment with Poetry.
   - [ ] Build the container image and ensure the development environment uses
@@ -111,7 +111,7 @@ and newer platforms, we have to do the following:
   - [ ] Run the Dangerzone tests.
   - [ ] Create an .rpm package and install it system-wide.
   - [ ] Test some QA scenarios (see [Scenarios](#Scenarios) below).
-- [ ] Create a test build in the most recent Qubes Fedora template (Fedora 39 as
+- [ ] Create a test build in the most recent Qubes Fedora template (Fedora 40 as
   of writing this) and make sure it works:
   - [ ] Create a new development environment with Poetry.
   - [ ] Run the Dangerzone tests.
@@ -385,15 +385,15 @@ repo, by sending a PR. Follow the instructions in that repo on how to do so.
 
 > **NOTE**: This procedure will have to be done for every supported Fedora version.
 >
-> In this section, we'll use Fedora 39 as an example.
+> In this section, we'll use Fedora 41 as an example.
 
 Create a Fedora development environment. You can [follow the
 instructions in our build section](https://github.com/freedomofpress/dangerzone/blob/main/BUILD.md#fedora),
 or create your own locally with:
 
 ```sh
-./dev_scripts/env.py --distro fedora --version 39 build-dev
-./dev_scripts/env.py --distro fedora --version 39 run --dev bash
+./dev_scripts/env.py --distro fedora --version 41 build-dev
+./dev_scripts/env.py --distro fedora --version 41 run --dev bash
 cd dangerzone
 ```
 

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -166,6 +166,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 """
 
+# NOTE: Fedora 41 comes with Python 3.13 installed. Our Python project is not compatible
+# yet with Python 3.13, because PySide6 cannot work with this Python version. To
+# sidestep this, install Python 3.12 *only* in dev environments.
+DOCKERFILE_BUILD_DEV_FEDORA_41_DEPS = r"""
+# Install Python 3.12 since our project is not compatible yet with Python 3.13.
+RUN dnf install -y python3.12
+"""
+
 # FIXME: Install Poetry on Fedora via package manager.
 DOCKERFILE_BUILD_DEV_FEDORA_DEPS = r"""
 RUN dnf install -y git rpm-build podman python3 python3-devel python3-poetry-core \
@@ -664,6 +672,8 @@ class Env:
 
         if self.distro == "fedora":
             install_deps = DOCKERFILE_BUILD_DEV_FEDORA_DEPS
+            if self.version == "41":
+                install_deps += DOCKERFILE_BUILD_DEV_FEDORA_41_DEPS
         else:
             # Use Qt6 in all of our Linux dev environments, and add a missing
             # libxcb-cursor0 dependency

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -52,7 +52,7 @@ and newer platforms, we have to do the following:
   - [ ] Run the Dangerzone tests.
   - [ ] Create a .deb package and install it system-wide.
   - [ ] Test some QA scenarios (see [Scenarios](#Scenarios) below).
-- [ ] Create a test build in the most recent Fedora platform (Fedora 40 as of
+- [ ] Create a test build in the most recent Fedora platform (Fedora 41 as of
   writing this) and make sure it works:
   - [ ] Create a new development environment with Poetry.
   - [ ] Build the container image and ensure the development environment uses
@@ -60,7 +60,7 @@ and newer platforms, we have to do the following:
   - [ ] Run the Dangerzone tests.
   - [ ] Create an .rpm package and install it system-wide.
   - [ ] Test some QA scenarios (see [Scenarios](#Scenarios) below).
-- [ ] Create a test build in the most recent Qubes Fedora template (Fedora 39 as
+- [ ] Create a test build in the most recent Qubes Fedora template (Fedora 40 as
   of writing this) and make sure it works:
   - [ ] Create a new development environment with Poetry.
   - [ ] Run the Dangerzone tests.
@@ -234,7 +234,7 @@ Install dependencies:
   </br>
 
   The default Python version that ships with Ubuntu Focal (3.8) is not
-  compatible with PySide6, which requires Python 3.9 of greater.
+  compatible with PySide6, which requires Python 3.9 or greater.
 
   You can install Python 3.9 using the `python3.9` package.
 
@@ -317,6 +317,28 @@ Install dependencies:
 sudo dnf install -y rpm-build podman python3 python3-devel python3-poetry-core \
     pipx qt6-qtbase-gui
 ```
+
+<table>
+  <tr>
+      <td>
+<details>
+  <summary><i>:memo: Expand this section if you are on Fedora 41.</i></summary>
+  </br>
+
+  The default Python version that ships with Fedora 41 (3.13) is not
+  compatible with PySide6, which requires Python 3.12 or earlier.
+
+  You can install Python 3.12 using the `python3.12` package.
+
+  ```bash
+  sudo dnf install -y python3.12
+  ```
+
+  Poetry will automatically pick up the correct version when running.
+</details>
+    </td>
+  </tr>
+</table>
 
 Install Poetry using `pipx`:
 

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -221,6 +221,17 @@ convert the documents within a secure sandbox.
 %prep
 %autosetup -p1 -n dangerzone-%{version}
 
+# XXX: Bump the Python requirement in pyproject.toml from <3.13 to <3.14. Fedora
+# 41 comes with Python 3.13 installed, but our pyproject.toml does not support
+# it because PySide6 in PyPI works with Python 3.12 or earlier.
+#
+# This hack sidesteps this issue, and we haven't noticed any paticular problem
+# with the package that is built from that.
+%if 0%{?fedora} == 41
+sed -i 's/<3.13/<3.14/' pyproject.toml
+%endif
+
+
 %generate_buildrequires
 %pyproject_buildrequires -R
 


### PR DESCRIPTION
Add support for Fedora 41. A slight obstacle with this distro is that it has Python 3.13 installed, which is not supported by the PySide6 version shipped via PyPI. The `python3-pyside6` package has support for Python 3.13, so this is not a real problem for our end users. It's only a problem for dev environments, and this PR installs Python 3.12 to sidestep it.

Fixes #947