### PR TITLE
Do not use already existing Podman credentials

### DIFF
--- a/dangerzone/container_utils.py
+++ b/dangerzone/container_utils.py
@@ -421,3 +421,16 @@ def get_local_image_digest(image: Optional[str] = None) -> str:
         )
     image_digest = lines.pop().replace("sha256:", "")
     return image_digest
+
+
+def disable_registry_auth(env: dict) -> None:
+    """Disable registry authentication by setting auth-related environment variables
+    to non-existent files.
+
+    This prevents Podman/Docker from using any existing credentials that might be
+    configured on the system, avoiding potential authentication errors.
+    """
+    if "REGISTRY_AUTH_FILE" not in env:
+        env["REGISTRY_AUTH_FILE"] = "does-not-exist"
+    if "DOCKER_CONFIG" not in env:
+        env["DOCKER_CONFIG"] = "does-not-exist"

--- a/dangerzone/updater/cosign.py
+++ b/dangerzone/updater/cosign.py
@@ -1,8 +1,9 @@
+import os
 import subprocess
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from ..container_utils import subprocess_run
+from ..container_utils import disable_registry_auth, subprocess_run
 from ..util import get_resource_path
 from . import errors, log
 
@@ -53,6 +54,8 @@ def verify_blob(pubkey: Path, bundle: str, payload: str) -> None:
 
 
 def download_signature(image: str, digest: str) -> list[str]:
+    env = os.environ.copy()
+    disable_registry_auth(env)
     try:
         process = subprocess_run(
             [
@@ -61,6 +64,7 @@ def download_signature(image: str, digest: str) -> list[str]:
                 "signature",
                 f"{image}@sha256:{digest}",
             ],
+            env=env,
             capture_output=True,
             check=True,
         )


### PR DESCRIPTION
Two things to note:

- I haven't found how to reproduce exactly the error I've been seeing yesterday on this machine, that was solved by doing `podman logout ghcr.io`
- This seem a simple-enough fix, that was able to avoid using some broken credentials on my machine, that made the pull fail.

(I believe this) fixes #1266

PS: I've added the "no changelog" label because this refers to stuff not yet released, and as such I don't believe they need a specific entry. Let me know if you feel differently.