### PR TITLE
grype: Ignore CVE-2024-11053

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -2,47 +2,10 @@
 # latest release of Dangerzone, and offer our analysis.
 
 ignore:
-  - vulnerability: CVE-2024-5535
-  # CVE-2024-5171
-  # =============
-  #
-  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2024-5171
-  # Verdict: Dangerzone is not affected. The rationale is the following:
-  #
-  # The affected library, `libaom.so`, is linked by GStreamer's `libgstaom.so`
-  # library. The vulnerable `aom_img_alloc` function is only used when
-  # **encoding** a video to AV1. LibreOffce uses the **decode** path instead,
-  # when generating thumbnails.
-  #
-  # See also: https://github.com/freedomofpress/dangerzone/issues/895
-  - vulnerability: CVE-2024-5171
-
-  # CVE-2024-45491, CVE-2024-45492
-  # ===============================
-  #
-  # NVD Entries:
-  # * https://nvd.nist.gov/vuln/detail/CVE-2024-45491
-  # * https://nvd.nist.gov/vuln/detail/CVE-2024-45492
-  #
-  # Verdict: Dangerzone is not affected. The rationale is the following:
-  #
-  # The vulnerabilities that have been assigned to these CVEs affect only 32-bit
-  # architectures. Dangerzone ships only 64-bit images to users.
-  #
-  # See also: https://github.com/freedomofpress/dangerzone/issues/913
-  - vulnerability: CVE-2024-45491
-  - vulnerability: CVE-2024-45492
-
-  # CVE-2024-45490
+  # CVE-2024-11053
   # ==============
   #
-  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2024-45490
-  # Verdict: Dangerzone is not affected. The rationale is the following:
-  #
-  # In order to exploit this bug, the caller must pass a negative length to the
-  # `XML_ParseBuffer` function. This function is not directly used by
-  # LibreOffice, which instead uses a higher-level wrapper. Therefore, our
-  # understanding is that this path cannot be exploited by attackers.
-  #
-  # See also: https://github.com/freedomofpress/dangerzone/issues/913
-  - vulnerability: CVE-2024-45490
+  # NVD Entry: https://nvd.nist.gov/vuln/detail/CVE-2024-11053
+  # Verdict: Dangerzone is not affected because libcurl is an HTTP client, and
+  # the Dangerzone container does not make any network calls.
+  - vulnerability: CVE-2024-11053


### PR DESCRIPTION
Ignore the CVE-2024-11053 vulnerability, since it's a libcurl one, and the Dangerzone container does not make network calls.

Also, clear the previous vulnerabilities, now that we have a new image out.