### PR TITLE
tests: Restore previously mocked function

### DIFF
--- a/tests/isolation_provider/base.py
+++ b/tests/isolation_provider/base.py
@@ -164,6 +164,7 @@ class IsolationProviderTermination:
         terminate_proc_mock = mocker.patch.object(
             provider, "terminate_doc_to_pixels_proc", return_value=None
         )
+        kill_pg_orig = base.kill_process_group
         kill_pg_mock = mocker.patch(
             "dangerzone.isolation_provider.base.kill_process_group", return_value=None
         )
@@ -178,6 +179,7 @@ class IsolationProviderTermination:
 
         # Reset the function to the original state.
         provider.terminate_doc_to_pixels_proc = terminate_proc_orig  # type: ignore [method-assign]
+        base.kill_process_group = kill_pg_orig
 
         # Really kill the spawned process, so that it doesn't linger after the tests
         # complete.


### PR DESCRIPTION
Restore the `isolation_provider.base.kill_process_group()` function, which was previously mocked, at the end of the
`test_linger_unkillable()` test. This function is initially mocked, in order to simulate a hang process. After the mocking completes, the test needs the original function once more, in order to actually kill the spawned process.