### PR TITLE
Update issue-templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_linux.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_linux.yml
@@ -55,7 +55,7 @@ body:
         If the bug occurs during document conversion, we'd like some logs from this process. Please copy and paste the following commands in your terminal, and provide us with the output (replace `/path/to/file` with the path to your document):
 
         ```bash
-        dangerzone-cli /path/to/file
+        dangerzone-cli --debug /path/to/file
         ```
 
       render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report_macos.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_macos.yml
@@ -44,18 +44,19 @@ body:
     validations:
       required: true
   - type: textarea
-    id: docker-info
+    id: podman-info
     attributes:
-      label: Docker info
+      label: Podman info
       description: |
         Please copy and paste the following commands in your
         terminal, and provide us with the output:
 
         ```shell
-        docker version
-        docker info -f 'json'
-        docker images
-        docker run hello-world
+        /Applications/Dangerzone.app/Contents/MacOS/dangerzone-machine start
+        /Applications/Dangerzone.app/Contents/MacOS/dangerzone-machine --log-level debug raw version
+        /Applications/Dangerzone.app/Contents/MacOS/dangerzone-machine --log-level debug raw info -f 'json'
+        /Applications/Dangerzone.app/Contents/MacOS/dangerzone-machine --log-level debug raw images
+        /Applications/Dangerzone.app/Contents/MacOS/dangerzone-machine --log-level debug raw run hello-world
         ```
 
         This will be automatically formatted into code, so no need for backticks.
@@ -70,7 +71,7 @@ body:
 
         ```bash
 
-        /Applications/Dangerzone.app/Contents/MacOS/dangerzone-cli /path/to/file
+        /Applications/Dangerzone.app/Contents/MacOS/dangerzone-cli --debug /path/to/file
         ```
 
       render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report_windows.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_windows.yml
@@ -39,11 +39,11 @@ body:
         terminal, and provide us with the output:
 
         ```shell
-        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' start
-        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' --log-level debug raw version
-        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' --log-level debug raw info -f json
-        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' --log-level debug raw images
-        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' --log-level debug raw run hello-world
+        'C:\Program Files\Dangerzone\dangerzone-machine.exe' start
+        'C:\Program Files\Dangerzone\dangerzone-machine.exe' --log-level debug raw version
+        'C:\Program Files\Dangerzone\dangerzone-machine.exe' --log-level debug raw info -f json
+        'C:\Program Files\Dangerzone\dangerzone-machine.exe' --log-level debug raw images
+        'C:\Program Files\Dangerzone\dangerzone-machine.exe' --log-level debug raw run hello-world
         ```
 
         This will be automatically formatted into code, so no need for backticks.
@@ -56,7 +56,7 @@ body:
         If the bug occurs during document conversion, we'd like some logs from this process. Please copy and paste the following commands in your terminal, and provide us with the output (replace `\path\to\file` with the path to your document):
 
         ```bash
-        'C:\Program Files (x86)\Dangerzone\dangerzone-cli.exe' --debug \path\to\file
+        'C:\Program Files\Dangerzone\dangerzone-cli.exe' --debug \path\to\file
         ```
 
       render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report_windows.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_windows.yml
@@ -31,18 +31,19 @@ body:
     validations:
       required: true
   - type: textarea
-    id: docker-info
+    id: podman-info
     attributes:
-      label: Docker info
+      label: Podman info
       description: |
         Please copy and paste the following commands in your
         terminal, and provide us with the output:
 
         ```shell
-        docker version
-        docker info -f 'json'
-        docker images
-        docker run hello-world
+        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' start
+        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' --log-level debug raw version
+        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' --log-level debug raw info -f json
+        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' --log-level debug raw images
+        'C:\Program Files (x86)\Dangerzone\dangerzone-machine.exe' --log-level debug raw run hello-world
         ```
 
         This will be automatically formatted into code, so no need for backticks.
@@ -55,7 +56,7 @@ body:
         If the bug occurs during document conversion, we'd like some logs from this process. Please copy and paste the following commands in your terminal, and provide us with the output (replace `\path\to\file` with the path to your document):
 
         ```bash
-        'C:\Program Files (x86)\Dangerzone\dangerzone-cli.exe' \path\to\file
+        'C:\Program Files (x86)\Dangerzone\dangerzone-cli.exe' --debug \path\to\file
         ```
 
       render: shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,16 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
   longer compatible, due to some changes in the bundled container image.
   Instead, Podman Desktop is used under the hood
   ([#118](https://github.com/freedomofpress/dangerzone/issues/118))
+- Add a deprecation warning for Debian bullseye ([#1214](https://github.com/freedomofpress/dangerzone/issues/1214))
+- Platform support: Drop support for Ubuntu Oracular (24.10) since it is end of life ([#1246](https://github.com/freedomofpress/dangerzone/issues/1246))
 
 ### Fixed
 
 - Fix a Dangerzone error that manifested in recent Debian-based environments
   that included both PySide6 and PySide2 libraries
   ([#1218](https://github.com/freedomofpress/dangerzone/issues/1218))
+- Issue templates have been updated to work on Windows
+  ([#1237](https://github.com/freedomofpress/dangerzone/issues/1237))
 
 ### Development changes
 
@@ -47,11 +51,6 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
   ([#1212](https://github.com/freedomofpress/dangerzone/pull/1212))
 - Run our full CI test suite on Windows and macOS GitHub runners
   ([#1009](https://github.com/freedomofpress/dangerzone/issues/1009))
-
-### Removed
-
-- Add a deprecation warning for Debian bullseye ([#1214](https://github.com/freedomofpress/dangerzone/issues/1214))
-- Platform support: Drop support for Ubuntu Oracular (24.10) since it is end of life ([#1246](https://github.com/freedomofpress/dangerzone/issues/1246))
 
 ## [0.9.1](https://github.com/freedomofpress/dangerzone/compare/v0.9.1...0.9.0)
 


### PR DESCRIPTION
- Use `podman-machine` commands rather than raw Docker commands
- Add the `--debug` flag to the conversion command

Note: This is to be merged after #1145 hits the `main` branch.

I'm also thinking about adding an utility `dangerzone-machine doctor` command to retrieve the logs in one command, avoiding the need for the users to copy-paste multiple commands. I'm not doing this here to avoid stacking too much things on top of the `embed-podman` effort for now, though.