### PR TITLE
Document Podman Desktop experimental support for Windows and macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ Dangerzone gets updates to improve its features _and_ to fix problems. So, updat
 1. Check which version of Dangerzone you are currently using: run Dangerzone, then look for a series of numbers to the right of the logo within the app. The format of the numbers will look similar to `0.4.1`
 2. Now find the latest available version of Dangerzone: go to the [download page](https://dangerzone.rocks/#downloads). Look for the version number displayed. The number will be using the same format as in Step 1.
 3. Is the version on the Dangerzone download page higher than the version of your installed app? Go ahead and update.
+
+### Can I use Podman Desktop?
+
+Yes! We've introduced [experimental support for Podman Desktop](https://github.com/freedomofpress/dangerzone/blob/main/docs/podman-desktop.md) on Windows and macOS.

--- a/docs/podman-desktop.md
+++ b/docs/podman-desktop.md
@@ -1,0 +1,40 @@
+# Podman Desktop support
+
+Starting with Dangerzone 0.9.0, it is possible to use Podman Desktop on
+Windows and macOS. The support for this container runtime is currently only
+experimental. If you try it out and encounter issues, please reach to us, we'll
+be glad to help.
+
+With [Podman Desktop](https://podman-desktop.io/) installed on your machine,
+here are the required steps to change the dangerzone container runtime.
+
+You will be required to open a terminal and follow these steps:
+
+## On macOS
+
+To set the container runtime to podman, use this command:
+
+```bash
+/Applications/Dangerzone.app/Contents/MacOS/dangerzone-cli --set-container-runtime podman
+```
+
+In order to get back to the default behaviour (Docker Desktop on macOS), pass
+the `default` value instead:
+
+```bash
+/Applications/Dangerzone.app/Contents/MacOS/dangerzone-cli --set-container-runtime default
+```
+
+## On Windows
+
+To set the container runtime to podman, use this command:
+
+```bash
+'C:\Program Files\Dangerzone\dangerzone-cli.exe' --set-container-runtime podman
+```
+
+To revert back to the default behavior, pass the `default` value:
+
+```bash
+'C:\Program Files\Dangerzone\dangerzone-cli.exe' --set-container-runtime podman
+```


### PR DESCRIPTION
This documents how to change the container runtime on windows and macOS