### PR TITLE
ci: Security scan ARM images

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,7 +10,12 @@ on:
 
 jobs:
   security-scan-container:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,7 +63,12 @@ jobs:
           severity-cutoff: critical
 
   security-scan-app:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -9,11 +9,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-24.04
             arch: i686
-          # Do not scan Silicon mac for now to avoid masking release scan results for other plaforms.
-          # - runs-on: macos-latest
-          #   arch: arm64
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
@@ -55,7 +54,12 @@ jobs:
           severity-cutoff: critical
 
   security-scan-app:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Scan ARM images using Anchore's scan action, by utilizing the Ubuntu ARM runners provided by GitHub. While our ARM images are used only in macOS silicon platforms, we can use the Ubuntu ARM runners just for scanning.

CI jobs:
- Scan released app and container: https://github.com/freedomofpress/dangerzone/actions/runs/13769808346
- Scan latest app and container: https://github.com/freedomofpress/dangerzone/actions/runs/13769808387

Closes #1008