### PR TITLE
Fix cx_freeze not able to build .exe files (#974)

### DIFF
--- a/setup-windows.py
+++ b/setup-windows.py
@@ -4,7 +4,6 @@ from cx_Freeze import Executable, setup
 with open("share/version.txt") as f:
     version = f.read().strip()
 
-packages = ["dangerzone", "dangerzone.gui"]
 
 setup(
     name="dangerzone",
@@ -12,10 +11,9 @@ setup(
     # On Windows description will show as the app's name in the "Open With" menu. See:
     # https://github.com/freedomofpress/dangerzone/issues/283#issuecomment-1365148805
     description="Dangerzone",
-    packages=packages,
     options={
         "build_exe": {
-            "packages": packages,
+            "packages": ["dangerzone", "dangerzone.gui"],
             "excludes": ["test", "tkinter"],
             "include_files": [("share", "share"), ("LICENSE", "LICENSE")],
             "include_msvcr": True,

--- a/setup-windows.py
+++ b/setup-windows.py
@@ -13,7 +13,11 @@ setup(
     description="Dangerzone",
     options={
         "build_exe": {
-            "packages": ["dangerzone", "dangerzone.gui"],
+            # Explicitly specify pymupdf.util module to fix building the executables
+            # with cx_freeze. See https://github.com/marcelotduarte/cx_Freeze/issues/2653
+            # for more details.
+            # TODO: Upgrade to cx_freeze 7.3.0 which should include a fix.
+            "packages": ["dangerzone", "dangerzone.gui", "pymupdf.utils"],
             "excludes": ["test", "tkinter"],
             "include_files": [("share", "share"), ("LICENSE", "LICENSE")],
             "include_msvcr": True,


### PR DESCRIPTION
Here's a quick workaround for #974 as suggested by @apyrgio  until the fix in upstream lands in a future release of cx_freeze.

Also revert an earlier workaround for an error that no longer triggers that I noticed while debugging this error.