### PR TITLE
CI: check that our Github Actions are able to run on ubuntu-24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   build-dev-environment:
     name: "Build dev-env (${{ matrix.distro }}-${{ matrix.version }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     strategy:
       matrix:
         include:

--- a/.github/workflows/check_push.yml
+++ b/.github/workflows/check_push.yml
@@ -1,10 +1,14 @@
 name: Check branch conformity
 on:
   pull_request:
+  push:
+    branches:
+      - main
+      - "test/**"
 
 jobs:
   prevent-fixup-commits:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24
       env:
         target: debian-bookworm
         distro: debian

--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -10,11 +10,15 @@ on:
   schedule:
     - cron: '0 0 * * *' # Run every day at 00:00 UTC.
   workflow_dispatch:
+  push:
+    branches:
+      - main
+      - "test/**"
 
 jobs:
   install-from-apt-repo:
     name: "Install Dangerzone on ${{ matrix.distro}} ${{ matrix.version }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     container: ${{ matrix.distro }}:${{ matrix.version }}
     strategy:
       matrix:
@@ -70,7 +74,7 @@ jobs:
 
   install-from-yum-repo:
     name: "Install Dangerzone on ${{ matrix.distro}} ${{ matrix.version }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     container: ${{ matrix.distro }}:${{ matrix.version }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   run-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     container:
       image: debian:bookworm
     steps:
@@ -70,7 +70,7 @@ jobs:
 
   download-tessdata:
     name: Download and cache Tesseract data
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
     - uses: actions/checkout@v4
     - name: Cache Tessdata
@@ -156,7 +156,7 @@ jobs:
     needs:
       - build-container-image
     name: "build-deb (${{ matrix.distro }} ${{ matrix.version }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     strategy:
       matrix:
         include:
@@ -223,7 +223,7 @@ jobs:
 
   install-deb:
     name: "install-deb (${{ matrix.distro }} ${{ matrix.version }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     needs: 
       - build-deb
     strategy:
@@ -278,7 +278,7 @@ jobs:
 
   build-install-rpm:
     name: "build-install-rpm (${{ matrix.distro }} ${{matrix.version}})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     needs:
       - build-container-image
     strategy:
@@ -342,7 +342,7 @@ jobs:
 
   run-tests:
     name: "run tests (${{ matrix.distro }} ${{ matrix.version }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     needs:
       - build-container-image
       - download-tessdata

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -2,10 +2,14 @@ name: Close inactive issues
 on:
   schedule:
     - cron: "30 1 * * *"
+  push:
+    branches:
+      - main
+      - "test/**"
 
 jobs:
   close-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       issues: write
     steps:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - "test/**"
   pull_request:
   schedule:
     - cron: '0 0 * * *' # Run every day at 00:00 UTC.
@@ -10,7 +11,7 @@ on:
 
 jobs:
   security-scan-container:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +45,7 @@ jobs:
           severity-cutoff: critical
 
   security-scan-app:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -1,5 +1,9 @@
 name: Scan released app and container
 on:
+  push:
+    branches:
+      - main
+      - "test/**"
   schedule:
     - cron: '0 0 * * *' # Run every day at 00:00 UTC.
   workflow_dispatch:
@@ -9,7 +13,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-24
             arch: i686
           # Do not scan Silicon mac for now to avoid masking release scan results for other plaforms.
           # - runs-on: macos-latest
@@ -50,7 +54,7 @@ jobs:
           severity-cutoff: critical
 
   security-scan-app:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
`ubuntu-latest` will point to `ubuntu-24` in the following months rather than `ubuntu-22`. This PR tries to change it beforehand to see if the CI passes, and try to fix the situation.

Related to https://github.com/freedomofpress/infrastructure/issues/5203

