### PR TITLE
Bump the bundled logindex

### DIFF
--- a/dangerzone/updater/signatures.py
+++ b/dangerzone/updater/signatures.py
@@ -35,7 +35,7 @@ def appdata_dir() -> Path:
 
 # RELEASE: Bump this value to the log index of the latest signature
 # to ensure the software can't upgrade to container images that predates it.
-BUNDLED_LOG_INDEX = 708814078
+BUNDLED_LOG_INDEX = 732661252
 
 DEFAULT_PUBKEY_LOCATION = get_resource_path("freedomofpress-dangerzone.pub")
 SIGNATURES_PATH = appdata_dir() / "signatures"


### PR DESCRIPTION
Here are the log indexes as reported by GHCR signer:

  $ ls -t SIGNATURES \
    | grep -v README.md \
    | head -1 \
    | xargs -I {} find "SIGNATURES/{}" -name MANIFEST \
    | xargs cat \
    | jq -r '.layers[].annotations."dev.sigstore.cosign/bundle"' \
    | jq .Payload.logIndex \
    | sort
  732661252
  732661337
  732661410

The Rekor entry is the following:
https://search.sigstore.dev/?logIndex=732661252