### PR TITLE
Exclude dangerzone-machine from Linux packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,5 @@ export DH_VERBOSE=1
 
 override_dh_builddeb:
 	./install/linux/debian-vendor-pymupdf.py --dest debian/dangerzone/usr/lib/python3/dist-packages/dangerzone/vendor/
+	rm -f debian/dangerzone/usr/bin/dangerzone-machine
 	dh_builddeb $@

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -225,6 +225,7 @@ convert the documents within a secure sandbox.
 %install
 %pyproject_install
 %pyproject_save_files dangerzone
+rm -f %{buildroot}%{_bindir}/dangerzone-machine
 
 # Create some extra directories for non-Python data, which are not covered by
 # pyproject_save_files.
@@ -271,7 +272,6 @@ fi
 /usr/bin/dangerzone
 /usr/bin/dangerzone-cli
 /usr/bin/dangerzone-image
-/usr/bin/dangerzone-machine
 /usr/share/
 %license LICENSE
 %doc README.md


### PR DESCRIPTION
Resolves: https://github.com/freedomofpress/dangerzone/issues/1404

I decided to make a minimal change on the level of the package builders themselves instead of more upstream in e.g `setup.py`. This to avoid breaking other build-flows and development ergonomics.