### PR TITLE
Docs: fix Debian and Ubuntu installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased](https://github.com/freedomofpress/dangerzone/compare/v0.9.0...HEAD)
 
+## Fixed
+
+- Fix Debian and Ubuntu installation instructions ([#1161](https://github.com/freedomofpress/dangerzone/pull/1161))
+
 ## Changed
 
 - Update installation instructions (and CI checks) for Debian derivatives ([#1141](https://github.com/freedomofpress/dangerzone/pull/1141))

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,10 +110,22 @@ Dangerzone is available for:
   </tr>
 </table>
 
-First, retrieve the PGP keys. The instructions differ depending on the specific
-distribution you are using:
+First, retrieve the PGP keys.
 
-For Debian Trixie and Ubuntu Plucky (25.04), follow these instructions to
+**The instructions differ depending on the specific distribution you are using**
+
+For all distributions **except Debian Trixie and Ubuntu Plucky (25.04)**:
+
+```sh
+sudo apt-get update && sudo apt-get install gnupg2 ca-certificates -y
+sudo mkdir -p /etc/apt/keyrings/
+sudo dirmngr&
+sudo gpg --keyserver hkps://keys.openpgp.org \
+    --no-default-keyring --keyring /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg \
+    --recv-keys "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281"
+```
+
+For **Debian Trixie** and **Ubuntu Plucky (25.04)**, follow these instructions to
 download the PGP keys:
 
 ```bash
@@ -126,15 +138,6 @@ sudo mkdir -p /etc/apt/keyrings/
 sudo mv fpfdz.gpg /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
 ```
 
-On other Debian-derivatives:
-
-```sh
-sudo apt-get update && sudo apt-get install gnupg2 ca-certificates -y
-sudo mkdir -p /etc/apt/keyrings/
-sudo gpg --keyserver hkps://keys.openpgp.org \
-    --no-default-keyring --keyring /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg \
-    --recv-keys "DE28 AB24 1FA4 8260 FAC9 B8BA A7C9 B385 2260 4281"
-```
 
 Then, on all distributions, add the URL of the repo in your APT sources:
 


### PR DESCRIPTION
When using gpg to retrieve the keys in `sudo` mode, one needs to run `dirmngr` in the background first. Also change the order in which the different distributions appear and make the separation between the two clearer.

Fixes #1158