### PR TITLE
Ignore CVE-2025-6965 in our grype scans

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -112,3 +112,12 @@ ignore:
   #    a fix.
   - vulnerability: CVE-2025-49794
   - vulnerability: CVE-2025-49796
+  # CVE-2025-6965
+  # =============
+  #
+  # Debian tracker:
+  # * https://security-tracker.debian.org/tracker/CVE-2025-6965
+  #
+  # Verdict: libsql is only used by python, and we do not use any of its
+  # SQLite-related features, so we are not affected.
+  - vulnerability: CVE-2025-6965


### PR DESCRIPTION
libsqlite is required by python, but we are not using nor exposing the parts that make use of it, and so are not affected.