### PR TITLE
Update RELEASE.md to publish arm64 architectures.

### DIFF
--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Download container image for the latest release
         run: |
           VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | jq -r '.tag_name')
-          wget https://github.com/freedomofpress/dangerzone/releases/download/${VERSION}/container.tar.gz
+          wget https://github.com/freedomofpress/dangerzone/releases/download/${VERSION}/container-${VERSION}-i686.tar.gz -O container.tar.gz
       - name: Load container image
         run: docker load -i container.tar.gz
       # NOTE: Scan first without failing, else we won't be able to read the scan

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -289,7 +289,7 @@ Our [GitHub Releases page](https://github.com/freedomofpress/dangerzone/releases
 hosts the following files:
 * Windows installer (`Dangerzone-<version>.msi`)
 * macOS archives (`Dangerzone-<version>-<arch>.dmg`)
-* Container image (`container.tar.gz`)
+* Container images (`container-<version>-<arch>.tar.gz`)
 * Source package (`dangerzone-<version>.tar.gz`)
 
 All these files are accompanied by signatures (as `.asc` files). We'll explain
@@ -314,10 +314,10 @@ gpg --verify Dangerzone-0.6.1-arm64.dmg.asc Dangerzone-0.6.1-arm64.dmg
 gpg --verify Dangerzone-0.6.1-i686.dmg.asc Dangerzone-0.6.1-i686.dmg
 ```
 
-For the container image:
+For the container images:
 
 ```
-gpg --verify container.tar.gz.asc container.tar.gz
+gpg --verify container-0.6.1-i686.tar.gz.asc container-0.6.1-i686.tar.gz
 ```
 
 For the source package:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -285,6 +285,11 @@ Once we are confident that the release will be out shortly, and doesn't need any
   * You can verify the correct Python version is used with `poetry debug info`
 - [ ] Verify and checkout the git tag for this release
 - [ ] Run `poetry install --sync`
+- [ ] On the silicon mac, build the container image:
+  ```
+  python3 ./install/common/build-image.py
+  ```
+  Then copy the `share/container.tar.gz` to the assets folder on `dangerzone-$VERSION-arm64.tar.gz`, along with the `share/image-id.txt` file.
 - [ ] Run `poetry run ./install/macos/build-app.py`; this will make `dist/Dangerzone.app`
 - [ ] Make sure that the build application works with the containerd graph
   driver (see [#933](https://github.com/freedomofpress/dangerzone/issues/933))
@@ -403,6 +408,8 @@ Build the latest container:
 python3 ./install/common/build-image.py
 ```
 
+Copy the container image to the assets folder on `dangerzone-$VERSION-i686.tar.gz`.
+
 Create a .rpm:
 
 ```sh
@@ -449,9 +456,9 @@ To publish the release:
   * Copy the release notes text from the template at [`docs/templates/release-notes`](https://github.com/freedomofpress/dangerzone/tree/main/docs/templates/)
   * You can use `./dev_scripts/upload-asset.py`, if you want to upload an asset
     using an access token.
-- [ ] Upload the `container.tar.gz` i686 image that was created in the previous step
+- [ ] Upload the `container-$VERSION-i686.tar.gz` and `container-$VERSION-arm64.tar.gz` images that were created in the previous step
 
-  **Important:** Make sure that it's the same container image as the ones that
+  **Important:** Make sure that it's the same container images as the ones that
   are shipped in other platforms (see our [Pre-release](#Pre-release) section)
 
 - [ ] Upload the detached signatures (.asc) and checksum file.

--- a/dev_scripts/sign-assets.py
+++ b/dev_scripts/sign-assets.py
@@ -11,7 +11,8 @@ log = logging.getLogger(__name__)
 
 
 DZ_ASSETS = [
-    "container.tar.gz",
+    "container-{version}-i686.tar.gz",
+    "container-{version}-arm64.tar.gz",
     "Dangerzone-{version}.msi",
     "Dangerzone-{version}-arm64.dmg",
     "Dangerzone-{version}-i686.dmg",


### PR DESCRIPTION
This can be merged before the release, so we are advised to publish `container.tar.gz`for both i686 and arm64 architectures.