### PR TITLE
debian: Switch to quilt format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-dangerzone (0.8.1) unstable; urgency=low
+dangerzone (0.8.1-1) unstable; urgency=low
 
   * Released Dangerzone 0.8.1
 
- -- Freedom of the Press Foundation   <info@freedom.press>  Tue, 22 December 2024 22:03:28 +0300
+ -- Freedom of the Press Foundation   <info@freedom.press>  Tue, 22 Dec 2024 22:03:28 +0300
 
 dangerzone (0.8.0) unstable; urgency=low
 

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/install/linux/build-deb.py
+++ b/install/linux/build-deb.py
@@ -21,22 +21,6 @@ def run(cmd):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        prog=sys.argv[0],
-        description="Dev script for building Dangerzone debs",
-    )
-    # FIXME: The name of the distro is important, as it can help users who are upgrading
-    # from a distro version to another. If we *do* need to provide a name at some point,
-    # here's a suggestion on how we should tackle naming:
-    #
-    # https://github.com/freedomofpress/dangerzone/pull/322#issuecomment-1428665162
-    parser.add_argument(
-        "--distro",
-        required=False,
-        help="The name of the Debian-based distro",
-    )
-    args = parser.parse_args()
-
     dist_path = root / "dist"
     deb_dist_path = root / "deb_dist"
 
@@ -46,28 +30,15 @@ def main():
     if os.path.exists(deb_dist_path):
         shutil.rmtree(deb_dist_path)
 
-    print("* Building DEB package")
-    if args.distro is None:
-        deb_ver = "1"
-    else:
-        deb_ver = args.distro
-
-    run(
-        [
-            "dpkg-buildpackage",
-        ]
-    )
+    print("* Building binary-only DEB package")
+    run(["dpkg-buildpackage", "-b"])
 
     os.makedirs(deb_dist_path, exist_ok=True)
-    print("")
-    print("* To install run:")
-
-    # dpkg-buildpackage produces a .deb file in the parent folder
-    # that needs to be copied to the `deb_dist` folder manually
-    src = root.parent / f"dangerzone_{version}_amd64.deb"
-    destination = root / "deb_dist" / f"dangerzone_{version}-{deb_ver}_amd64.deb"
-    shutil.move(src, destination)
-    print(f"sudo dpkg -i {destination}")
+    print("The following files have been created:")
+    for src in root.parent.glob(f"dangerzone_{version}*"):
+        dest = deb_dist_path / src.name
+        shutil.move(src, dest)
+        print(f"{dest}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Switch to quilt package format, and use `dpkg-buildpackage -b` to build the new Python package.

Refs #1071