### PR TITLE
ci: Fix security scans of released images

### DIFF
--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -17,24 +17,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Download container image for the latest release and load it
-        run: |
-          VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | grep "tag_name" | cut -d '"' -f 4)
-          CONTAINER_FILENAME=container-${VERSION:1}-${{ matrix.arch }}.tar
-          wget https://github.com/freedomofpress/dangerzone/releases/download/${VERSION}/${CONTAINER_FILENAME} -O ${CONTAINER_FILENAME}
-          docker load -i ${CONTAINER_FILENAME}
-      - name: Get image tag
-        id: tag
-        run: |
-          tag=$(docker images dangerzone.rocks/dangerzone --format '{{ .Tag }}')
-          echo "tag=$tag" >> $GITHUB_OUTPUT
       # NOTE: Scan first without failing, else we won't be able to read the scan
       # report.
       - name: Scan container image (no fail)
         uses: anchore/scan-action@v7
         id: scan_container
         with:
-          image: "dangerzone.rocks/dangerzone:${{ steps.tag.outputs.tag }}"
+          image: "ghcr.io/freedomofpress/dangerzone/v1:latest"
           fail-build: false
           only-fixed: false
           severity-cutoff: critical
@@ -48,7 +37,7 @@ jobs:
       - name: Scan container image
         uses: anchore/scan-action@v7
         with:
-          image: "dangerzone.rocks/dangerzone:${{ steps.tag.outputs.tag }}"
+          image: "ghcr.io/freedomofpress/dangerzone/v1:latest"
           fail-build: true
           only-fixed: false
           severity-cutoff: critical


### PR DESCRIPTION
We no longer include the container tarball in our releases anymore, since it can change from time to time. Instead, it's best to run security scans against ghcr.io/freedomofpress/dangerzone/v1:latest, which is guaranteed to be the most recently released image.