### PR TITLE
doc: update Debian Trixie installation instructions

### DIFF
--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -46,21 +46,30 @@ jobs:
           apt update
           apt-get install python-all -y
 
-      - name: Add GPG key for the packages.freedom.press
+      - name: Add packages.freedom.press PGP key (gpg)
+        if: matrix.version != 'trixie'
         run: |
           apt-get update && apt-get install -y gnupg2 ca-certificates
           dirmngr  # NOTE: This is a command that's necessary only in containers
+          # The key needs to be in the GPG keybox database format so the
+          # signing subkey is detected by apt-secure.
           gpg --keyserver hkps://keys.openpgp.org \
               --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
               --recv-keys "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281"
-
-          # Export the GPG key in armor mode because sequoia needs it this way
-          # (sqv is used on debian trixie by default to check the keys)
           mkdir -p /etc/apt/keyrings/
-          gpg --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
-              --armor --export "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281" \
-              > /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
+          mv ./fpf-apt-tools-archive-keyring.gpg /etc/apt/keyrings/.
 
+      - name: Add packages.freedom.press PGP key (sq)
+        if: matrix.version == 'trixie'
+        run: |
+          apt-get update && apt-get install -y ca-certificates sq
+          mkdir -p /etc/apt/keyrings/
+          # On debian trixie, apt-secure uses `sqv` to verify the signatures
+          # so we need to retrieve PGP keys and store them using the base64 format.
+          sq network keyserver \
+             --server hkps://keys.openpgp.org \
+             search "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281" \
+             --output /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
       - name: Add packages.freedom.press to our APT sources
         run: |
           . /etc/os-release

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,9 +84,20 @@ Dangerzone is available for:
   </tr>
 </table>
 
-Add our repository following these instructions:
+First, retrieve the PGP keys.
 
-Download the GPG key for the repo:
+Starting with Trixie, follow these instructions to download the PGP keys:
+
+```bash
+sudo apt-get update && sudo apt-get install sq -y
+mkdir -p /etc/apt/keyrings/
+sq network keyserver \
+   --server hkps://keys.openpgp.org \
+   search "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281" \
+   --output /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
+```
+
+On other Debian-derivatives:
 
 ```sh
 sudo apt-get update && sudo apt-get install gnupg2 ca-certificates -y
@@ -99,7 +110,7 @@ sudo gpg --no-default-keyring --keyring ./fpf-apt-tools-archive-keyring.gpg \
     > /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
 ```
 
-Add the URL of the repo in your APT sources:
+Then, on all distributions, add the URL of the repo in your APT sources:
 
 ```sh
 . /etc/os-release


### PR DESCRIPTION
Starting with Debian Trixie, `apt secure` relies on `sqv` to do its verification, which doesn't support the GPG keybox database format.

In [a previous episode](https://github.com/freedomofpress/dangerzone/pull/1053) we switched to the base64 version of the key, but this resulted in all other debian-versions not able to follow our instructions (see #1055 for more details).

The reason is that the standard PGP base64 format makes the verification fail for versions of `apt secure` which relies on `gpg`, as the subkey is not detected there.

This PR takes two different routes for versions which rely on `sq` and versions which rely on `gpg` for the verification.

Fixes #1055, supersedes #1054