### PR TITLE
build: use the version-less container released-asset for now

### DIFF
--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Download container image for the latest release
         run: |
           VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | jq -r '.tag_name')
-          wget https://github.com/freedomofpress/dangerzone/releases/download/${VERSION}/container-${VERSION}-i686.tar.gz -O container.tar.gz
+          wget https://github.com/freedomofpress/dangerzone/releases/download/${VERSION}/container.tar.gz -O container.tar.gz
       - name: Load container image
         run: docker load -i container.tar.gz
       # NOTE: Scan first without failing, else we won't be able to read the scan


### PR DESCRIPTION
When merging #961, we actually merged the CI changes that look for the not-yet released assets. This PR fixes it, and the commit should be reverted as soon as we release 0.8.0.