### PR TITLE
CI: Run macOS Intel tests only nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,71 +161,27 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
-  macOS:
-    name: "macOS (${{ matrix.arch }})"
+  # See https://github.com/abiosoft/colima/issues/970
+  macOS-arm64:
     needs:
       - build-container-image
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # See https://github.com/abiosoft/colima/issues/970
-          - runner: macos-15
-            arch: arm64
-          - runner: macos-15-intel
-            arch: x86_64
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-      - run: pip install poetry
-      - run: poetry install
-      - name: Cache mazette assets
-        id: cache-mazette
-        uses: actions/cache@v4
-        with:
-          path: |
-            share/tessdata/
-            share/vendor/
-            share/machine.tar
-          key: v1-mazette-darwin-${{ matrix.arch }}-${{ hashFiles('./mazette.lock') }}
-      - name: Install mazette assets
-        if: steps.cache-mazette.outputs.cache-hit != 'true'
-        run: poetry run mazette install
-      - name: Check cosign is present
-        run: ls share/vendor
-      - name: Restore container image
-        uses: actions/cache/restore@v4
-        with:
-          path: |-
-            share/container.tar
-            share/freedomofpress-dangerzone.pub
-            share/image-name.txt
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-          key: v6-container-${{ needs.build-container-image.outputs.image_uri }}
-      - name: Smoke test
-        # Nested virtualization does not work on M1 CPUs.
-        continue-on-error: ${{ matrix.arch == 'arm64'}}
-        run: poetry run ./dev_scripts/dangerzone-cli ./tests/test_docs/sample-pdf.pdf --ocr-lang eng --debug
-      - name: Run CLI tests
-        run: |
-          # Nested virtualization does not work on M1 CPUs.
-          if [ ${{ matrix.arch }} == 'arm64' ]; then
-              export DUMMY_CONVERSION=1
-          fi
-          poetry run make test
-      - name: Build macOS app
-        run: poetry run python ./install/macos/build-app.py
-      - name: Upload macOS app
-        uses: actions/upload-artifact@v5
-        with:
-          name: Dangerzone-${{ matrix.arch }}.app
-          path: "dist/Dangerzone.app"
-          if-no-files-found: error
-          compression-level: 0
+    uses: ./.github/workflows/ci_macos.yml
+    with:
+      runner: macos-15
+      arch: arm64
+      image_uri: ${{ needs.build-container-image.outputs.image_uri }}
+
+  # Run Intel tests only on scheduled/manual runs (they take ~2.5 hours).
+  # See https://github.com/freedomofpress/dangerzone/issues/1338
+  macOS-intel:
+    needs:
+      - build-container-image
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/ci_macos.yml
+    with:
+      runner: macos-15-intel
+      arch: x86_64
+      image_uri: ${{ needs.build-container-image.outputs.image_uri }}
   build-deb:
     needs:
       - build-container-image

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,0 +1,70 @@
+name: macOS Build
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+      image_uri:
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: "macOS (${{ inputs.arch }})"
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: pip install poetry
+      - run: poetry install
+      - name: Cache mazette assets
+        id: cache-mazette
+        uses: actions/cache@v4
+        with:
+          path: |
+            share/tessdata/
+            share/vendor/
+            share/machine.tar
+          key: v1-mazette-darwin-${{ inputs.arch }}-${{ hashFiles('./mazette.lock') }}
+      - name: Install mazette assets
+        if: steps.cache-mazette.outputs.cache-hit != 'true'
+        run: poetry run mazette install
+      - name: Check cosign is present
+        run: ls share/vendor
+      - name: Restore container image
+        uses: actions/cache/restore@v4
+        with:
+          path: |-
+            share/container.tar
+            share/freedomofpress-dangerzone.pub
+            share/image-name.txt
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+          key: v6-container-${{ inputs.image_uri }}
+      - name: Smoke test
+        # Nested virtualization does not work on M1 CPUs.
+        continue-on-error: ${{ inputs.arch == 'arm64' }}
+        run: poetry run ./dev_scripts/dangerzone-cli ./tests/test_docs/sample-pdf.pdf --ocr-lang eng --debug
+      - name: Run CLI tests
+        run: |
+          # Nested virtualization does not work on M1 CPUs.
+          if [ ${{ inputs.arch }} == 'arm64' ]; then
+              export DUMMY_CONVERSION=1
+          fi
+          poetry run make test
+      - name: Build macOS app
+        run: poetry run python ./install/macos/build-app.py
+      - name: Upload macOS app
+        uses: actions/upload-artifact@v5
+        with:
+          name: Dangerzone-${{ inputs.arch }}.app
+          path: "dist/Dangerzone.app"
+          if-no-files-found: error
+          compression-level: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
   ([#1238](https://github.com/freedomofpress/dangerzone/issues/1238))
 
 
+### Development changes
+
+- Run macOS Intel CI tests only on scheduled/manual runs to reduce PR CI time
+  ([#1338](https://github.com/freedomofpress/dangerzone/issues/1338))
+
+
 ## [0.10.0](https://github.com/freedomofpress/dangerzone/compare/v0.10.0...0.9.1)
 
 ### Added


### PR DESCRIPTION
Run macOS Intel tests only on scheduled/manual runs as they take ~2.5 hours

Fix #1338