### PR TITLE
Add a deprecation warning for debian bullseye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ### Removed
 
+- Add a deprecation warning for Debian bullseye ([#1214](https://github.com/freedomofpress/dangerzone/issues/1214))
 - Platform support: Drop support for Ubuntu Oracular (24.10) since it is end of life ([#1246](https://github.com/freedomofpress/dangerzone/issues/1246))
 
 ## [0.9.1](https://github.com/freedomofpress/dangerzone/compare/v0.9.1...0.9.0)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,7 +71,7 @@ an isolated environment. It will be installed automatically when installing Dang
 > - Ubuntu: We follow upstream support with an extra cutoff date. No support for
 >   versions prior to the second oldest LTS release.
 > - Fedora: We follow upstream support
-> - Debian: current stable, oldstable and LTS releases.
+> - Debian: We support the last two stable releases.
 
 Dangerzone is available for:
 
@@ -80,7 +80,7 @@ Dangerzone is available for:
 - Ubuntu 22.04 (jammy)
 - Debian 13 (trixie)
 - Debian 12 (bookworm)
-- Debian 11 (bullseye)
+- Debian 11 (bullseye), support will be dropped in future releases.
 - Fedora 42
 - Fedora 41
 - Tails

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -79,6 +79,13 @@ handle it manually.</p>
 """
 
 
+DEBIAN_BULLSEYE_DEPRECATION_MSG = """\
+<p><b>Warning:</b> Debian Bullseye systems and their derivatives will
+stop being supported in subsequent Dangerzone releases. We encourage you to upgrade to a
+more recent version of your operating system in order to get security updates.</p>
+"""
+
+
 HAMBURGER_MENU_SIZE = 30
 
 
@@ -715,6 +722,19 @@ class ConversionWidget(QtWidgets.QWidget):
         self.dangerzone = dangerzone
         self.conversion_started = False
 
+        self.warning_label = None
+        if platform.system() == "Linux":
+            # Add the warning message only for debian bullseye
+            os_release_path = Path("/etc/os-release")
+            if os_release_path.exists():
+                os_release = os_release_path.read_text()
+                if "Debian GNU/Linux 11" in os_release or "bullseye" in os_release:
+                    self.warning_label = QtWidgets.QLabel(
+                        DEBIAN_BULLSEYE_DEPRECATION_MSG
+                    )
+                    self.warning_label.setWordWrap(True)
+                    self.warning_label.setProperty("style", "warning")
+
         # Doc selection widget
         self.doc_selection_widget = DocSelectionWidget(self.dangerzone)
         self.doc_selection_widget.documents_selected.connect(self.documents_selected)
@@ -740,6 +760,8 @@ class ConversionWidget(QtWidgets.QWidget):
 
         # Layout
         layout = QtWidgets.QVBoxLayout()
+        if self.warning_label:
+            layout.addWidget(self.warning_label)  # Add warning at the top
         layout.addWidget(self.settings_widget, stretch=1)
         layout.addWidget(self.documents_list, stretch=1)
         layout.addWidget(self.doc_selection_wrapper, stretch=1)


### PR DESCRIPTION
Also, this clarifies that we only support the last two stable releases for Debian.