### PR TITLE
Ignore CVE-2025-43859 / GHSA-vqfr-h8mv-ghfj

### DIFF
--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -67,8 +67,12 @@ jobs:
           fetch-depth: 0
       - name: Checkout the latest released tag
         run: |
+          # Grab the latest Grype ignore list before git checkout overwrites it.
+          cp .grype.yaml .grype.yaml.new
           VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | jq -r '.tag_name')
           git checkout $VERSION
+          # Restore the newest Grype ignore list.
+          mv .grype.yaml.new .grype.yaml
       # NOTE: Scan first without failing, else we won't be able to read the scan
       # report.
       - name: Scan application (no fail)

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -45,4 +45,12 @@ ignore:
   # present in Debian Bookworm. Also, libcurl is an HTTP client, and the
   # Dangerzone container does not make any network calls.
   - vulnerability: CVE-2025-0665
-
+  # CVE-2025-43859
+  # ==============
+  #
+  # GitHub advisory: https://github.com/advisories/GHSA-vqfr-h8mv-ghfj
+  # Verdict: Dangerzone is not affected because the vulnerable code is triggered
+  # when parsing HTTP requests, e.g., by web **servers**. Dangerzone on the
+  # other hand performs HTTP requests, i.e., it operates as **client**.
+  - vulnerability: CVE-2025-43859
+  - vulnerability: GHSA-vqfr-h8mv-ghfj


### PR DESCRIPTION
Ignore an h11 vulnerability that is present in the Dangerzone application released from the `v0.9.0` tag. This vulnerability
reportedly affects web servers behind reverse proxies, which is not Dangerzone's case.
