### PR TITLE
Specify version when installing WiX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,9 @@ jobs:
         with:
           dotnet-version: "8.x"
       - name: Install WiX Toolset
-        run: dotnet tool install --global wix
+        run: dotnet tool install --global wix --version 5.0.2
       - name: Add WiX UI extension
-        run: wix extension add --global WixToolset.UI.wixext
+        run: wix extension add --global WixToolset.UI.wixext/5.0.2
       - name: Build the MSI installer
         # NOTE: This also builds the .exe internally.
         run: poetry run .\install\windows\build-app.bat

--- a/BUILD.md
+++ b/BUILD.md
@@ -478,13 +478,13 @@ poetry shell
 Install [.NET SDK](https://dotnet.microsoft.com/en-us/download) version 6 or later. Then, open a terminal and install the latest version of [WiX Toolset .NET tool](https://wixtoolset.org/) **v5** with:
 
 ```sh
-dotnet tool install --global wix --version 5.*
+dotnet tool install --global wix --version 5.0.2
 ```
 
 Install the WiX UI extension. You may need to open a new terminal in order to use the newly installed `wix` .NET tool:
 
 ```sh
-wix extension add --global WixToolset.UI.wixext/5.x.y
+wix extension add --global WixToolset.UI.wixext/5.0.2
 ```
 
 > [!IMPORTANT]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@ Here is a list of tasks that should be done before issuing the release:
       You can generate its content with the the `poetry run ./dev_scripts/generate-release-tasks.py` command.
 - [ ] [Add new Linux platforms and remove obsolete ones](https://github.com/freedomofpress/dangerzone/blob/main/RELEASE.md#add-new-linux-platforms-and-remove-obsolete-ones)
 - [ ] Bump the Python dependencies using `poetry lock`
+- [ ] Check for new [WiX releases](https://github.com/wixtoolset/wix/releases) and update it if needed
 - [ ] Update `version` in `pyproject.toml`
 - [ ] Update `share/version.txt`
 - [ ] Update the "Version" field in `install/linux/dangerzone.spec`


### PR DESCRIPTION
Update our CI job and build instructions with the latest WiX version, so that we don't encounter any installation issues when new WiX versions are released.

Also, add a reminder in our release instruction to bump the WiX version before we start a new release.

Fixes #1087