### PR TITLE
Make container.tar optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 - Update the theme correctly on dark/light mode changes
   ([#1238](https://github.com/freedomofpress/dangerzone/issues/1238))
 
+### Added
+
+- Dangerzone is able to function without a bundled `container.tar` file 
+  ([#1400](https://github.com/freedomofpress/dangerzone/pull/1400))
+
 
 ### Development changes
 

--- a/dangerzone/isolation_provider/qubes.py
+++ b/dangerzone/isolation_provider/qubes.py
@@ -9,7 +9,7 @@ from typing import IO, Callable, Optional
 
 from ..conversion.common import running_on_qubes
 from ..document import Document
-from ..util import get_resource_path
+from ..updater.signatures import is_container_tar_bundled
 from .base import IsolationProvider
 
 log = logging.getLogger(__name__)
@@ -123,6 +123,6 @@ def is_qubes_native_conversion() -> bool:
         # This disambiguates if it is running a Qubes targetted build or not
         # (Qubes-specific builds don't ship the container image)
 
-        return not get_resource_path("container.tar").exists()
+        return not is_container_tar_bundled()
     else:
         return False

--- a/dangerzone/updater/__init__.py
+++ b/dangerzone/updater/__init__.py
@@ -5,12 +5,13 @@ log = logging.getLogger(__name__)
 from .errors import SignatureError, UpdaterError
 from .installer import Strategy as InstallationStrategy
 from .installer import apply_installation_strategy, get_installation_strategy, install
+from .log_index import LAST_KNOWN_LOG_INDEX
 from .releases import EmptyReport, ErrorReport, ReleaseReport
 from .signatures import (
-    BUNDLED_LOG_INDEX,
     DEFAULT_PUBKEY_LOCATION,
     bypass_signature_checks,
     install_local_container_tar,
+    is_container_tar_bundled,
     upgrade_container_image,
     verify_local_image,
 )

--- a/dangerzone/updater/log_index.py
+++ b/dangerzone/updater/log_index.py
@@ -1,0 +1,3 @@
+# RELEASE: Bump this value to the log index of the latest signature
+# to ensure the software can't upgrade to container images that predates it.
+LAST_KNOWN_LOG_INDEX = 732661252

--- a/dodo.py
+++ b/dodo.py
@@ -43,12 +43,9 @@ ASSETS_DEPS = ["mazette.lock"]
 # NOTE: The container image is a major dependency of our assets, and we would ideally
 # want to track it with its hash. In practice though, what we need here is to bust
 # doit's cache, when the `latest` tag changes. So, an alternative way to do it without
-# pinning the hash is to monitor changes to the BUNDLED_LOG_INDEX of
-# dangerzone/updater/signatures.py, which is unique per image.
-#
-# FIXME: Find a better way to track the latest image, since if BUNDLE_LOG_INDEX moves to
-# a different file, this target should change as well.
-IMAGE_DEPS = ["dangerzone/updater/signatures.py"]
+# pinning the hash is to monitor changes to the LAST_KNOWN_LOG_INDEX of
+# dangerzone/updater/log_index.py, which is unique per image.
+IMAGE_DEPS = ["dangerzone/updater/log_index.py"]
 
 SOURCE_DEPS = [
     *list_files("assets"),

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -37,7 +37,7 @@ from dangerzone.gui.main_window import (
 from dangerzone.isolation_provider.container import Container
 from dangerzone.isolation_provider.dummy import Dummy
 from dangerzone.updater import (
-    BUNDLED_LOG_INDEX,
+    LAST_KNOWN_LOG_INDEX,
     EmptyReport,
     InstallationStrategy,
     ReleaseReport,

--- a/tests/test_updater_installer.py
+++ b/tests/test_updater_installer.py
@@ -39,7 +39,8 @@ def test_user_installs_dangerzone_for_the_first_time(mocker: MockerFixture) -> N
         "updater_check_all": False
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=False)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 10)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 10)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.INSTALL_LOCAL_CONTAINER
@@ -66,7 +67,8 @@ def test_upgrades_disabled_detect_wrong_container_upgrade(
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=100)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     # Check that we get the right strategy
     strategy = get_installation_strategy()
@@ -98,7 +100,8 @@ def test_building_dangerzone_from_source_first_time(mocker: MockerFixture) -> No
         "updater_check_all": False
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=False)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 10)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 10)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.INSTALL_LOCAL_CONTAINER
@@ -119,7 +122,8 @@ def test_building_dangerzone_from_source_nth_time(mocker: MockerFixture) -> None
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=200)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.DO_NOTHING
@@ -144,7 +148,8 @@ def test_enable_updates_after_some_time(mocker: MockerFixture) -> None:
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=200)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     # Check that we get the right strategy
     strategy = get_installation_strategy()
