### PR TITLE
Fix Fedora install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -167,7 +167,7 @@ sudo apt install -y dangerzone
 Type the following commands in a terminal:
 
 ```
-sudo dnf config-manager add-repo --from-repofile=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+sudo dnf config-manager addrepo --from-repofile=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone
 ```
 
@@ -254,7 +254,7 @@ dz.Convert         *       @anyvm       @dispvm:dz-dvm  allow
 Install Dangerzone:
 
 ```
-sudo dnf config-manager add-repo --from-repofile=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
+sudo dnf config-manager addrepo --from-repofile=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone-qubes
 ```
 


### PR DESCRIPTION
Looks like this was [fixed in CI](https://github.com/freedomofpress/dangerzone/commit/eaef95b7748191878cf5c71fad9008b0eb8e7e90) but missed in the official instructions.

(signed with Github's web key. Feel free to force-push to re-sign)