### PR TITLE
Make README.md point to INSTALL.md for instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,21 @@
 ## MacOS
-See instructions in [README.md](README.md#macos).
+
+- Download [Dangerzone 0.8.0 for Mac (Apple Silicon CPU)](https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0-arm64.dmg)
+- Download [Dangerzone 0.8.0 for Mac (Intel CPU)](https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0-i686.dmg)
+
+You can also install Dangerzone for Mac using [Homebrew](https://brew.sh/): `brew install --cask dangerzone`
+
+> **Note**: you will also need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+> This program needs to run alongside Dangerzone at all times, since it is what allows Dangerzone to
+> create the secure environment.
 
 ## Windows
-See instructions in [README.md](README.md#windows).
+
+- Download [Dangerzone 0.8.0 for Windows](https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0.msi)
+
+> **Note**: you will also need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+> This program needs to run alongside Dangerzone at all times, since it is what allows Dangerzone to
+> create the secure environment.
 
 ## Linux
 On Linux, Dangerzone uses [Podman](https://podman.io/) instead of Docker Desktop for creating

--- a/README.md
+++ b/README.md
@@ -12,27 +12,15 @@ _Read more about Dangerzone in the [official site](https://dangerzone.rocks/abou
 
 ## Getting started
 
-### MacOS
-- Download [Dangerzone 0.8.0 for Mac (Apple Silicon CPU)](https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0-arm64.dmg)
-- Download [Dangerzone 0.8.0 for Mac (Intel CPU)](https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0-i686.dmg)
+Follow the instructions for each platform:
 
-You can also install Dangerzone for Mac using [Homebrew](https://brew.sh/): `brew install --cask dangerzone`
-
-> **Note**: you will also need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
-> This program needs to run alongside Dangerzone at all times, since it is what allows Dangerzone to
-> create the secure environment.
-
-### Windows
-
-- Download [Dangerzone 0.8.0 for Windows](https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0.msi)
-
-> **Note**: you will also need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
-> This program needs to run alongside Dangerzone at all times, since it is what allows Dangerzone to
-> create the secure environment.
-
-### Linux
-
-See [installing Dangerzone](INSTALL.md#linux) for adding the Linux repositories to your system.
+* [macOS](https://github.com/freedomofpress/dangerzone/blob/v0.8.0//INSTALL.md#macos).
+* [Windows](https://github.com/freedomofpress/dangerzone/blob/v0.8.0//INSTALL.md#macos).
+* [Ubuntu Linux](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#ubuntu-debian)
+* [Debian Linux](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#ubuntu-debian)
+* [Fedora Linux](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#fedora)
+* [Qubes OS (beta)](https://github.com/freedomofpress/dangerzone/v0.8.0/main/INSTALL.md#qubes-os)
+* [Tails](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#tails)
 
 ## Some features
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ _Read more about Dangerzone in the [official site](https://dangerzone.rocks/abou
 
 Follow the instructions for each platform:
 
-* [macOS](https://github.com/freedomofpress/dangerzone/blob/v0.8.0//INSTALL.md#macos).
-* [Windows](https://github.com/freedomofpress/dangerzone/blob/v0.8.0//INSTALL.md#macos).
+* [macOS](https://github.com/freedomofpress/dangerzone/blob/v0.8.0//INSTALL.md#macos)
+* [Windows](https://github.com/freedomofpress/dangerzone/blob/v0.8.0//INSTALL.md#windows)
 * [Ubuntu Linux](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#ubuntu-debian)
 * [Debian Linux](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#ubuntu-debian)
 * [Fedora Linux](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#fedora)
-* [Qubes OS (beta)](https://github.com/freedomofpress/dangerzone/v0.8.0/main/INSTALL.md#qubes-os)
+* [Qubes OS (beta)](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#qubes-os)
 * [Tails](https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#tails)
 
 ## Some features


### PR DESCRIPTION
Our repo's README.md should point to our INSTALL.md for installation instructions, and not the other way around. This fixes an issue with INSTALL.md pointing to a stale README.md version. Updating our README before tagging is not possible, since the latest version is the one that our users visit, and it can't point to download links that do not exist.

Fixes #1003