### PR TITLE
Set UTF-16 encoding when running WSL

### DIFF
--- a/dangerzone/capture_output.py
+++ b/dangerzone/capture_output.py
@@ -43,8 +43,9 @@ class PatchedPopen(original_subprocess_popen):
         # Read the stdout and stderr as streams (text=True and bufsize=1)
         kwargs["stdout"] = subprocess.PIPE
         kwargs["stderr"] = subprocess.PIPE
-        kwargs["text"] = True
-        kwargs["bufsize"] = 1
+        if "encoding" is not None:
+            kwargs["text"] = True
+            kwargs["bufsize"] = 1
 
         super().__init__(*args, **kwargs)
 

--- a/dangerzone/podman/machine.py
+++ b/dangerzone/podman/machine.py
@@ -82,7 +82,12 @@ class PodmanMachineManager:
             return
 
         if platform.system() == "Windows":
-            container_utils.subprocess_run(["wsl", "--update"], check=False)
+            # Set the encoding to non-BOM UTF16, which is what WSL uses.
+            # If not set, stdout will contain invisible null characters which
+            # renders the output impossible to read and copy/paste.
+            container_utils.subprocess_run(
+                ["wsl", "--update"], encoding="UTF16LE", check=False
+            )
 
         logger.info(f"Initializing Podman machine: {self.name}")
         self.podman.machine.init(


### PR DESCRIPTION
Set the encoding to non-BOM UTF16, which is what WSL uses. If not set, stdout will contain invisible null characters which renders the output impossible to read and copy/paste.

Fixes #1319