### PR TITLE
Revert "Disable gVisor's DirectFS feature."

### DIFF
--- a/dangerzone/gvisor_wrapper/entrypoint.py
+++ b/dangerzone/gvisor_wrapper/entrypoint.py
@@ -142,9 +142,6 @@ runsc_argv = [
     "--rootless=true",
     "--network=none",
     "--root=/home/dangerzone/.containers",
-    # Disable DirectFS for to make the seccomp filter even stricter,
-    # at some performance cost.
-    "--directfs=false",
 ]
 if os.environ.get("RUNSC_DEBUG"):
     runsc_argv += ["--debug=true", "--alsologtostderr=true"]


### PR DESCRIPTION
This reverts commit 73b0f8b7d45f2e1ceb003fff006dc4ab6d419058. Unfortunately, disabling DirectFS causes a problem in Linux systems that enable Yama mode 2. Turns out that Tails is such a system, so we have to revert this change, if we want to support it.

Refs #982