### PR TITLE
[FIX] - invalid path found in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN mkdir -p /opt/dangerzone/dangerzone
 RUN touch /opt/dangerzone/dangerzone/__init__.py
 
 # Copy only the Python code, and not any produced .pyc files.
-COPY conversion/*.py /opt/dangerzone/dangerzone/conversion/
+COPY dangerzone/conversion/*.py /opt/dangerzone/dangerzone/conversion/
 
 # Create a directory that will be used by gVisor as the place where it will
 # store the state of its containers.


### PR DESCRIPTION
- Bug:
When using the Docker file in Ubuntu, Debian using `docker build -t dangerzone .` below error occurred due to an invalid path.

- Initial error:

<img width="1271" height="347" alt="image" src="https://github.com/user-attachments/assets/30b3945c-8aed-4504-98f2-8397073600b8" />

- Fix: 
The `entrypoint.py` file exists, but it's located at `dangerzone` folder, not in `container_helpers/entrypoint.py`. The Dockerfile is looking in the wrong path.

Fixed container_helpers mount paths:
- ./container_helpers/repro-sources-list.sh → repro-sources-list.sh
- ./container_helpers/gvisor.key → gvisor.key

Fixed conversion COPY path:
- COPY conversion/*.py → COPY dangerzone/conversion/*.py
Fixed entrypoint COPY path:
- COPY container_helpers/entrypoint.py → COPY dangerzone/container_helpers/entrypoint.py