### PR TITLE
Do not swallow podman output

### DIFF
--- a/dangerzone/capture_output.py
+++ b/dangerzone/capture_output.py
@@ -50,7 +50,7 @@ class PatchedPopen(original_subprocess_popen):
 
         def _consume_pipe(pipe: IOBase) -> None:
             for line in iter(pipe.readline, ""):
-                log.debug(_decode_if_needed(line))
+                log.info(_decode_if_needed(line))
 
         # Create threads to read the stdout and stderr
         thread_out = threading.Thread(target=_consume_pipe, args=(self.stdout,))
@@ -99,9 +99,9 @@ def patched_subprocess_run(  # type: ignore[no-untyped-def]
     # streams as it comes. If it is set here, it means it is not logged
     # elsewhere, so do it.
     if process.stdout is not None:
-        log.debug(_decode_if_needed(process.stdout))
+        log.info(_decode_if_needed(process.stdout))
     if process.stderr is not None:
-        log.debug(_decode_if_needed(process.stderr))
+        log.info(_decode_if_needed(process.stderr))
 
     log.debug(f"Process returncode: {process.returncode}")
     return process

--- a/dangerzone/podman/cli.py
+++ b/dangerzone/podman/cli.py
@@ -22,7 +22,10 @@ logger = logging.getLogger(__name__)
 )
 def main(log_level: str) -> None:
     """Manage Dangerzone Podman machines."""
-    logging.basicConfig(level=getattr(logging, log_level.upper()), stream=sys.stderr)
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper()),
+        format="%(message)s",
+    )
 
 
 @main.command()


### PR DESCRIPTION
Output the captured streams to INFO or DEBUG

The standard streams are output with an INFO level so they can be
visible by default, and the name of the command and returncode are
sent to the DEBUG level.

Fixes https://github.com/freedomofpress/dangerzone/issues/1267