### PR TITLE
ci: Explicitly use Ubuntu 24.04 for our runner images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
               build-dev --sync
 
   build-container-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   # This is already built daily by the "build.yml" file
   # But we also want to include this in the checks that run on each push.
   build-container-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
GitHub actions somehow managed to downgrade our runners from Ubuntu 24.04 to Ubuntu 22.04, even though we use `ubuntu-latest`. Make the Ubuntu 24.04 requirement more explicit, until GitHub migrates fully to this version for the `ubuntu-latest` tag.

Fixes #957