### PR TITLE
Update dnf command to add repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## Changed
 
+- (Docs) Update installation instructions for Fedora. `dnf config-manager` is not a plugin ([#1176](https://github.com/freedomofpress/dangerzone/pull/1176))
 - (Docs) Update installation instructions (and CI checks) for Debian derivatives ([#1141](https://github.com/freedomofpress/dangerzone/pull/1141),
   [#1163](https://github.com/freedomofpress/dangerzone/pull/1163))
 - (Docs) Point to relevant install sections in the OS-support table ([#1160](https://github.com/freedomofpress/dangerzone/pull/1160))

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -167,8 +167,7 @@ sudo apt install -y dangerzone
 Type the following commands in a terminal:
 
 ```
-sudo dnf install 'dnf-command(config-manager)'
-sudo dnf-3 config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+sudo dnf config-manager add-repo --from-repofile=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone
 ```
 
@@ -255,7 +254,7 @@ dz.Convert         *       @anyvm       @dispvm:dz-dvm  allow
 Install Dangerzone:
 
 ```
-sudo dnf-3 config-manager --add-repo=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+sudo dnf config-manager add-repo --from-repofile=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone-qubes
 ```
 


### PR DESCRIPTION
Since Fedora 41 dnf is replaced by dnf5 which uses an updated syntax and includes config-manager as a core command