### PR TITLE
Call 'dnf config-manager' via the dnf-3 interface

### DIFF
--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Add packages.freedom.press to our YUM sources
         run: |
           dnf install -y 'dnf-command(config-manager)'
-          dnf config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+          dnf-3 config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 
       - name: Install Dangerzone
         # FIXME: We add the `-y` flag here, in lieu of a better way to check the

--- a/BUILD.md
+++ b/BUILD.md
@@ -300,7 +300,7 @@ test it.
 
    ```sh
    sudo dnf install 'dnf-command(config-manager)'
-   sudo dnf config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+   sudo dnf-3 config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
    sudo dnf install ~/QubesIncoming/dz/*.rpm
    ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -147,7 +147,7 @@ Type the following commands in a terminal:
 
 ```
 sudo dnf install 'dnf-command(config-manager)'
-sudo dnf config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+sudo dnf-3 config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone
 ```
 
@@ -234,7 +234,7 @@ dz.Convert         *       @anyvm       @dispvm:dz-dvm  allow
 Install Dangerzone:
 
 ```
-sudo dnf config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+sudo dnf-3 config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone-qubes
 ```
 


### PR DESCRIPTION
Fedora 41 has a newer dnf interface (dnf v5), and the config-manager plugin that we use is not compatible with it. Suggest running it with `dnf-3` instead, which is present in all Fedora versions.