### PR TITLE
CI: Do not scan release assets for mac silicon for now.

### DIFF
--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -11,8 +11,9 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             arch: i686
-          - runs-on: macos-latest
-            arch: arm64
+          # Do not scan Silicon mac for now to avoid masking release scan results for other plaforms.
+          # - runs-on: macos-latest
+          #   arch: arm64
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Disable the scans for now on mac silicon, until we are able to run docker on the macOS runners.

See #1008 