### PR TITLE
CI: Only run CI on branch or pull request events, but not twice.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build dev environments
 on:
+  pull_request:
   push:
+    branches:
+      - main
+      - "test/**"
   schedule:
     - cron: "0 0 * * *" # Run every day at 00:00 UTC.
 

--- a/.github/workflows/check_push.yml
+++ b/.github/workflows/check_push.yml
@@ -1,6 +1,6 @@
 name: Check branch conformity
 on:
-  push:
+  pull_request:
 
 jobs:
   prevent-fixup-commits:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: Tests
 on:
-  push:
   pull_request:
-    branches: [main]
+  push:
+    branches:
+      - main
+      - "test/**"
   schedule:
     - cron: "2 0 * * *" # Run every day at 02:00 UTC.
   workflow_dispatch:
@@ -91,7 +93,8 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    needs: download-tessdata
+    needs:
+      - download-tessdata
     env:
       DUMMY_CONVERSION: 1
     steps:
@@ -121,7 +124,8 @@ jobs:
   macOS:
     name: "macOS (${{ matrix.arch }})"
     runs-on: ${{ matrix.runner }}
-    needs: download-tessdata
+    needs:
+      - download-tessdata
     strategy:
       matrix:
         include:
@@ -149,9 +153,10 @@ jobs:
         run: poetry run make test
 
   build-deb:
+    needs:
+      - build-container-image
     name: "build-deb (${{ matrix.distro }} ${{ matrix.version }})"
     runs-on: ubuntu-latest
-    needs: build-container-image
     strategy:
       matrix:
         include:
@@ -219,7 +224,8 @@ jobs:
   install-deb:
     name: "install-deb (${{ matrix.distro }} ${{ matrix.version }})"
     runs-on: ubuntu-latest
-    needs: build-deb
+    needs: 
+      - build-deb
     strategy:
       matrix:
         include:
@@ -273,7 +279,8 @@ jobs:
   build-install-rpm:
     name: "build-install-rpm (${{ matrix.distro }} ${{matrix.version}})"
     runs-on: ubuntu-latest
-    needs: build-container-image
+    needs:
+      - build-container-image
     strategy:
       matrix:
         distro: ["fedora"]

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,8 +1,9 @@
 name: Scan latest app and container
 on:
   push:
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
   schedule:
     - cron: '0 0 * * *' # Run every day at 00:00 UTC.
   workflow_dispatch:


### PR DESCRIPTION
The CI currently runs on both `pull-requests` and `branch` events. This is an attempt to only run on one or the other.