### PR TITLE
Run `apt update` before running `apt get install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,7 @@ jobs:
 
       - name: Setup xvfb (Linux)
         run: |
+          sudo apt update
           # Stuff copied wildly from several stackoverflow posts
           sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
 


### PR DESCRIPTION
The CI currently fails because `apt` cached packages are out of date.

This fixes it.