### PR TITLE
Skip Podman tasks if a custom runtime was specified

### DIFF
--- a/dangerzone/shutdown.py
+++ b/dangerzone/shutdown.py
@@ -2,7 +2,7 @@ import logging
 import platform
 import typing
 
-from . import container_utils, startup
+from . import container_utils, settings, startup
 from .podman.machine import PodmanMachineManager
 
 logger = logging.getLogger(__name__)
@@ -13,7 +13,10 @@ class MachineStopTask(startup.Task):
     name = "Stopping Dangerzone VM"
 
     def should_skip(self) -> bool:
-        return platform.system() == "Linux"
+        return (
+            settings.Settings().custom_runtime_specified()
+            or platform.system() == "Linux"
+        )
 
     def run(self) -> None:
         PodmanMachineManager().stop()

--- a/dangerzone/startup.py
+++ b/dangerzone/startup.py
@@ -70,7 +70,10 @@ class MachineInitTask(Task):
     name = "Initializing Dangerzone VM"
 
     def should_skip(self) -> bool:
-        return platform.system() == "Linux"
+        return (
+            settings.Settings().custom_runtime_specified()
+            or platform.system() == "Linux"
+        )
 
     def run(self) -> None:
         PodmanMachineManager().init()
@@ -80,7 +83,10 @@ class MachineStartTask(Task):
     name = "Starting Dangerzone VM"
 
     def should_skip(self) -> bool:
-        return platform.system() == "Linux"
+        return (
+            settings.Settings().custom_runtime_specified()
+            or platform.system() == "Linux"
+        )
 
     def run(self) -> None:
         PodmanMachineManager().start()
@@ -93,6 +99,9 @@ class MachineStopOthersTask(Task):
         raise errors.OtherMachineRunningError(message)
 
     def should_skip(self) -> bool:
+        if settings.Settings().custom_runtime_specified():
+            return True
+
         if platform.system() in ["Linux", "Windows"]:
             # * On Linux, there are no Podman machines
             # * On Windows, WSL allows multiple VMs:


### PR DESCRIPTION
Do not initialize and start Podman machines if a custom runtime was specified, because that's a clear indication that the user does not want Dangerzone to take control over the Podman installation.

Closes #1151

> [!NOTE]
> The accompanying documentation changes will be sent once we release Dangerzone 0.10.0, so as not to confuse our users.