### PR TITLE
build: add poetry-plugin-export to the dependencies

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -17,7 +17,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install container build dependencies
-        run: sudo apt install pipx && pipx install poetry
+        run: |
+          sudo apt install pipx
+          pipx install poetry
+          pipx inject poetry poetry-plugin-export
       - name: Build container image
         run: python3 ./install/common/build-image.py --runtime docker --no-save
       - name: Get image tag

--- a/BUILD.md
+++ b/BUILD.md
@@ -70,6 +70,7 @@ methods](https://python-poetry.org/docs/#installation))_
 ```sh
 pipx ensurepath
 pipx install poetry
+pipx inject poetry poetry-plugin-export
 ```
 
 After this, restart the terminal window, for the `poetry` command to be in your
@@ -157,6 +158,7 @@ Install Poetry using `pipx`:
 
 ```sh
 pipx install poetry
+pipx inject poetry poetry-plugin-export
 ```
 
 Clone this repository:
@@ -369,7 +371,7 @@ cd dangerzone
 Install Python dependencies:
 
 ```sh
-python3 -m pip install poetry
+python3 -m pip install poetry poetry-plugin-export
 poetry install
 ```
 
@@ -430,7 +432,7 @@ Install Microsoft Visual C++ 14.0 or greater. Get it with ["Microsoft C++ Build 
 Install [poetry](https://python-poetry.org/). Open PowerShell, and run:
 
 ```
-python -m pip install poetry
+python -m pip install poetry poetry-plugin-export
 ```
 
 Install git from [here](https://git-scm.com/download/win), open a Windows terminal (`cmd.exe`) and clone this repository:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -113,7 +113,7 @@ Here is what you need to do:
 
   # In case of a new Python installation or minor version upgrade, e.g., from
   # 3.11 to 3.12, reinstall Poetry
-  python3 -m pip install poetry
+  python3 -m pip install poetry poetry-plugin-export
 
   # You can verify the correct Python version is used
   poetry debug info
@@ -195,7 +195,7 @@ The Windows release is performed in a Windows 11 virtual machine (as opposed to 
   ```bash
   # In case of a new Python installation or minor version upgrade, e.g., from
   # 3.11 to 3.12, reinstall Poetry
-  python3 -m pip install poetry
+  python3 -m pip install poetry poetry-plugin-export
 
   # You can verify the correct Python version is used
   poetry debug info

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -183,6 +183,7 @@ COPY storage.conf /home/user/.config/containers
 # FIXME: pipx install poetry does not work for Ubuntu Focal.
 ENV PATH="$PATH:/home/user/.local/bin"
 RUN pipx install poetry
+RUN pipx inject poetry poetry-plugin-export
 
 COPY pyproject.toml poetry.lock /home/user/dangerzone/
 RUN cd /home/user/dangerzone && poetry --no-ansi install

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -292,6 +292,7 @@ def get_build_dir_sources(distro, version):
     sources = [
         git_root() / "pyproject.toml",
         git_root() / "poetry.lock",
+        git_root() / "dev_scripts" / "env.py",
         git_root() / "dev_scripts" / "storage.conf",
         git_root() / "dev_scripts" / "containers.conf",
     ]

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -287,6 +287,7 @@ methods](https://python-poetry.org/docs/#installation))_
 ```sh
 pipx ensurepath
 pipx install poetry
+pipx inject poetry poetry-plugin-export
 ```
 
 After this, restart the terminal window, for the `poetry` command to be in your
@@ -375,6 +376,7 @@ Install Poetry using `pipx`:
 
 ```sh
 pipx install poetry
+pipx inject poetry poetry-plugin-export
 ```
 
 Clone this repository:
@@ -440,7 +442,7 @@ Install Microsoft Visual C++ 14.0 or greater. Get it with ["Microsoft C++ Build 
 Install [poetry](https://python-poetry.org/). Open PowerShell, and run:
 
 ```
-python -m pip install poetry
+python -m pip install poetry poetry-plugin-export
 ```
 
 Install git from [here](https://git-scm.com/download/win), open a Windows terminal (`cmd.exe`) and clone this repository:
@@ -878,7 +880,7 @@ class QAWindows(QABase):
         "Install Poetry and the project's dependencies", ref=REF_BUILD, auto=True
     )
     def install_poetry(self):
-        self.run("python", "-m", "pip", "install", "poetry")
+        self.run("python", "-m", "pip", "install", "poetry", "poetry-plugin-export")
         self.run("poetry", "install", "--sync")
 
     @QABase.task("Build Dangerzone container image", ref=REF_BUILD, auto=True)


### PR DESCRIPTION
Since Poetry 2.0.0, the `export` command has been removed and it's advised to use the "poetry-plugin-export" package instead.

This commit adds this dependency to the different places it's needed (debian environments, CI, build instructions etc).

I also took the chance to include `env.py` in the hashed files for the dev containers.

Fixes #825 