### PR TITLE
Disable rosetta from the podman machine on macOS

### DIFF
--- a/dangerzone/container_utils.py
+++ b/dangerzone/container_utils.py
@@ -188,6 +188,7 @@ helper_binaries_dir=["{helper_binaries_dir}"]
 [machine]
 cpus={cpu_count}
 volumes=["{volume}"]
+rosetta=false
 """
     # FIXME: Do not unconditionally write to this file.
     dst = CONTAINERS_CONF_PATH


### PR DESCRIPTION
Rosetta is not needed since we provide ARM64 container images.

Fixes #1317