### PR TITLE
Bump the logindex to the one of the last image

### DIFF
--- a/dangerzone/updater/signatures.py
+++ b/dangerzone/updater/signatures.py
@@ -36,7 +36,7 @@ def appdata_dir() -> Path:
 
 # RELEASE: Bump this value to the log index of the latest signature
 # to ensure the software can't upgrade to container images that predates it.
-BUNDLED_LOG_INDEX = 634403782
+BUNDLED_LOG_INDEX = 652343092
 
 DEFAULT_PUBKEY_LOCATION = get_resource_path("freedomofpress-dangerzone.pub")
 SIGNATURES_PATH = appdata_dir() / "signatures"


### PR DESCRIPTION
This matches this root manifest [ghcr.io/freedomofpress/dangerzone/v1@sha256:748d45842c605d33cc101cb17aca42892c8411636b8d4141b0c1e7e4420a050d](https://oci.dag.dev/?image=ghcr.io/freedomofpress/dangerzone/v1@sha256:748d45842c605d33cc101cb17aca42892c8411636b8d4141b0c1e7e4420a050d&mt=application%2Fvnd.docker.distribution.manifest.list.v2%2Bjson&size=683)