@@ -187,7 +192,8 @@ def test_enable_updates_no_new_image_available(mocker: MockerFixture) -> None:
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=200)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.DO_NOTHING
@@ -208,7 +214,8 @@ def test_downgrade_dangerzone_application(mocker: MockerFixture) -> None:
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=300)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.DO_NOTHING
@@ -229,7 +236,8 @@ def test_disable_updates(mocker: MockerFixture) -> None:
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=300)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.DO_NOTHING
@@ -247,7 +255,8 @@ def test_podman_state_reset_updates_enabled(mocker: MockerFixture) -> None:
         "updater_remote_log_index": 300,
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=False)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.INSTALL_REMOTE_CONTAINER
@@ -264,7 +273,8 @@ def test_podman_state_reset_updates_disabled(mocker: MockerFixture) -> None:
         "updater_check_all": False
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=False)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.INSTALL_LOCAL_CONTAINER
@@ -286,7 +296,8 @@ def test_upgrade_to_latest_container_via_cli(mocker: MockerFixture) -> None:
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=200)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.DO_NOTHING
@@ -308,7 +319,8 @@ def test_install_new_dangerzone_version_updates_enabled(mocker: MockerFixture) -
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=200)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 200)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.INSTALL_REMOTE_CONTAINER
@@ -329,7 +341,59 @@ def test_airgapped_installation_container_tarball(mocker: MockerFixture) -> None
     }.get(key)
     mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=True)
     mocker.patch(f"{installer}.get_last_log_index", return_value=200)
-    mocker.patch(f"{installer}.BUNDLED_LOG_INDEX", 300)
+    mocker.patch(f"{installer}.LAST_KNOWN_LOG_INDEX", 300)
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=True)
 
     result = get_installation_strategy()
     assert result == Strategy.INSTALL_LOCAL_CONTAINER
+
+
+def test_no_bundled_container_tar_first_install(mocker: MockerFixture) -> None:
+    """User installs dangerzone-slim (no container.tar) for the first time.
+
+    Without a bundled container, the strategy should fall back to remote
+    installation if updates are enabled.
+    """
+    mocker.patch(f"{installer}.runtime.list_image_digests", return_value=[])
+    mocker.patch(
+        f"{installer}.runtime.expected_image_name",
+        return_value="ghcr.io/freedomofpress/dangerzone/v1",
+    )
+    mocker.patch(f"{installer}.Settings").return_value.get.side_effect = lambda key: {
+        "updater_check_all": True,
+        "updater_remote_log_index": 300,
+    }.get(key)
+    mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=False)
+    # No container.tar bundled, so is_container_tar_bundled returns False
+    # making bundled_log_index effectively 0
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=False)
+
+    result = get_installation_strategy()
+    assert result == Strategy.INSTALL_REMOTE_CONTAINER
+
+
+def test_no_bundled_container_tar_updates_disabled(mocker: MockerFixture) -> None:
+    """User installs dangerzone-slim (no container.tar) with updates disabled.
+
+    Without a bundled container and with updates disabled, the strategy
+    should be DO_NOTHING if there's already an image installed, or
+    INSTALL_REMOTE_CONTAINER if there's no image (since max would be 0).
+    In this case, with no images and no remote updates, max_log_index is 0
+    and local_log_index is 0, so DO_NOTHING is returned.
+    """
+    mocker.patch(f"{installer}.runtime.list_image_digests", return_value=[])
+    mocker.patch(
+        f"{installer}.runtime.expected_image_name",
+        return_value="ghcr.io/freedomofpress/dangerzone/v1",
+    )
+    mocker.patch(f"{installer}.Settings").return_value.get.side_effect = lambda key: {
+        "updater_check_all": False,
+    }.get(key)
+    mocker.patch(f"dangerzone.updater.signatures.Path.exists", return_value=False)
+    # No container.tar bundled, so is_container_tar_bundled returns False
+    # making bundled_log_index effectively 0
+    mocker.patch(f"{installer}.is_container_tar_bundled", return_value=False)
+
+    result = get_installation_strategy()
+    # With all indexes at 0, local_log_index == max_log_index, so DO_NOTHING
+    assert result == Strategy.DO_NOTHING


### PR DESCRIPTION
This removes the need to have a `container.tar` file packaged with Dangerzone.

Related to #1069, but is not enough to close it for now, as a `dangerzone-slim` version will be required at some point, which will probably need an update of our Debian and Fedora packages as well.