### PR TITLE
CI fixes for recent breakages

### DIFF
--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -35,7 +35,7 @@ jobs:
             version: "11"  # bullseye
     steps:
       - name: Add packages.freedom.press PGP key (gpg --keyring)
-        if: matrix.version != 'trixie' && matrix.version != "25.04"
+        if: matrix.version != 'trixie' && matrix.version != '25.04'
         run: |
           apt-get update && apt-get install -y gnupg2 ca-certificates
           dirmngr  # NOTE: This is a command that's necessary only in containers

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -54,3 +54,10 @@ ignore:
   # other hand performs HTTP requests, i.e., it operates as **client**.
   - vulnerability: CVE-2025-43859
   - vulnerability: GHSA-vqfr-h8mv-ghfj
+  # CVE-2025-2866
+  # ==============
+  #
+  # Debian tracker: https://security-tracker.debian.org/tracker/CVE-2025-2866
+  # Verdict: Dangerzone is not affected because it does not rely on the
+  # signature checking feature of LibreOffice.
+  - vulnerability: CVE-2025-2866


### PR DESCRIPTION
This PR fixes the following issues in our CI:
1. Ignore CVE-2025-2866 from our security alerts, which does not affect Dangerzone.
2. Fix a startup failure in our `check_repos.yml` GitHub action.