### PR TITLE
CI: Put `build-deb` as its own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Run CLI tests
         run: poetry run make test
 
-  build-deb:
+  build-all-debs:
     needs:
       - build-container-image
     name: "build-deb (${{ matrix.distro }} ${{ matrix.version }})"
@@ -170,8 +170,6 @@ jobs:
             version: "24.10"
           - distro: debian
             version: bullseye
-          - distro: debian
-            version: bookworm
           - distro: debian
             version: trixie
     steps:
@@ -214,6 +212,62 @@ jobs:
 
       - name: Upload Dangerzone .deb
         if: matrix.distro == 'debian' && matrix.version == 'bookworm'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dangerzone-${{ matrix.distro }}-${{ matrix.version }}.deb
+          path: "deb_dist/dangerzone_*_*.deb"
+          if-no-files-found: error
+          compression-level: 0
+
+  build-deb:
+    needs:
+      - build-container-image
+    name: "build-deb (${{ matrix.distro }} ${{ matrix.version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - distro: debian
+            version: bookworm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Login to GHCR
+        run: |
+          echo ${{ github.token }} | podman login ghcr.io -u USERNAME --password-stdin
+
+      - name: Get the dev environment
+        run: |
+          ./dev_scripts/env.py \
+              --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              build-dev --sync
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Restore container cache
+        uses: actions/cache/restore@v4
+        with:
+          key: v2-${{ steps.date.outputs.date }}-${{ hashFiles('Dockerfile', 'dangerzone/conversion/common.py', 'dangerzone/conversion/doc_to_pixels.py', 'dangerzone/conversion/pixels_to_pdf.py', 'poetry.lock', 'gvisor_wrapper/entrypoint.py') }}
+          path: |-
+            share/container.tar.gz
+            share/image-id.txt
+          fail-on-cache-miss: true
+
+      - name: Build Dangerzone .deb
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              run --dev --no-gui ./dangerzone/install/linux/build-deb.py
+
+      - name: Upload Dangerzone .deb
         uses: actions/upload-artifact@v4
         with:
           name: dangerzone-${{ matrix.distro }}-${{ matrix.version }}.deb


### PR DESCRIPTION
I wanted to speed up a bit the CI runs by not waiting for all the debian packages to build.

It turns out the way to implement this requires us to duplicate the job definition, because the feature [is not implemented in Github Actions](https://github.com/orgs/community/discussions/42335).

What do you think @apyrgio?