### PR TITLE
CI: Store the signature key using the base64 format

### DIFF
--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -53,8 +53,13 @@ jobs:
           gpg --keyserver hkps://keys.openpgp.org \
               --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
               --recv-keys "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281"
+
+          # Export the GPG key in armor mode because sequoia needs it this way
+          # (sqv is used on debian trixie by default to check the keys)
           mkdir -p /etc/apt/keyrings/
-          mv fpf-apt-tools-archive-keyring.gpg /etc/apt/keyrings
+          gpg --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
+              --armor --export "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281" \
+              > /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
 
       - name: Add packages.freedom.press to our APT sources
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,9 @@ gpg --keyserver hkps://keys.openpgp.org \
     --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
     --recv-keys "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281"
 sudo mkdir -p /etc/apt/keyrings/
-sudo mv fpf-apt-tools-archive-keyring.gpg /etc/apt/keyrings
+sudo gpg --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
+    --armor --export "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281" \
+    > /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
 ```
 
 Add the URL of the repo in your APT sources:


### PR DESCRIPTION
The GPG binary format used until now doesn't seem to please `sqv` which is now used by default on debian trixie.

Fixes #1052