### PR TITLE
Allow to specify the container_runtime in the settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 - Document Operating System support [#986](https://github.com/freedomofpress/dangerzone/issues/986)
 - Tests: Look for regressions when converting PDFs [#321](https://github.com/freedomofpress/dangerzone/issues/321)
 
+## Added
+
+- (experimental): It is now possible to specify a custom container runtime in
+  the settings, by using the `container_runtime` key. It should contain the path
+  to the container runtime you want to use. Please note that this doesn't mean
+  we support more container runtimes than Podman and Docker for the time being,
+  but enables you to chose which one you want to use, independently of your
+  platform. ([#925](https://github.com/freedomofpress/dangerzone/issues/925))
+
 ## [0.8.1](https://github.com/freedomofpress/dangerzone/compare/v0.8.1...0.8.0)
 
 - Update the container image

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -320,4 +320,10 @@ def display_banner() -> None:
         + Style.DIM
         + "│"
     )
-    print(Back.BLACK + Fore.YELLOW + Style.DIM + "╰──────────────────────────╯")
+    print(
+        Back.BLACK
+        + Fore.YELLOW
+        + Style.DIM
+        + "╰──────────────────────────╯"
+        + Style.RESET_ALL
+    )

--- a/dangerzone/container_utils.py
+++ b/dangerzone/container_utils.py
@@ -21,6 +21,8 @@ class Runtime(object):
 
         if settings.custom_runtime_specified():
             self.path = Path(settings.get("container_runtime"))
+            if not self.path.exists():
+                raise errors.UnsupportedContainerRuntime(self.path)
             self.name = self.path.stem
         else:
             self.name = self.get_default_runtime_name()
@@ -28,6 +30,9 @@ class Runtime(object):
             if binary_path is None or not os.path.exists(binary_path):
                 raise errors.NoContainerTechException(self.name)
             self.path = Path(binary_path)
+
+        if self.name not in ("podman", "docker"):
+            raise errors.UnsupportedContainerRuntime(self.name)
 
     @staticmethod
     def get_default_runtime_name() -> str:

--- a/dangerzone/container_utils.py
+++ b/dangerzone/container_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import platform
 import shutil
 import subprocess
@@ -26,6 +27,11 @@ def get_runtime() -> str:
     container_tech = get_runtime_name()
     runtime = shutil.which(container_tech)
     if runtime is None:
+        # Fallback to the container runtime path from the settings
+        settings = Settings()
+        runtime_path = settings.get("container_runtime_path")
+        if os.path.exists(runtime_path):
+            return runtime_path
         raise errors.NoContainerTechException(container_tech)
     return runtime
 

--- a/dangerzone/container_utils.py
+++ b/dangerzone/container_utils.py
@@ -121,7 +121,7 @@ def delete_image_tag(tag: str) -> None:
 
 def get_expected_tag() -> str:
     """Get the tag of the Dangerzone image tarball from the image-id.txt file."""
-    with open(get_resource_path("image-id.txt")) as f:
+    with get_resource_path("image-id.txt").open() as f:
         return f.read().strip()
 
 
@@ -130,7 +130,7 @@ def load_image_tarball() -> None:
     tarball_path = get_resource_path("container.tar")
     try:
         res = subprocess.run(
-            [get_runtime(), "load", "-i", tarball_path],
+            [get_runtime(), "load", "-i", str(tarball_path)],
             startupinfo=get_subprocess_startupinfo(),
             capture_output=True,
             check=True,

--- a/dangerzone/errors.py
+++ b/dangerzone/errors.py
@@ -140,3 +140,7 @@ class NotAvailableContainerTechException(Exception):
         self.error = error
         self.container_tech = container_tech
         super().__init__(f"{container_tech} is not available")
+
+
+class UnsupportedContainerRuntime(Exception):
+    pass

--- a/dangerzone/gui/__init__.py
+++ b/dangerzone/gui/__init__.py
@@ -51,7 +51,7 @@ class Application(QtWidgets.QApplication):
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super(Application, self).__init__(*args, **kwargs)
         self.setQuitOnLastWindowClosed(False)
-        with open(get_resource_path("dangerzone.css"), "r") as f:
+        with get_resource_path("dangerzone.css").open("r") as f:
             style = f.read()
         self.setStyleSheet(style)
 

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -63,7 +63,7 @@ class DangerzoneGui(DangerzoneCore):
             path = get_resource_path("dangerzone.ico")
         else:
             path = get_resource_path("icon.png")
-        return QtGui.QIcon(path)
+        return QtGui.QIcon(str(path))
 
     def open_pdf_viewer(self, filename: str) -> None:
         if platform.system() == "Darwin":
@@ -252,7 +252,7 @@ class Alert(Dialog):
     def create_layout(self) -> QtWidgets.QBoxLayout:
         logo = QtWidgets.QLabel()
         logo.setPixmap(
-            QtGui.QPixmap.fromImage(QtGui.QImage(get_resource_path("icon.png")))
+            QtGui.QPixmap.fromImage(QtGui.QImage(str(get_resource_path("icon.png"))))
         )
 
         label = QtWidgets.QLabel()

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -221,11 +221,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setProperty("OSColorMode", self.dangerzone.app.os_color_mode.value)
 
         if hasattr(self.dangerzone.isolation_provider, "check_docker_desktop_version"):
-            is_version_valid, version = (
-                self.dangerzone.isolation_provider.check_docker_desktop_version()
-            )
-            if not is_version_valid:
-                self.handle_docker_desktop_version_check(is_version_valid, version)
+            try:
+                is_version_valid, version = (
+                    self.dangerzone.isolation_provider.check_docker_desktop_version()
+                )
+                if not is_version_valid:
+                    self.handle_docker_desktop_version_check(is_version_valid, version)
+            except errors.UnsupportedContainerRuntime as e:
+                pass  # It's catched later in the flow.
 
         self.show()
 

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -605,17 +605,18 @@ class WaitingWidgetContainer(WaitingWidget):
                 )
             elif platform.system() == "Linux":
                 # "not_running" here means that the `podman image ls` command failed.
-                message = (
+                self.show_error(
                     "<strong>Dangerzone requires Podman</strong><br><br>"
-                    "Podman is installed but cannot run properly. See errors below"
+                    "Podman is installed but cannot run properly. See errors below",
+                    error,
                 )
             else:
-                message = (
+                self.show_error(
                     "<strong>Dangerzone requires Docker Desktop</strong><br><br>"
                     "Docker is installed but isn't running.<br><br>"
-                    "Open Docker and make sure it's running in the background."
+                    "Open Docker and make sure it's running in the background.",
+                    error,
                 )
-            self.show_error(message, error)
         else:
             self.show_message(
                 "Installing the Dangerzone container image.<br><br>"

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -62,7 +62,7 @@ def load_svg_image(filename: str, width: int, height: int) -> QtGui.QPixmap:
     This answer is basically taken from: https://stackoverflow.com/a/25689790
     """
     path = get_resource_path(filename)
-    svg_renderer = QtSvg.QSvgRenderer(path)
+    svg_renderer = QtSvg.QSvgRenderer(str(path))
     image = QtGui.QImage(width, height, QtGui.QImage.Format_ARGB32)
     # Set the ARGB to 0 to prevent rendering artifacts
     image.fill(0x00000000)
@@ -130,9 +130,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Header
         logo = QtWidgets.QLabel()
-        logo.setPixmap(
-            QtGui.QPixmap.fromImage(QtGui.QImage(get_resource_path("icon.png")))
-        )
+        icon_path = str(get_resource_path("icon.png"))
+        logo.setPixmap(QtGui.QPixmap.fromImage(QtGui.QImage(icon_path)))
         header_label = QtWidgets.QLabel("Dangerzone")
         header_label.setFont(self.dangerzone.fixed_font)
         header_label.setStyleSheet("QLabel { font-weight: bold; font-size: 50px; }")
@@ -1306,7 +1305,7 @@ class DocumentWidget(QtWidgets.QWidget):
 
     def load_status_image(self, filename: str) -> QtGui.QPixmap:
         path = get_resource_path(filename)
-        img = QtGui.QImage(path)
+        img = QtGui.QImage(str(path))
         image = QtGui.QPixmap.fromImage(img)
         return image.scaled(QtCore.QSize(15, 15))
 

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -574,8 +574,15 @@ class WaitingWidgetContainer(WaitingWidget):
             self.finished.emit()
 
     def state_change(self, state: str, error: Optional[str] = None) -> None:
+        custom_runtime = self.dangerzone.settings.custom_runtime_specified()
+
         if state == "not_installed":
-            if platform.system() == "Linux":
+            if custom_runtime:
+                self.show_error(
+                    "<strong>We could not find the container runtime defined in your settings</strong><br><br>"
+                    "Please check your settings, install it if needed, and retry."
+                )
+            elif platform.system() == "Linux":
                 self.show_error(
                     "<strong>Dangerzone requires Podman</strong><br><br>"
                     "Install it and retry."
@@ -588,7 +595,12 @@ class WaitingWidgetContainer(WaitingWidget):
                 )
 
         elif state == "not_running":
-            if platform.system() == "Linux":
+            if custom_runtime:
+                self.show_error(
+                    "<strong>We were unable to start the container runtime defined in your settings</strong><br><br>"
+                    "Please check your settings, install it if needed, and retry."
+                )
+            elif platform.system() == "Linux":
                 # "not_running" here means that the `podman image ls` command failed.
                 message = (
                     "<strong>Dangerzone requires Podman</strong><br><br>"

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -143,7 +143,10 @@ class Container(IsolationProvider):
     def check_docker_desktop_version(self) -> Tuple[bool, str]:
         # On windows and darwin, check that the minimum version is met
         version = ""
-        if platform.system() != "Linux":
+        runtime_is_docker = container_utils.get_runtime_name() == "docker"
+        platform_is_not_linux = platform.system() != "Linux"
+
+        if runtime_is_docker and platform_is_not_linux:
             with subprocess.Popen(
                 ["docker", "version", "--format", "{{.Server.Platform.Name}}"],
                 stdout=subprocess.PIPE,

--- a/dangerzone/isolation_provider/container.py
+++ b/dangerzone/isolation_provider/container.py
@@ -64,7 +64,7 @@ class Container(IsolationProvider):
         #
         # [1] https://github.com/freedomofpress/dangerzone/issues/846
         # [2] https://github.com/containers/common/blob/d3283f8401eeeb21f3c59a425b5461f069e199a7/pkg/seccomp/seccomp.json
-        seccomp_json_path = get_resource_path("seccomp.gvisor.json")
+        seccomp_json_path = str(get_resource_path("seccomp.gvisor.json"))
         security_args += ["--security-opt", f"seccomp={seccomp_json_path}"]
 
         security_args += ["--cap-drop", "all"]

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -130,7 +130,6 @@ def is_qubes_native_conversion() -> bool:
         # This disambiguates if it is running a Qubes targetted build or not
         # (Qubes-specific builds don't ship the container image)
 
-        container_image_path = get_resource_path("container.tar")
-        return not os.path.exists(container_image_path)
+        return not get_resource_path("container.tar").exists()
     else:
         return False

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -27,7 +27,7 @@ class DangerzoneCore(object):
         self.appdata_path = util.get_config_dir()
 
         # Languages supported by tesseract
-        with open(get_resource_path("ocr-languages.json"), "r") as f:
+        with get_resource_path("ocr-languages.json").open("r") as f:
             unsorted_ocr_languages = json.load(f)
             self.ocr_languages = dict(sorted(unsorted_ocr_languages.items()))
 

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -23,16 +23,13 @@ class DangerzoneCore(object):
         # Initialize terminal colors
         colorama.init(autoreset=True)
 
-        # App data folder
-        self.appdata_path = util.get_config_dir()
-
         # Languages supported by tesseract
         with get_resource_path("ocr-languages.json").open("r") as f:
             unsorted_ocr_languages = json.load(f)
             self.ocr_languages = dict(sorted(unsorted_ocr_languages.items()))
 
         # Load settings
-        self.settings = Settings(self)
+        self.settings = Settings()
         self.documents: List[Document] = []
         self.isolation_provider = isolation_provider
 

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -6,12 +6,9 @@ from typing import TYPE_CHECKING, Any, Dict
 from packaging import version
 
 from .document import SAFE_EXTENSION
-from .util import get_version
+from .util import get_config_dir, get_version
 
 log = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from .logic import DangerzoneCore
 
 SETTINGS_FILENAME: str = "settings.json"
 
@@ -19,11 +16,8 @@ SETTINGS_FILENAME: str = "settings.json"
 class Settings:
     settings: Dict[str, Any]
 
-    def __init__(self, dangerzone: "DangerzoneCore") -> None:
-        self.dangerzone = dangerzone
-        self.settings_filename = os.path.join(
-            self.dangerzone.appdata_path, SETTINGS_FILENAME
-        )
+    def __init__(self) -> None:
+        self.settings_filename = get_config_dir() / SETTINGS_FILENAME
         self.default_settings: Dict[str, Any] = self.generate_default_settings()
         self.load()
 
@@ -91,6 +85,6 @@ class Settings:
         self.save()
 
     def save(self) -> None:
-        os.makedirs(self.dangerzone.appdata_path, exist_ok=True)
-        with open(self.settings_filename, "w") as settings_file:
+        self.settings_filename.parent.mkdir(parents=True, exist_ok=True)
+        with self.settings_filename.open("w") as settings_file:
             json.dump(self.settings, settings_file, indent=4)

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict
 
 from packaging import version
@@ -41,6 +42,15 @@ class Settings:
 
     def custom_runtime_specified(self) -> bool:
         return "container_runtime" in self.settings
+
+    def set_custom_runtime(self, runtime: str, autosave: bool = False) -> Path:
+        from .container_utils import Runtime  # Avoid circular import
+
+        container_runtime = Runtime.path_from_name(runtime)
+        self.settings["container_runtime"] = str(container_runtime)
+        if autosave:
+            self.save()
+        return container_runtime
 
     def get(self, key: str) -> Any:
         return self.settings[key]

--- a/dangerzone/settings.py
+++ b/dangerzone/settings.py
@@ -39,6 +39,9 @@ class Settings:
             "updater_errors": 0,
         }
 
+    def custom_runtime_specified(self) -> bool:
+        return "container_runtime" in self.settings
+
     def get(self, key: str) -> Any:
         return self.settings[key]
 

--- a/tests/gui/test_updater.py
+++ b/tests/gui/test_updater.py
@@ -48,9 +48,7 @@ def test_default_updater_settings(updater: UpdaterThread) -> None:
     )
 
 
-def test_pre_0_4_2_settings(
-    tmp_path: Path, monkeypatch: MonkeyPatch, mocker: MockerFixture
-) -> None:
+def test_pre_0_4_2_settings(tmp_path: Path, mocker: MockerFixture) -> None:
     """Check settings of installations prior to 0.4.2.
 
     Check that installations that have been upgraded from a version < 0.4.2 to >= 0.4.2
@@ -58,7 +56,7 @@ def test_pre_0_4_2_settings(
     in their settings.json file.
     """
     save_settings(tmp_path, default_settings_0_4_1())
-    updater = generate_isolated_updater(tmp_path, monkeypatch, mocker)
+    updater = generate_isolated_updater(tmp_path, mocker, mock_app=True)
     assert (
         updater.dangerzone.settings.get_updater_settings() == default_updater_settings()
     )
@@ -83,12 +81,10 @@ def test_post_0_4_2_settings(
     # version is 0.4.3.
     expected_settings = default_updater_settings()
     expected_settings["updater_latest_version"] = "0.4.3"
-    monkeypatch.setattr(
-        settings, "get_version", lambda: expected_settings["updater_latest_version"]
-    )
+    monkeypatch.setattr(settings, "get_version", lambda: "0.4.3")
 
     # Ensure that the Settings class will correct the latest version field to 0.4.3.
-    updater = generate_isolated_updater(tmp_path, monkeypatch, mocker)
+    updater = generate_isolated_updater(tmp_path, mocker, mock_app=True)
     assert updater.dangerzone.settings.get_updater_settings() == expected_settings
 
     # Simulate an updater check that found a newer Dangerzone version (e.g., 0.4.4).
@@ -118,9 +114,7 @@ def test_linux_no_check(updater: UpdaterThread, monkeypatch: MonkeyPatch) -> Non
     assert updater.dangerzone.settings.get_updater_settings() == expected_settings
 
 
-def test_user_prompts(
-    updater: UpdaterThread, monkeypatch: MonkeyPatch, mocker: MockerFixture
-) -> None:
+def test_user_prompts(updater: UpdaterThread, mocker: MockerFixture) -> None:
     """Test prompting users to ask them if they want to enable update checks."""
     # First run
     #
@@ -370,8 +364,6 @@ def test_update_errors(
 def test_update_check_prompt(
     qtbot: QtBot,
     qt_updater: UpdaterThread,
-    monkeypatch: MonkeyPatch,
-    mocker: MockerFixture,
 ) -> None:
     """Test that the prompt to enable update checks works properly."""
     # Force Dangerzone to check immediately for updates

--- a/tests/isolation_provider/test_container.py
+++ b/tests/isolation_provider/test_container.py
@@ -74,7 +74,7 @@ class TestContainer(IsolationProviderTest):
                 container_utils.get_runtime(),
                 "load",
                 "-i",
-                get_resource_path("container.tar"),
+                get_resource_path("container.tar").absolute(),
             ],
             returncode=-1,
         )
@@ -113,7 +113,7 @@ class TestContainer(IsolationProviderTest):
                 container_utils.get_runtime(),
                 "load",
                 "-i",
-                get_resource_path("container.tar"),
+                get_resource_path("container.tar").absolute(),
             ],
         )
         with pytest.raises(errors.ImageNotPresentException):

--- a/tests/isolation_provider/test_container.py
+++ b/tests/isolation_provider/test_container.py
@@ -87,7 +87,7 @@ class TestContainer(IsolationProviderTest):
     ) -> None:
         """When an image keep being not installed, it should return False"""
         fp.register_subprocess(
-            ["podman", "version", "-f", "{{.Client.Version}}"],
+            [container_utils.get_runtime(), "version", "-f", "{{.Client.Version}}"],
             stdout="4.0.0",
         )
 

--- a/tests/test_container_utils.py
+++ b/tests/test_container_utils.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from pytest_mock import MockerFixture
+
+from dangerzone.container_utils import get_runtime_name
+from dangerzone.settings import Settings
+
+
+def test_get_runtime_name_from_settings(mocker: MockerFixture, tmp_path: Path) -> None:
+    mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
+
+    settings = Settings()
+    settings.set("container_runtime", "new-kid-on-the-block", autosave=True)
+
+    assert get_runtime_name() == "new-kid-on-the-block"
+
+
+def test_get_runtime_name_linux(mocker: MockerFixture) -> None:
+    mocker.patch("platform.system", return_value="Linux")
+    assert get_runtime_name() == "podman"
+
+
+def test_get_runtime_name_non_linux(mocker: MockerFixture) -> None:
+    mocker.patch("platform.system", return_value="Windows")
+    assert get_runtime_name() == "docker"
+
+    mocker.patch("platform.system", return_value="Something else")
+    assert get_runtime_name() == "docker"

--- a/tests/test_container_utils.py
+++ b/tests/test_container_utils.py
@@ -1,20 +1,21 @@
 from pathlib import Path
 
+import pytest
 from pytest_mock import MockerFixture
 
+from dangerzone import errors
 from dangerzone.container_utils import Runtime
 from dangerzone.settings import Settings
 
 
 def test_get_runtime_name_from_settings(mocker: MockerFixture, tmp_path: Path) -> None:
     mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
+    mocker.patch("dangerzone.container_utils.Path.exists", return_value=True)
 
     settings = Settings()
-    settings.set(
-        "container_runtime", "/opt/somewhere/new-kid-on-the-block", autosave=True
-    )
+    settings.set("container_runtime", "/opt/somewhere/docker", autosave=True)
 
-    assert Runtime().name == "new-kid-on-the-block"
+    assert Runtime().name == "docker"
 
 
 def test_get_runtime_name_linux(mocker: MockerFixture, tmp_path: Path) -> None:
@@ -46,3 +47,14 @@ def test_get_runtime_name_non_linux(mocker: MockerFixture, tmp_path: Path) -> No
     assert runtime.name == "docker"
     assert runtime.path == Path("/usr/bin/docker")
     assert Runtime().name == "docker"
+
+
+def test_get_unsupported_runtime_name(mocker: MockerFixture, tmp_path: Path):
+    mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
+    settings = Settings()
+    settings.set(
+        "container_runtime", "/opt/somewhere/new-kid-on-the-block", autosave=True
+    )
+
+    with pytest.raises(errors.UnsupportedContainerRuntime):
+        assert Runtime().name == "new-kid-on-the-block"

--- a/tests/test_container_utils.py
+++ b/tests/test_container_utils.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from pytest_mock import MockerFixture
 
-from dangerzone.container_utils import get_runtime_name
+from dangerzone.container_utils import Runtime
 from dangerzone.settings import Settings
 
 
@@ -10,19 +10,39 @@ def test_get_runtime_name_from_settings(mocker: MockerFixture, tmp_path: Path) -
     mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
 
     settings = Settings()
-    settings.set("container_runtime", "new-kid-on-the-block", autosave=True)
+    settings.set(
+        "container_runtime", "/opt/somewhere/new-kid-on-the-block", autosave=True
+    )
 
-    assert get_runtime_name() == "new-kid-on-the-block"
+    assert Runtime().name == "new-kid-on-the-block"
 
 
-def test_get_runtime_name_linux(mocker: MockerFixture) -> None:
+def test_get_runtime_name_linux(mocker: MockerFixture, tmp_path: Path) -> None:
+    mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
     mocker.patch("platform.system", return_value="Linux")
-    assert get_runtime_name() == "podman"
+    mocker.patch(
+        "dangerzone.container_utils.shutil.which", return_value="/usr/bin/podman"
+    )
+    mocker.patch("dangerzone.container_utils.os.path.exists", return_value=True)
+    runtime = Runtime()
+    assert runtime.name == "podman"
+    assert runtime.path == Path("/usr/bin/podman")
 
 
-def test_get_runtime_name_non_linux(mocker: MockerFixture) -> None:
+def test_get_runtime_name_non_linux(mocker: MockerFixture, tmp_path: Path) -> None:
     mocker.patch("platform.system", return_value="Windows")
-    assert get_runtime_name() == "docker"
+    mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
+    mocker.patch(
+        "dangerzone.container_utils.shutil.which", return_value="/usr/bin/docker"
+    )
+    mocker.patch("dangerzone.container_utils.os.path.exists", return_value=True)
+    runtime = Runtime()
+    assert runtime.name == "docker"
+    assert runtime.path == Path("/usr/bin/docker")
 
     mocker.patch("platform.system", return_value="Something else")
-    assert get_runtime_name() == "docker"
+
+    runtime = Runtime()
+    assert runtime.name == "docker"
+    assert runtime.path == Path("/usr/bin/docker")
+    assert Runtime().name == "docker"

--- a/tests/test_container_utils.py
+++ b/tests/test_container_utils.py
@@ -49,7 +49,7 @@ def test_get_runtime_name_non_linux(mocker: MockerFixture, tmp_path: Path) -> No
     assert Runtime().name == "docker"
 
 
-def test_get_unsupported_runtime_name(mocker: MockerFixture, tmp_path: Path):
+def test_get_unsupported_runtime_name(mocker: MockerFixture, tmp_path: Path) -> None:
     mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
     settings = Settings()
     settings.set(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -21,6 +21,13 @@ def default_settings_0_4_1() -> dict:
     }
 
 
+def save_settings(tmp_path: Path, settings: dict) -> None:
+    """Mimic the way Settings save a dictionary to a settings.json file."""
+    settings_filename = tmp_path / "settings.json"
+    with open(settings_filename, "w") as settings_file:
+        json.dump(settings, settings_file, indent=4)
+
+
 def test_no_settings_file_creates_new_one(
     tmp_path: Path,
     mocker: MockerFixture,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,7 +11,7 @@ VERSION_FILE_NAME = "version.txt"
 
 def test_get_resource_path() -> None:
     share_dir = Path("share").resolve()
-    resource_path = Path(util.get_resource_path(VERSION_FILE_NAME)).parent
+    resource_path = util.get_resource_path(VERSION_FILE_NAME).parent
     assert share_dir.samefile(resource_path), (
         f"{share_dir} is not the same file as {resource_path}"
     )


### PR DESCRIPTION
This allows to use Podman Desktop on macOS (or windows) as an alternative container runtime.