### PR TITLE
Docs: link the relevant installation sections in the OS-support table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 ## Changed
 
 - Update installation instructions (and CI checks) for Debian derivatives ([#1141](https://github.com/freedomofpress/dangerzone/pull/1141))
+- (Docs) Point to relevant install sections in the OS-support table ([#1160](https://github.com/freedomofpress/dangerzone/pull/1160))
 
 ### Development changes
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,16 +10,16 @@ following sections.
 
 (Unless specified, the architecture of the OS is AMD64)
 
-| Distribution  | Supported releases        | Automated tests        | Manual QA |
-| ------------  | ------------------------- | ---------------------- | --------- |
-| Windows       | 2 last releases           | 🗹 (`windows-latest`) ◎ | 🗹         |
-| macOS intel   | 3 last releases           | 🗹 (`macos-13`) ◎       | 🗹         |
-| macOS silicon | 3 last releases           | 🗹 (`macos-latest`) ◎   | 🗹         |
-| Ubuntu        | Follow upstream support ✰ | 🗹                      | 🗹         |
-| Debian        | Current stable, Oldstable and LTS releases | 🗹     | 🗹         |
-| Fedora        | Follow upstream support   | 🗹                      | 🗹         |
-| Qubes OS      | [Beta support](https://github.com/freedomofpress/dangerzone/issues/413) ✢ | 🗷 | Latest Fedora template |
-| Tails         | Only the last release   | 🗷 | Last release only |
+| Distribution             | Supported releases        | Automated tests        | Manual QA |
+| ------------------------ | ------------------------- | ---------------------- | --------- |
+| [Windows](#windows)      | 2 last releases           | 🗹 (`windows-latest`) ◎ | 🗹         |
+| [macOS intel](#macOS)    | 3 last releases           | 🗹 (`macos-13`) ◎       | 🗹         |
+| [macOS silicon](#macOS)  | 3 last releases           | 🗹 (`macos-latest`) ◎   | 🗹         |
+| [Ubuntu](#ubuntu-debian) | Follow upstream support ✰ | 🗹                      | 🗹         |
+| [Debian](#ubuntu-debian) | Current stable, Oldstable and LTS releases | 🗹     | 🗹         |
+| [Fedora](#fedora)        | Follow upstream support   | 🗹                      | 🗹         |
+| [Qubes OS](#qubes-os)    | [Beta support](https://github.com/freedomofpress/dangerzone/issues/413) ✢ | 🗷 | Latest Fedora template |
+| [Tails](#tails)          | Only the last release     | 🗷              | Last release only |
 
 Notes:
 


### PR DESCRIPTION
It might help disambiguate some questions about which releases are supported.