### PR TITLE
Avoid passing wrong options `-B` to subprocesses

### DIFF
--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -3,6 +3,7 @@ import os
 import platform
 import tempfile
 import typing
+from multiprocessing import freeze_support
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import List, Optional
@@ -1220,6 +1221,9 @@ class DocumentsListWidget(QtWidgets.QListWidget):
     def start_conversion(self) -> None:
         if not self.thread_pool_initized:
             max_jobs = self.dangerzone.isolation_provider.get_max_parallel_conversions()
+            # Call freeze_support() to avoid passing unknown options to the subprocess.
+            # See https://github.com/freedomofpress/dangerzone/issues/873
+            freeze_support()
             self.thread_pool = ThreadPool(max_jobs)
 
         for doc in self.docs_list:


### PR DESCRIPTION
This is a common pitfall of pyinstaller, when using multiprocessing.

In our case, the spawned processes is passed the `-B` option, thinking it's python (but it's dangerzone), so it fails. 

In case you are wondering, `-B` is an option you can pass python to avoid generating `.pyc` files at runtime:

> -B     Don't write .pyc files on import. See also PYTHONDONTWRITEBYTECODE.

From the pyinstaller docs:

> In the frozen application, sys.executable points to your application
> executable. So when the multiprocessing module in your main process
> attempts to spawn a subprocess (a worker or the resource tracker), it
> runs another instance of your program, with the following arguments for
> resource tracker:
>
> my_program -B -S -I -c "from multiprocessing.resource_tracker import main;main(5)"

https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html#multi-processing

Fixes #873 