### PR TITLE
Fix default PDF reader selection on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased](https://github.com/freedomofpress/dangerzone/compare/v0.9.0...HEAD)
 
+### Fixed
+
+- Fix default PDF reader selection on Linux ([#814](https://github.com/freedomofpress/dangerzone/issues/814))
+
 ## [0.10.0](https://github.com/freedomofpress/dangerzone/compare/v0.10.0...0.9.1)
 
 ### Added

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -104,9 +104,13 @@ class DangerzoneGui(DangerzoneCore):
             # Opportunistically query for default pdf handler
             default_pdf_viewer = None
             try:
-                default_pdf_viewer = subprocess.check_output(
-                    ["xdg-mime", "query", "default", "application/pdf"]
-                ).decode()
+                default_pdf_viewer = (
+                    subprocess.check_output(
+                        ["xdg-mime", "query", "default", "application/pdf"]
+                    )
+                    .decode()
+                    .strip()
+                )  # remove trailing "\n"
             except (FileNotFoundError, subprocess.CalledProcessError) as e:
                 # Log it and continue
                 log.info(

--- a/tests/gui/test_logic.py
+++ b/tests/gui/test_logic.py
@@ -35,7 +35,7 @@ def test_order_mime_handers() -> None:
 
     with (
         mock.patch(
-            "subprocess.check_output", return_value=b"libreoffice-draw.desktop"
+            "subprocess.check_output", return_value=b"libreoffice-draw.desktop\n"
         ) as mock_default_mime_hander,
         mock.patch(
             "os.listdir",


### PR DESCRIPTION
`xdg-mime` outputs `\n`, causing the default PDF reader to not be recognized.

Fixes #814