### PR TITLE
Drop support for Ubuntu 24.10 (Oracular)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,6 @@ jobs:
           - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
-            version: "24.10"
-          - distro: ubuntu
             version: "25.04"
           - distro: debian
             version: bullseye

--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -21,8 +21,6 @@ jobs:
           - distro: ubuntu
             version: "25.04"  # plucky
           - distro: ubuntu
-            version: "24.10"  # oracular
-          - distro: ubuntu
             version: "24.04"  # noble
           - distro: ubuntu
             version: "22.04"  # jammy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,6 @@ jobs:
           - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
-            version: "24.10"
-          - distro: ubuntu
             version: "25.04"
           - distro: debian
             version: bullseye
@@ -237,8 +235,6 @@ jobs:
             version: "22.04"
           - distro: ubuntu
             version: "24.04"
-          - distro: ubuntu
-            version: "24.10"
           - distro: ubuntu
             version: "25.04"
           - distro: debian
@@ -382,8 +378,6 @@ jobs:
             version: "22.04"
           - distro: ubuntu
             version: "24.04"
-          - distro: ubuntu
-            version: "24.10"
           - distro: ubuntu
             version: "25.04"
           - distro: debian

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,6 @@ an isolated environment. It will be installed automatically when installing Dang
 Dangerzone is available for:
 
 - Ubuntu 25.04 (plucky)
-- Ubuntu 24.10 (oracular)
 - Ubuntu 24.04 (noble)
 - Ubuntu 22.04 (jammy)
 - Debian 13 (trixie)

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -556,8 +556,6 @@ class Env:
             elif self.distro == "ubuntu" and self.version in (
                 "24.04",
                 "noble",
-                "24.10",
-                "ocular",
                 "25.04",
                 "plucky",
             ):
@@ -621,8 +619,6 @@ class Env:
             elif self.distro == "ubuntu" and self.version in (
                 "24.04",
                 "noble",
-                "24.10",
-                "ocular",
                 "25.04",
                 "plucky",
             ):

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -1007,11 +1007,6 @@ class QAUbuntu2404(QADebianBased):
     VERSION = "24.04"
 
 
-class QAUbuntu2410(QADebianBased):
-    DISTRO = "ubuntu"
-    VERSION = "24.10"
-
-
 class QAUbuntu2504(QADebianBased):
     DISTRO = "ubuntu"
     VERSION = "25.04"


### PR DESCRIPTION
Ubuntu 24.10 (Oracular) is currently end of life, and Ubuntu has stop serving its APT repo. Therefore, we have to drop support for it and remove it from our CI tests and docs.

Closes #1246