### PR TITLE
Drop support for Ubuntu Mantic (23.10), which is EOL since 11 Jul 2024.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ jobs:
           - distro: ubuntu
             version: "22.04"
           - distro: ubuntu
-            version: "23.10"
-          - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
             version: "24.10"

--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -24,8 +24,6 @@ jobs:
           - distro: ubuntu
             version: "24.04"  # noble
           - distro: ubuntu
-            version: "23.10"  # mantic
-          - distro: ubuntu
             version: "22.04"  # jammy
           - distro: ubuntu
             version: "20.04"  # focal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,6 @@ jobs:
           - distro: ubuntu
             version: "22.04"
           - distro: ubuntu
-            version: "23.10"
-          - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
             version: "24.10"
@@ -229,8 +227,6 @@ jobs:
             version: "20.04"
           - distro: ubuntu
             version: "22.04"
-          - distro: ubuntu
-            version: "23.10"
           - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
@@ -350,8 +346,6 @@ jobs:
             version: "20.04"
           - distro: ubuntu
             version: "22.04"
-          - distro: ubuntu
-            version: "23.10"
           - distro: ubuntu
             version: "24.04"
           - distro: ubuntu

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,6 @@ an isolated environment. It will be installed automatically when installing Dang
 Dangerzone is available for:
 - Ubuntu 24.10 (oracular)
 - Ubuntu 24.04 (noble)
-- Ubuntu 23.10 (mantic)
 - Ubuntu 22.04 (jammy)
 - Ubuntu 20.04 (focal)
 - Debian 13 (trixie)

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -696,8 +696,6 @@ class Env:
                     DOCKERFILE_CONMON_UPDATE + DOCKERFILE_BUILD_DEV_DEBIAN_DEPS
                 )
             elif self.distro == "ubuntu" and self.version in (
-                "23.10",
-                "mantic",
                 "24.04",
                 "noble",
                 "24.10",
@@ -784,8 +782,6 @@ class Env:
                 # package (see https://github.com/freedomofpress/dangerzone/issues/685)
                 install_deps = DOCKERFILE_CONMON_UPDATE + DOCKERFILE_BUILD_DEBIAN_DEPS
             elif self.distro == "ubuntu" and self.version in (
-                "23.10",
-                "mantic",
                 "24.04",
                 "noble",
                 "24.10",

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -978,11 +978,6 @@ class QAUbuntu2204(QADebianBased):
     VERSION = "22.04"
 
 
-class QAUbuntu2310(QADebianBased):
-    DISTRO = "ubuntu"
-    VERSION = "23.10"
-
-
 class QAUbuntu2404(QADebianBased):
     DISTRO = "ubuntu"
     VERSION = "24.04"


### PR DESCRIPTION
Ubuntu mantic is now EOL since July 2024. This PR removes the support for it.