### PR TITLE
Look for desktop files in XDG_DATA_DIRS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 - Dangerzone is able to function without a bundled `container.tar` file 
   ([#1400](https://github.com/freedomofpress/dangerzone/pull/1400))
+- Look for desktop entries in `XDG_DATA_DIRS` paths on Linux ([#1413](https://github.com/freedomofpress/dangerzone/issues/1413))
 
 
 ### Development changes

--- a/dangerzone/gui/logic.py
+++ b/dangerzone/gui/logic.py
@@ -119,11 +119,16 @@ class DangerzoneGui(DangerzoneCore):
                 log.debug(f"xdg-mime query failed: {e}")
 
             # Find all .desktop files
-            for search_path in [
-                "/usr/share/applications",
-                "/usr/local/share/applications",
-                os.path.expanduser("~/.local/share/applications"),
-            ]:
+            # Use dict.fromkeys (rather than a set) to retain paths order
+            # (only dict keys are used, values are set to `None`)
+            for search_path in dict.fromkeys(
+                os.environ.get(
+                    "XDG_DATA_DIRS",
+                    "/usr/local/share:/usr/share",
+                ).split(":")
+                + [os.path.expanduser("~/.local/share")]
+            ):
+                search_path = os.path.join(search_path, "applications")
                 try:
                     for filename in os.listdir(search_path):
                         full_filename = os.path.join(search_path, filename)


### PR DESCRIPTION
Resolves https://github.com/freedomofpress/dangerzone/issues/1413

In this change I split the contents of the `XDG_DATA_DIRS` environment variable and concat it with `~/.local/share`. I use `dict.fromkeys` to remove duplicates, otherwise we would potentially search the same directory affecting performance. If `XDG_DATA_DIRS` is empty we default to the paths specified before this change avoiding regression and matching the [expected behavior](https://wiki.archlinux.org/title/XDG_Base_Directory#System_directories).

I tested it by installing indiPDF through flatpack. After this change indiPDF was listed as option:
<img width="601" height="467" alt="image" src="https://github.com/user-attachments/assets/1c4291fb-1cb5-430e-bd1d-c1f0128cd601" />

When unsetting `XDG_DATA_DIRS` the same options as before this change are listed. This fixes the issue raised here https://github.com/freedomofpress/dangerzone/discussions/1410