### PR TITLE
Issue templates: rephrase how we ask `docker info` to the users

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_linux.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_linux.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Podman info
       description: |
-        If the bug occurs during document conversion, or is otherwise related with Podman, please copy and paste the following commands in your terminal, and provide us with the output:
+        Please copy and paste the following commands in your terminal, and provide us with the output:
 
         ```shell
         podman version

--- a/.github/ISSUE_TEMPLATE/bug_report_macos.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_macos.yml
@@ -48,8 +48,7 @@ body:
     attributes:
       label: Docker info
       description: |
-        If the bug occurs during document conversion, or is otherwise related
-        with Docker, please copy and paste the following commands in your
+        Please copy and paste the following commands in your
         terminal, and provide us with the output:
 
         ```shell

--- a/.github/ISSUE_TEMPLATE/bug_report_windows.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_windows.yml
@@ -35,8 +35,7 @@ body:
     attributes:
       label: Docker info
       description: |
-        If the bug occurs during document conversion, or is otherwise related
-        with Docker, please copy and paste the following commands in your
+        Please copy and paste the following commands in your
         terminal, and provide us with the output:
 
         ```shell


### PR DESCRIPTION
People might not now if the issue is related to docker or not, and we've had to ask them for additional information after they opened the issue.

This makes it clearer that this information might be useful.