### PR TITLE
CI: Enforce updating the CHANGELOG in the CI

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -31,5 +31,6 @@ jobs:
         shell: bash
         run: |
           if git diff --exit-code "origin/${BASE_REF}" -- CHANGELOG.md; then
-              echo "::warning::No CHANGELOG.md modifications were found in this pull request."
+              echo "::error::No CHANGELOG.md modifications were found in this pull request."
+              return -1;
           fi


### PR DESCRIPTION
Currently, this is only returning warnings, but we seem to just skip them. As it's possible to merge PRs when the CI is red, issuing an error would help us to think about populating this file.