### PR TITLE
CI: Use grep + cut rather than jq to get the version number

### DIFF
--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Download container image for the latest release and load it
         run: |
-          VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | jq -r '.tag_name')
+          VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | grep "tag_name" | cut -d '"' -f 4)
           CONTAINER_FILENAME=container-${VERSION:1}-${{ matrix.arch }}.tar.gz
           wget https://github.com/freedomofpress/dangerzone/releases/download/${VERSION}/${CONTAINER_FILENAME} -O ${CONTAINER_FILENAME}
           docker load -i ${CONTAINER_FILENAME}


### PR DESCRIPTION
The scans from yesterday are failing: https://github.com/freedomofpress/dangerzone/actions/runs/11944196277/job/33294696171

I hope this will make them run again :-) Github macOS runners don't come with `jq` pre-installed somehow (or not the right version? Not sure)