### PR TITLE
Provide `*-full` packages for Linux, and remove `container.tar` from default ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
           poetry run dangerzone-image prepare-archive
           --output share/container.tar
 
-      - name: Build Dangerzone .deb
+      - name: Build Dangerzone .deb packages
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} \
               --version ${{ matrix.version }} \
@@ -248,8 +248,17 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
+      - name: Upload Dangerzone-full .deb
+        if: matrix.distro == 'debian' && matrix.version == 'bookworm'
+        uses: actions/upload-artifact@v6
+        with:
+          name: dangerzone-full.deb
+          path: "deb_dist/dangerzone-full_*_*.deb"
+          if-no-files-found: error
+          compression-level: 0
+
   install-deb:
-    name: "install-deb (${{ matrix.distro }} ${{ matrix.version }})"
+    name: "install-deb (${{ matrix.distro }} ${{ matrix.version }} ${{ matrix.package }})"
     runs-on: ubuntu-latest
     needs:
       - build-deb
@@ -259,16 +268,28 @@ jobs:
         include:
           - distro: ubuntu
             version: "22.04"
+            package: "dangerzone.deb"
           - distro: ubuntu
             version: "24.04"
+            package: "dangerzone.deb"
           - distro: ubuntu
             version: "26.04"
+            package: "dangerzone.deb"
           - distro: ubuntu
             version: "25.10"
+            package: "dangerzone.deb"
           - distro: debian
             version: bookworm
+            package: "dangerzone.deb"
+          - distro: debian
+            version: bookworm
+            package: "dangerzone.deb"
+          - distro: debian
+            version: bookworm
+            package: "dangerzone-full.deb"
           - distro: debian
             version: trixie
+            package: "dangerzone.deb"
 
     steps:
       - name: Checkout
@@ -281,7 +302,7 @@ jobs:
       - name: Download Dangerzone .deb
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dangerzone.deb
+          name: ${{ matrix.package }}
           path: "deb_dist/"
 
       - name: Build end-user environment
@@ -289,6 +310,13 @@ jobs:
           ./dev_scripts/env.py --distro ${{ matrix.distro }} \
               --version ${{ matrix.version }} \
               build
+
+      - if: matrix.package == 'dangerzone-full.deb'
+        name: Download container image
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              run dangerzone-image upgrade
 
       - name: Run a test command
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,7 @@ jobs:
       matrix:
         distro: ["fedora"]
         version: ["42", "43", "44"]
+        full: [true, false]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -351,31 +352,48 @@ jobs:
         id: image-digest
         run: echo "digest=$(crane digest $(cat share/image-name.txt):latest)" >> $GITHUB_OUTPUT
 
-      - name: Cache container image archive
+      - if: matrix.full
+        name: Cache container image archive
         id: cache-container
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: share/container.tar
           key: v1-container-tar-${{ runner.arch }}-${{ steps.image-digest.outputs.digest }}
 
-      - name: Download the container image as a tar archive
-        if: steps.cache-container.outputs.cache-hit != 'true'
+      - if: matrix.full and steps.cache-container.outputs.cache-hit != 'true'
+        name: Download the container image as a tar archive
         env:
           DANGERZONE_DEV: "1"
         run: >-
-          poetry run dangerzone-image prepare-archive
-          --output share/container.tar
+          poetry run dangerzone-image prepare-archive --output share/container.tar
 
-      - name: Build Dangerzone .rpm
+      - if: not matrix.full
+        name: Build dangerzone(slim).rpm
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
               run --dev --no-gui ./dangerzone/install/linux/build-rpm.py
 
-      - name: Upload Dangerzone .rpm
+      - if: matrix.full
+        name: Build dangerzone-full.rpm
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
+              run --dev --no-gui ./dangerzone/install/linux/build-rpm.py --full
+
+      - if: not matrix.full
+        name: Upload dangerzone.rpm
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dangerzone-${{ matrix.distro }}-${{ matrix.version }}.rpm
           path: "dist/dangerzone-*.x86_64.rpm"
+          if-no-files-found: error
+          compression-level: 0
+
+      - if: matrix.full
+        name: Upload dangerzone-full.rpm
+        uses: actions/upload-artifact@v7
+        with:
+          name: dangerzone-full-${{ matrix.distro }}-${{ matrix.version }}.rpm
+          path: "dist/dangerzone-full-*.x86_64.rpm"
           if-no-files-found: error
           compression-level: 0
 
@@ -385,11 +403,25 @@ jobs:
       - name: Reclaim some storage space
         run: podman system reset -f
 
-      - name: Build end-user environment
+      - if: not matrix.full
+        name: Build (slim) end-user environment
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} \
               --version ${{ matrix.version }} \
               build
+
+      - if: matrix.full
+        name: Build (full) end-user environment
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              build --full
+
+      - if: not matrix.full
+        name: Download container image
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
+              run dangerzone-image upgrade
 
       - name: Run a test command
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,50 @@ jobs:
               --version ${{ matrix.version }} \
               run dangerzone --help
 
+
+  install-deb-full:
+    name: "install-deb-full (${{ matrix.distro }} ${{ matrix.version }})"
+    runs-on: ubuntu-latest
+    needs:
+      - build-deb
+    strategy:
+      matrix:
+        include:
+          - distro: debian
+            version: bookworm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Download Dangerzone full .deb
+        uses: actions/download-artifact@v6
+        with:
+          name: dangerzone-full.deb
+          path: "deb_dist/"
+
+      - name: Build end-user environment with full package
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              build --full
+
+      - name: Run a test command (container bundled)
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              run dangerzone-cli dangerzone/tests/test_docs/sample-pdf.pdf --ocr-lang eng --debug
+
+      - name: Check that the Dangerzone GUI imports work
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              run dangerzone --help
+
   build-install-rpm:
     name: "build-install-rpm (${{ matrix.distro }} ${{matrix.version}})"
     runs-on: ubuntu-latest
@@ -412,7 +456,22 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dangerzone-${{ matrix.distro }}-${{ matrix.version }}.rpm
-          path: "dist/dangerzone-*.x86_64.rpm"
+          path: |
+            dist/dangerzone-*.x86_64.rpm
+            !dist/dangerzone-full-*.x86_64.rpm
+          if-no-files-found: error
+          compression-level: 0
+
+      - name: Build Dangerzone-full .rpm
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
+              run --dev --no-gui ./dangerzone/install/linux/build-rpm.py --full
+
+      - name: Upload Dangerzone-full .rpm
+        uses: actions/upload-artifact@v7
+        with:
+          name: dangerzone-full-${{ matrix.distro }}-${{ matrix.version }}.rpm
+          path: "dist/dangerzone-full-*.x86_64.rpm"
           if-no-files-found: error
           compression-level: 0
 
@@ -459,6 +518,49 @@ jobs:
       - name: Check that the Dangerzone GUI imports work
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
+              run dangerzone --help
+
+  install-rpm-full:
+    name: "install-rpm-full (${{ matrix.distro }} ${{ matrix.version }})"
+    runs-on: ubuntu-latest
+    needs:
+      - build-install-rpm
+    strategy:
+      matrix:
+        include:
+          - distro: fedora
+            version: "43"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Download Dangerzone-full .rpm
+        uses: actions/download-artifact@v8
+        with:
+          name: dangerzone-full-${{ matrix.distro }}-${{ matrix.version }}.rpm
+          path: "dist/"
+
+      - name: Build end-user environment with full package
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              build --full
+
+      - name: Run a test command (container bundled)
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
+              run dangerzone-cli dangerzone/tests/test_docs/sample-pdf.pdf --ocr-lang eng --debug
+
+      - name: Check that the Dangerzone GUI imports work
+        run: |
+          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
+              --version ${{ matrix.version }} \
               run dangerzone --help
 
   run-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,19 @@ jobs:
       # `dangerzone-cli` command and its WSL detection will fail.
       #
       # For this reason, we prefer to run `wsl --update` before the tests.
+      # Microsoft's WSL update servers occasionally return HTTP 403, so retry
+      # before failing the job.
       - name: Update WSL
-        run: wsl --update
+        shell: pwsh
+        run: |
+          $ok = $false
+          for ($i = 1; $i -le 5; $i++) {
+            wsl --update
+            if ($LASTEXITCODE -eq 0) { $ok = $true; break }
+            Write-Host "wsl --update attempt $i failed (exit $LASTEXITCODE), retrying..."
+            Start-Sleep -Seconds 15
+          }
+          if (-not $ok) { exit 1 }
       - name: Smoke test
         run: poetry run dangerzone-cli .\tests\test_docs\sample-pdf.pdf --ocr-lang eng --debug
       - name: Run CLI tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
-      - name: Install maette tool
+      - name: Install mazette tool
         run: |
           sudo apt install pipx
           pipx install poetry
@@ -269,7 +269,7 @@ jobs:
           compression-level: 0
 
   install-deb:
-    name: "install-deb (${{ matrix.distro }} ${{ matrix.version }} ${{ matrix.package }})"
+    name: "install-deb (${{ matrix.distro }} ${{ matrix.version }})${{ matrix.full && ' [full]' || '' }}"
     runs-on: ubuntu-latest
     needs:
       - build-deb
@@ -279,28 +279,28 @@ jobs:
         include:
           - distro: ubuntu
             version: "22.04"
-            package: "dangerzone.deb"
+            full: false
           - distro: ubuntu
             version: "24.04"
-            package: "dangerzone.deb"
-          - distro: ubuntu
-            version: "26.04"
-            package: "dangerzone.deb"
+            full: false
           - distro: ubuntu
             version: "25.10"
-            package: "dangerzone.deb"
+            full: false
+          - distro: ubuntu
+            version: "26.04"
+            full: false
           - distro: debian
             version: bookworm
-            package: "dangerzone.deb"
+            full: true
           - distro: debian
             version: bookworm
-            package: "dangerzone.deb"
-          - distro: debian
-            version: bookworm
-            package: "dangerzone-full.deb"
+            full: false
           - distro: debian
             version: trixie
-            package: "dangerzone.deb"
+            full: false
+    env:
+      BUILD_FLAG: ${{ matrix.full && '--full' || '' }}
+      PKG_PREFIX: dangerzone${{ matrix.full && '-full' || '' }}
 
     steps:
       - name: Checkout
@@ -310,19 +310,19 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Download Dangerzone .deb
+      - name: Download ${{ env.PKG_PREFIX }}.deb
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ matrix.package }}
+          name: ${{ env.PKG_PREFIX }}.deb
           path: "deb_dist/"
 
       - name: Build end-user environment
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} \
               --version ${{ matrix.version }} \
-              build
+              build ${{ env.BUILD_FLAG }}
 
-      - if: matrix.package == 'dangerzone-full.deb'
+      - if: ${{ !matrix.full }}
         name: Download container image
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} \
@@ -341,62 +341,20 @@ jobs:
               --version ${{ matrix.version }} \
               run dangerzone --help
 
-
-  install-deb-full:
-    name: "install-deb-full (${{ matrix.distro }} ${{ matrix.version }})"
-    runs-on: ubuntu-latest
-    needs:
-      - build-deb
-    strategy:
-      matrix:
-        include:
-          - distro: debian
-            version: bookworm
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-
-      - name: Download Dangerzone full .deb
-        uses: actions/download-artifact@v6
-        with:
-          name: dangerzone-full.deb
-          path: "deb_dist/"
-
-      - name: Build end-user environment with full package
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
-              --version ${{ matrix.version }} \
-              build --full
-
-      - name: Run a test command (container bundled)
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
-              --version ${{ matrix.version }} \
-              run dangerzone-cli dangerzone/tests/test_docs/sample-pdf.pdf --ocr-lang eng --debug
-
-      - name: Check that the Dangerzone GUI imports work
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
-              --version ${{ matrix.version }} \
-              run dangerzone --help
-
   build-install-rpm:
-    name: "build-install-rpm (${{ matrix.distro }} ${{matrix.version}})"
+    name: "build-install-rpm (${{ matrix.distro }} ${{matrix.version}})${{ matrix.full && ' [full]' || '' }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         distro: ["fedora"]
         version: ["42", "43", "44"]
         full: [true, false]
+    env:
+      RPM_PREFIX: dangerzone${{ matrix.full && '-full' || '' }}
+      BUILD_FLAG: ${{ matrix.full && '--full' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
 
       - name: Install mazette tool
         run: |
@@ -424,14 +382,17 @@ jobs:
               --version ${{ matrix.version }} \
               build-dev --sync
 
-      - name: Use the testing image and key
+      - if: matrix.full
+        name: Use the testing image and key
         run: |-
           cp tests/assets/dangerzone-testing.pub share/freedomofpress-dangerzone.pub
           echo "ghcr.io/freedomofpress/dangerzone-testing/main/v1" > share/image-name.txt
 
-      - uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
+      - if: matrix.full
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
 
-      - name: Get the digest of the latest image
+      - if: matrix.full
+        name: Get the digest of the latest image
         id: image-digest
         run: echo "digest=$(crane digest $(cat share/image-name.txt):latest)" >> $GITHUB_OUTPUT
 
@@ -443,55 +404,23 @@ jobs:
           path: share/container.tar
           key: v1-container-tar-${{ runner.arch }}-${{ steps.image-digest.outputs.digest }}
 
-      - if: matrix.full and steps.cache-container.outputs.cache-hit != 'true'
+      - if: matrix.full && steps.cache-container.outputs.cache-hit != 'true'
         name: Download the container image as a tar archive
         env:
           DANGERZONE_DEV: "1"
         run: >-
           poetry run dangerzone-image prepare-archive --output share/container.tar
 
-      - if: not matrix.full
-        name: Build dangerzone(slim).rpm
+      - name: Build ${{ env.RPM_PREFIX }}.rpm
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
-              run --dev --no-gui ./dangerzone/install/linux/build-rpm.py
+              run --dev --no-gui ./dangerzone/install/linux/build-rpm.py ${{ env.BUILD_FLAG }}
 
-      - if: matrix.full
-        name: Build dangerzone-full.rpm
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
-              run --dev --no-gui ./dangerzone/install/linux/build-rpm.py --full
-
-      - if: not matrix.full
-        name: Upload dangerzone.rpm
+      - name: Upload ${{ env.RPM_PREFIX }}.rpm
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dangerzone-${{ matrix.distro }}-${{ matrix.version }}.rpm
-          path: |
-            dist/dangerzone-*.x86_64.rpm
-            !dist/dangerzone-full-*.x86_64.rpm
-          if-no-files-found: error
-          compression-level: 0
-
-      - name: Build Dangerzone-full .rpm
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
-              run --dev --no-gui ./dangerzone/install/linux/build-rpm.py --full
-
-      - name: Upload Dangerzone-full .rpm
-        uses: actions/upload-artifact@v7
-        with:
-          name: dangerzone-full-${{ matrix.distro }}-${{ matrix.version }}.rpm
-          path: "dist/dangerzone-full-*.x86_64.rpm"
-          if-no-files-found: error
-          compression-level: 0
-
-      - if: matrix.full
-        name: Upload dangerzone-full.rpm
-        uses: actions/upload-artifact@v7
-        with:
-          name: dangerzone-full-${{ matrix.distro }}-${{ matrix.version }}.rpm
-          path: "dist/dangerzone-full-*.x86_64.rpm"
+          name: ${{ env.RPM_PREFIX }}-${{ matrix.distro }}-${{ matrix.version }}.rpm
+          path: dist/${{ env.RPM_PREFIX }}-*.x86_64.rpm
           if-no-files-found: error
           compression-level: 0
 
@@ -501,21 +430,13 @@ jobs:
       - name: Reclaim some storage space
         run: podman system reset -f
 
-      - if: not matrix.full
-        name: Build (slim) end-user environment
+      - name: Build end-user environment
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} \
               --version ${{ matrix.version }} \
-              build
+              build ${{ env.BUILD_FLAG }}
 
-      - if: matrix.full
-        name: Build (full) end-user environment
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
-              --version ${{ matrix.version }} \
-              build --full
-
-      - if: not matrix.full
+      - if: ${{ !matrix.full }}
         name: Download container image
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
@@ -529,49 +450,6 @@ jobs:
       - name: Check that the Dangerzone GUI imports work
         run: |
           ./dev_scripts/env.py --distro ${{ matrix.distro }} --version ${{ matrix.version }} \
-              run dangerzone --help
-
-  install-rpm-full:
-    name: "install-rpm-full (${{ matrix.distro }} ${{ matrix.version }})"
-    runs-on: ubuntu-latest
-    needs:
-      - build-install-rpm
-    strategy:
-      matrix:
-        include:
-          - distro: fedora
-            version: "43"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Download Dangerzone-full .rpm
-        uses: actions/download-artifact@v8
-        with:
-          name: dangerzone-full-${{ matrix.distro }}-${{ matrix.version }}.rpm
-          path: "dist/"
-
-      - name: Build end-user environment with full package
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
-              --version ${{ matrix.version }} \
-              build --full
-
-      - name: Run a test command (container bundled)
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
-              --version ${{ matrix.version }} \
-              run dangerzone-cli dangerzone/tests/test_docs/sample-pdf.pdf --ocr-lang eng --debug
-
-      - name: Check that the Dangerzone GUI imports work
-        run: |
-          ./dev_scripts/env.py --distro ${{ matrix.distro }} \
-              --version ${{ matrix.version }} \
               run dangerzone --help
 
   run-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -134,9 +134,11 @@ dmypy.json
 
 debian/.debhelper
 debian/dangerzone
+debian/dangerzone-slim
 debian/files
 debian/debhelper-build-stamp
 debian/dangerzone.*
+debian/dangerzone-slim.*
 .pybuild/
 
 # Other

--- a/.gitignore
+++ b/.gitignore
@@ -134,11 +134,11 @@ dmypy.json
 
 debian/.debhelper
 debian/dangerzone
-debian/dangerzone-slim
+debian/dangerzone-full
 debian/files
 debian/debhelper-build-stamp
 debian/dangerzone.*
-debian/dangerzone-slim.*
+debian/dangerzone-full.*
 .pybuild/
 
 # Other

--- a/BUILD.md
+++ b/BUILD.md
@@ -173,11 +173,13 @@ Create a .rpm:
 ./install/linux/build-rpm.py
 ```
 
-Or alternatively, build a slim version of Dangerzone, which doesn't contain the
-`container.tar` image (it will then be downloaded on the first run).
+This builds the `dangerzone` package, which doesn't contain the `container.tar`
+image (it will be downloaded on the first run).
+
+To build the `dangerzone-full` package with the container bundled:
 
 ```sh
-./install/linux/build-rpm.py --slim
+./install/linux/build-rpm.py --full
 ```
 
 ## Qubes OS

--- a/BUILD.md
+++ b/BUILD.md
@@ -164,6 +164,13 @@ Create a .rpm:
 ./install/linux/build-rpm.py
 ```
 
+Or alternatively, build a slim version of Dangerzone, which doesn't contain the
+`container.tar` image (it will then be downloaded on the first run).
+
+```sh
+./install/linux/build-rpm.py --slim
+```
+
 ## Qubes OS
 
 > :warning: Native Qubes support is in beta stage, so the instructions below

--- a/BUILD.md
+++ b/BUILD.md
@@ -98,6 +98,15 @@ Create a .deb:
 ./install/linux/build-deb.py
 ```
 
+This builds both the `dangerzone` (slim) and `dangerzone-full` packages in a
+single run. The slim package does not contain the `container.tar` image (it
+will be downloaded on the first run), while `dangerzone-full` bundles the
+container image for offline or air-gapped installations.
+
+> **Note**: `container.tar` must be present in `share/` before running this
+> command, as it is required for the `dangerzone-full` package. See the
+> instructions above for how to download or build it.
+
 ## Fedora
 
 Install dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased](https://github.com/freedomofpress/dangerzone/compare/v0.10.0...HEAD)
 
+### Changes
+
+- Linux packages dropped the `container.tar` file, it is expected to be downloaded at the first usage, and then kept up to date. If you prefer to use packages with the `container.tar`, use the `dangerzone-full` variant ([#1069](https://github.com/freedomofpress/dangerzone/issues/1069))
+- **Breaking change (Linux CLI)**: with the slim `dangerzone` package, the CLI no longer auto-downloads the conversion sandbox. New installations must initialize the sandbox once with `dangerzone-image upgrade` (or run the GUI, which prompts for the download) before `dangerzone-cli` can convert documents. Users of the `dangerzone-full` package or who already have an image installed are unaffected.
+
+
 ### Fixed
 
 - Remember user-selected output directory across sessions

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,6 +164,10 @@ Type the following commands in a terminal:
 ```sh
 sudo dnf config-manager addrepo --from-repofile=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone
+
+# Alternatively, use dangerzone-slim if you prefer to install dangerzone
+# without its container (it will be downloaded at first use)
+sudo dnf install dangerzone-slim
 ```
 
 ##### Verifying Dangerzone GPG key
@@ -212,6 +216,9 @@ Type the following commands in a terminal:
 curl -o - https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo \
     | sudo tee /etc/yum.repos.d/dangerzone.repo > /dev/null
 rpm-ostree install dangerzone
+# Alternatively, use dangerzone-slim if you prefer to install dangerzone
+# without its container (it will be downloaded at first use)
+rpm-ostree install dangerzone-slim
 ```
 
 After the above command completes, restart your computer to complete the installation.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -134,9 +134,9 @@ Install Dangerzone:
 sudo apt update
 sudo apt install -y dangerzone
 
-# Alternatively, use dangerzone-slim if you prefer to install dangerzone
-# without its container (it will be downloaded at first use)
-sudo apt install -y dangerzone-slim
+# Alternatively, use dangerzone-full if you prefer to install dangerzone
+# with its container bundled (larger package, but no download at first use)
+sudo apt install -y dangerzone-full
 ```
 
 <table>
@@ -169,9 +169,9 @@ Type the following commands in a terminal:
 sudo dnf config-manager addrepo --from-repofile=https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo
 sudo dnf install dangerzone
 
-# Alternatively, use dangerzone-slim if you prefer to install dangerzone
-# without its container (it will be downloaded at first use)
-sudo dnf install dangerzone-slim
+# Alternatively, use dangerzone-full if you prefer to install dangerzone
+# with its container bundled (larger package, but no download at first use)
+sudo dnf install dangerzone-full
 ```
 
 ##### Verifying Dangerzone GPG key
@@ -220,9 +220,9 @@ Type the following commands in a terminal:
 curl -o - https://packages.freedom.press/yum-tools-prod/dangerzone/dangerzone.repo \
     | sudo tee /etc/yum.repos.d/dangerzone.repo > /dev/null
 rpm-ostree install dangerzone
-# Alternatively, use dangerzone-slim if you prefer to install dangerzone
-# without its container (it will be downloaded at first use)
-rpm-ostree install dangerzone-slim
+# Alternatively, use dangerzone-full if you prefer to install dangerzone
+# with its container bundled (larger package, but no download at first use)
+rpm-ostree install dangerzone-full
 ```
 
 After the above command completes, restart your computer to complete the installation.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,6 +133,10 @@ Install Dangerzone:
 ```sh
 sudo apt update
 sudo apt install -y dangerzone
+
+# Alternatively, use dangerzone-slim if you prefer to install dangerzone
+# without its container (it will be downloaded at first use)
+sudo apt install -y dangerzone-slim
 ```
 
 <table>

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -144,7 +144,19 @@ def run(
         ]
 
     try:
-        startup.StartupLogic(tasks=tasks).run()
+        try:
+            startup.StartupLogic(tasks=tasks).run()
+        except errors.UpdaterDisabledNoContainer:
+            click.echo(
+                "\n"
+                + Fore.RED
+                + Style.BRIGHT
+                + "No container image found."
+                + Style.RESET_ALL
+                + " Please initialize Dangerzone by running:\n\n"
+                "    dangerzone-image upgrade\n"
+            )
+            sys.exit(1)
         print_header("Converting document(s) to safe PDF")
         dangerzone.convert_documents(ocr_lang)
     finally:

--- a/dangerzone/errors.py
+++ b/dangerzone/errors.py
@@ -199,3 +199,13 @@ class WinShellExecNoHandle(WinShellExecError):
 
 class WinShellExecProcessError(WinShellExecError):
     pass
+
+
+class UpdaterDisabledNoContainer(Exception):
+    """User declined to enable updates, but no container image is available."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "No container image is available. "
+            "Updates must be enabled to download the container and use Dangerzone."
+        )

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -511,6 +511,9 @@ class MainWindow(QtWidgets.QMainWindow):
         task_update_check.needs_user_input.connect(
             self.handle_needs_user_input_enable_updates
         )
+        task_update_check.needs_user_input_download.connect(
+            self.handle_needs_user_input_download_container
+        )
 
         task_container_install.load_container.connect(
             self.status_bar.handle_task_container_install_local
@@ -685,9 +688,29 @@ class MainWindow(QtWidgets.QMainWindow):
         self.dangerzone.settings.save()
 
     def handle_needs_user_input_enable_updates(self) -> None:
+        """Handle the prompt to enable updates (container already available)."""
         check = prompt_for_checks(self.dangerzone)
         if check is not None:
             self.dangerzone.settings.set("updater_check_all", check, autosave=True)
+
+    def handle_needs_user_input_download_container(
+        self, req: startup.PromptRequest
+    ) -> None:
+        """Handle the prompt to download container (no container available).
+
+        This is a blocking prompt - the user must accept or the app will shut down.
+        """
+        check = prompt_for_checks(self.dangerzone, download_required=True)
+        if check is True:
+            req.reply(True)
+        else:
+            # User declined or pressed X - shutdown
+            req.reply(False)
+            QtCore.QTimer.singleShot(0, self._handle_download_declined)
+
+    def _handle_download_declined(self) -> None:
+        log.debug("User declined container download, shutting down")
+        self.exit(2)
 
     def handle_needs_user_input_stop_others(self, req: startup.PromptRequest) -> None:
         machine_name = req.req_data["name"]

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -798,13 +798,13 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         assert question.checkbox is not None
         result = question.launch()
-        if question.checkbox.isChecked():
-            self.dangerzone.settings.set(
-                "updater_ask_before_download",
-                False,
-                autosave=True,
-            )
         if result == Question.Accepted:
+            if question.checkbox.isChecked():
+                self.dangerzone.settings.set(
+                    "updater_ask_before_download",
+                    False,
+                    autosave=True,
+                )
             log.debug("Accepted")
             req.reply(True)
             return

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -710,6 +710,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _handle_download_declined(self) -> None:
         log.debug("User declined container download, shutting down")
+        # Shutting down using exit(2) because nothing has been started yet.
         self.exit(2)
 
     def handle_needs_user_input_stop_others(self, req: startup.PromptRequest) -> None:

--- a/dangerzone/gui/startup.py
+++ b/dangerzone/gui/startup.py
@@ -81,7 +81,7 @@ class PromptRequest:
 class MachineStopOthersTask(
     GUIMixin, startup.MachineStopOthersTask, metaclass=_MetaConflictResolver
 ):
-    needs_user_input = QtCore.Signal(object)  # PromptRequest
+    needs_user_input = QtCore.Signal(object)
 
     def prompt_user(self, machine_name: str) -> bool:
         return PromptRequest().ask(self.needs_user_input, data={"name": machine_name})
@@ -123,7 +123,11 @@ class ContainerInstallTask(
             self.load_container.emit()
             return super().run()
         elif strategy == InstallationStrategy.INSTALL_REMOTE_CONTAINER:
-            if Settings().get("updater_ask_before_download"):
+            ask = Settings().get("updater_ask_before_download")
+            if startup.ContainerInstallTask.skip_prompt_once:
+                startup.ContainerInstallTask.skip_prompt_once = False
+                ask = False
+            if ask:
                 resp = self.prompt_user()
                 if resp:
                     self._download_container()
@@ -144,12 +148,25 @@ class UpdateCheckTask(
     GUIMixin, startup.UpdateCheckTask, metaclass=_MetaConflictResolver
 ):
     needs_user_input = QtCore.Signal()
+    needs_user_input_download = QtCore.Signal(object)  # PromptRequest
     app_update_available = QtCore.Signal(object)
     container_update_available = QtCore.Signal(object)
 
-    def prompt_user(self) -> None:
-        super().prompt_user()
-        self.needs_user_input.emit()
+    def prompt_user(self, download_required: bool = False) -> Optional[bool]:
+        """Prompt user to enable updates.
+
+        When download is required (no container available), this blocks until the user
+        responds. Otherwise, this is non-blocking (user will be asked again next run).
+
+        Returns True if user accepts, False if user declines, None if dismissed/non-blocking.
+        """
+        if download_required:
+            # No container available: block until user responds
+            return PromptRequest().ask(self.needs_user_input_download)
+        else:
+            # Container available: non-blocking, just emit and return
+            self.needs_user_input.emit()
+            return None
 
     def handle_app_update(self, report: ReleaseReport) -> None:
         self.app_update_available.emit(report)

--- a/dangerzone/gui/startup.py
+++ b/dangerzone/gui/startup.py
@@ -9,10 +9,12 @@ else:
     except ImportError:
         from PySide2 import QtCore, QtWidgets
 
+from .. import container_utils as runtime
 from .. import errors, logging, startup
 from ..settings import Settings
 from ..updater import InstallationStrategy, installer
 from ..updater.releases import EmptyReport, ErrorReport, ReleaseReport
+from ..updater.signatures import is_container_tar_bundled
 
 log = logging.getLogger(__name__)
 
@@ -124,10 +126,13 @@ class ContainerInstallTask(
             return super().run()
         elif strategy == InstallationStrategy.INSTALL_REMOTE_CONTAINER:
             ask = Settings().get("updater_ask_before_download")
-            if startup.ContainerInstallTask.skip_prompt_once:
-                startup.ContainerInstallTask.skip_prompt_once = False
-                ask = False
-            if ask:
+            # If we are asked to install a remote container, only ask the user
+            # if nothing is currently installed. We avoid querying the container
+            # runtime unless we actually intend to prompt.
+            skip_user_request = ask and (
+                is_container_tar_bundled() or runtime.list_image_digests()
+            )
+            if ask and not skip_user_request:
                 resp = self.prompt_user()
                 if resp:
                     self._download_container()

--- a/dangerzone/gui/startup.py
+++ b/dangerzone/gui/startup.py
@@ -125,14 +125,17 @@ class ContainerInstallTask(
             self.load_container.emit()
             return super().run()
         elif strategy == InstallationStrategy.INSTALL_REMOTE_CONTAINER:
+            # Always ask the user if they want to install a remote container image,
+            # unless:
+            # 1. The user has strictly specified that they don't want to be prompted
+            #    again.
+            # 2. The Dangerzone installation has no bundled images and no images that
+            #    Podman has downloaded already. In this particular case, they have
+            #    already been prompted by the `UpdateCheckTask`, so they don't need to
+            #    be prompted again.
             ask = Settings().get("updater_ask_before_download")
-            # If we are asked to install a remote container, only ask the user
-            # if nothing is currently installed. We avoid querying the container
-            # runtime unless we actually intend to prompt.
-            skip_user_request = ask and (
-                is_container_tar_bundled() or runtime.list_image_digests()
-            )
-            if ask and not skip_user_request:
+            force = not is_container_tar_bundled() and not runtime.list_image_digests()
+            if ask and not force:
                 resp = self.prompt_user()
                 if resp:
                     self._download_container()

--- a/dangerzone/gui/startup.py
+++ b/dangerzone/gui/startup.py
@@ -137,12 +137,9 @@ class ContainerInstallTask(
             force = not is_container_tar_bundled() and not runtime.list_image_digests()
             if ask and not force:
                 resp = self.prompt_user()
-                if resp:
-                    self._download_container()
-                else:
+                if not resp:
                     log.debug("Skipping new container download (asked by the user)")
-            else:
-                self._download_container()
+            self._download_container()
 
     def _download_container(self) -> None:
         self.download_container.emit()

--- a/dangerzone/gui/updater.py
+++ b/dangerzone/gui/updater.py
@@ -38,15 +38,14 @@ MSG_CONFIRM_DOWNLOAD_CONTAINER = """\
     <b>Download conversion sandbox?</b>
 </p>
 
-<p>Dangerzone needs to download the sandbox from the internet to convert documents.</p>
+<p>Welcome to Dangerzone! In order to convert documents, it needs to download a sandbox from the internet.</p>
 
 <p>If you enable this option, Dangerzone will download the sandbox now and
 periodically check for updates.</p>
-<p>This is <b>required</b> for this version of Dangerzone to work.</p>
-
-<p>If you need to run Dangerzone in an air-gapped environment, you can use the dangerzone-full variant (on Linux). See <a href="https://github.com/freedomofpress/dangerzone/blob/main/INSTALL.md#linux">our documentation</a>.</p>
+<p>This is <b>required</b> for this version of Dangerzone to work</p>
+<o>If you prefer, you can <a href="https://github.com/freedomofpress/dangerzone/blob/main/INSTALL.md#linux">install the dangerzone-full variant</a> (Linux only), which comes with a bundled sandbox.</p>
 """
-OK_TEXT_DOWNLOAD = "Yes, download sandbox"
+OK_TEXT_DOWNLOAD = "Yes, download sandbox and enable updates"
 CANCEL_TEXT_DOWNLOAD = "Quit Dangerzone"
 
 
@@ -77,19 +76,36 @@ class UpdateCheckPrompt(Question):
         return buttons_layout
 
 
-def prompt_for_checks(dangerzone: DangerzoneGui) -> Optional[bool]:
-    """Check for Dangerzone updates.
+def prompt_for_checks(
+    dangerzone: DangerzoneGui, download_required: bool = False
+) -> Optional[bool]:
+    """Prompt the user to enable update checks.
 
-    This function is responsible for asking the user if they want to enable
-    update checks or not, and then performing the update check.
+    Args:
+        dangerzone: The DangerzoneGui instance.
+        download_required: If True, no container is available and download is required.
+
+    Returns:
+        True if the user accepts enabling updates
+        False if the user declines
+        None if the user pressed X (dismissed without choosing)
     """
+    if download_required:
+        message = MSG_CONFIRM_DOWNLOAD_CONTAINER
+        ok_text = OK_TEXT_DOWNLOAD
+        cancel_text = CANCEL_TEXT_DOWNLOAD
+        log.debug("Prompting the user for container download (no container available)")
+    else:
+        message = MSG_CONFIRM_UPDATE_CHECKS
+        ok_text = OK_TEXT
+        cancel_text = CANCEL_TEXT
+        log.debug("Prompting the user for update checks")
 
-    log.debug("Prompting the user for update checks")
     prompt = UpdateCheckPrompt(
         dangerzone,
-        message=MSG_CONFIRM_UPDATE_CHECKS,
-        ok_text=OK_TEXT,
-        cancel_text=CANCEL_TEXT,
+        message=message,
+        ok_text=ok_text,
+        cancel_text=cancel_text,
     )
     check = prompt.launch()
     if check is not None and not prompt.x_pressed:

--- a/dangerzone/gui/updater.py
+++ b/dangerzone/gui/updater.py
@@ -33,6 +33,22 @@ documentation ↗️</a>.</p>
 OK_TEXT = "Yes, enable sandbox updates"
 CANCEL_TEXT = "No, disable sandbox updates"
 
+MSG_CONFIRM_DOWNLOAD_CONTAINER = """\
+<p>
+    <b>Download conversion sandbox?</b>
+</p>
+
+<p>Dangerzone needs to download the sandbox from the internet to convert documents.</p>
+
+<p>If you enable this option, Dangerzone will download the sandbox now and
+periodically check for updates.</p>
+<p>This is <b>required</b> for this version of Dangerzone to work.</p>
+
+<p>If you need to run Dangerzone in an air-gapped environment, you can use the dangerzone-full variant (on Linux). See <a href="https://github.com/freedomofpress/dangerzone/blob/main/INSTALL.md#linux">our documentation</a>.</p>
+"""
+OK_TEXT_DOWNLOAD = "Yes, download sandbox"
+CANCEL_TEXT_DOWNLOAD = "Quit Dangerzone"
+
 
 class UpdateCheckPrompt(Question):
     """The prompt that asks the users if they want to enable update checks."""

--- a/dangerzone/shutdown.py
+++ b/dangerzone/shutdown.py
@@ -8,7 +8,7 @@ from .podman.machine import PodmanMachineManager
 logger = logging.getLogger(__name__)
 
 
-class MachineStopTask(startup.Task):
+class MachineStopTask(startup._NonLinuxTask):
     can_fail = True
     name = "Stopping Dangerzone VM"
 

--- a/dangerzone/startup.py
+++ b/dangerzone/startup.py
@@ -61,7 +61,17 @@ class Task(abc.ABC):
 #############
 
 
-class MachineInitTask(Task):
+class _NonLinuxTask(Task):
+    """Base class for tasks only relevant on specific platforms (macOS/Windows)."""
+
+    def handle_skip(self) -> None:
+        if platform.system() == "Linux":
+            logger.debug(f"Task '{self.name}' will be skipped")
+        else:
+            super().handle_skip()
+
+
+class MachineInitTask(_NonLinuxTask):
     name = "Initializing Dangerzone VM"
 
     def should_skip(self) -> bool:
@@ -74,7 +84,7 @@ class MachineInitTask(Task):
         PodmanMachineManager().init()
 
 
-class MachineStartTask(Task):
+class MachineStartTask(_NonLinuxTask):
     name = "Starting Dangerzone VM"
 
     def should_skip(self) -> bool:
@@ -87,7 +97,7 @@ class MachineStartTask(Task):
         PodmanMachineManager().start()
 
 
-class MachineStopOthersTask(Task):
+class MachineStopOthersTask(_NonLinuxTask):
     name = "Stopping other Podman VMs"
 
     def fail(self, message: str):  # type: ignore [no-untyped-def]
@@ -163,7 +173,7 @@ class MachineStopOthersTask(Task):
             raise RuntimeError("Failed to stop all other running Podman machines.")
 
 
-class WSLInstallTask(Task):
+class WSLInstallTask(_NonLinuxTask):
     name = "Installing Windows Subsystem for Linux"
 
     def should_skip(self) -> bool:

--- a/dangerzone/startup.py
+++ b/dangerzone/startup.py
@@ -2,6 +2,7 @@ import abc
 import logging
 import platform
 import typing
+from collections.abc import Sequence
 from typing import Optional
 
 from . import errors, settings, util
@@ -285,7 +286,7 @@ class UpdateCheckTask(Task):
 
 
 class Runner:
-    def __init__(self, tasks: list[Task], raise_on_error: bool = True) -> None:
+    def __init__(self, tasks: Sequence[Task], raise_on_error: bool = True) -> None:
         self.tasks = tasks
         self.raise_on_error = raise_on_error
         super().__init__()

--- a/dangerzone/startup.py
+++ b/dangerzone/startup.py
@@ -217,10 +217,6 @@ class WSLInstallTask(_NonLinuxTask):
 class ContainerInstallTask(Task):
     name = "Configuring Dangerzone sandbox"
 
-    # Set by UpdateCheckTask after the user consents to the initial download,
-    # so the GUI variant can skip its redundant prompt for this run only.
-    skip_prompt_once = False
-
     def should_skip(self) -> bool:
         return installer.get_installation_strategy() == InstallationStrategy.DO_NOTHING
 
@@ -243,29 +239,16 @@ class UpdateCheckTask(Task):
 
         try:
             return not releases.should_check_for_updates(settings.Settings())
-        except updater_errors.NeedUserInput as e:
-            download_required = isinstance(e, updater_errors.NeedUserInputNoContainer)
-            accepted = self.prompt_user(download_required=download_required)
-
-            if download_required:
-                # No container available: blocking prompt, handle response
-                if accepted is True:
-                    settings.Settings().set("updater_check_all", True, autosave=True)
-                    # Accepting here is consent for this download, so suppress
-                    # ContainerInstallTask's redundant prompt for this run.
-                    ContainerInstallTask.skip_prompt_once = True
-                    # Proceed with update check immediately so the remote
-                    # container can be downloaded.
-                    return False
-                elif accepted is False:
-                    # User declined - raise an error to stop startup
-                    raise errors.UpdaterDisabledNoContainer()
-                # User pressed X - treat as decline
-                raise errors.UpdaterDisabledNoContainer()
+        except updater_errors.NeedUserInputNoContainer as e:
+            if self.prompt_user(download_required=True):
+                settings.Settings().set("updater_check_all", True, autosave=True)
+                return False
             else:
-                # Container available: non-blocking prompt, handler saves setting
-                # Skip update check, user will be prompted again next run if needed
-                return True
+                # User declined or pressed X raise an error to stop startup
+                raise errors.UpdaterDisabledNoContainer()
+        except updater_errors.NeedUserInput as e:
+            self.prompt_user()
+            return True
 
     def run(self) -> None:
         report = releases.check_for_updates(settings.Settings())

--- a/dangerzone/startup.py
+++ b/dangerzone/startup.py
@@ -206,6 +206,10 @@ class WSLInstallTask(Task):
 class ContainerInstallTask(Task):
     name = "Configuring Dangerzone sandbox"
 
+    # Set by UpdateCheckTask after the user consents to the initial download,
+    # so the GUI variant can skip its redundant prompt for this run only.
+    skip_prompt_once = False
+
     def should_skip(self) -> bool:
         return installer.get_installation_strategy() == InstallationStrategy.DO_NOTHING
 
@@ -228,9 +232,29 @@ class UpdateCheckTask(Task):
 
         try:
             return not releases.should_check_for_updates(settings.Settings())
-        except updater_errors.NeedUserInput:
-            self.prompt_user()
-            return True
+        except updater_errors.NeedUserInput as e:
+            download_required = isinstance(e, updater_errors.NeedUserInputNoContainer)
+            accepted = self.prompt_user(download_required=download_required)
+
+            if download_required:
+                # No container available: blocking prompt, handle response
+                if accepted is True:
+                    settings.Settings().set("updater_check_all", True, autosave=True)
+                    # Accepting here is consent for this download, so suppress
+                    # ContainerInstallTask's redundant prompt for this run.
+                    ContainerInstallTask.skip_prompt_once = True
+                    # Proceed with update check immediately so the remote
+                    # container can be downloaded.
+                    return False
+                elif accepted is False:
+                    # User declined - raise an error to stop startup
+                    raise errors.UpdaterDisabledNoContainer()
+                # User pressed X - treat as decline
+                raise errors.UpdaterDisabledNoContainer()
+            else:
+                # Container available: non-blocking prompt, handler saves setting
+                # Skip update check, user will be prompted again next run if needed
+                return True
 
     def run(self) -> None:
         report = releases.check_for_updates(settings.Settings())
@@ -242,8 +266,16 @@ class UpdateCheckTask(Task):
         elif isinstance(report, ErrorReport):
             raise RuntimeError(report.error)
 
-    def prompt_user(self) -> None:
-        pass
+    def prompt_user(self, download_required: bool = False) -> Optional[bool]:
+        """Prompt the user to enable updates.
+
+        Args:
+            download_required: If True, no container is available and download is required.
+
+        Returns:
+            True if user accepts, False if user declines, None if user dismissed.
+        """
+        return None
 
     def handle_app_update(self, report: ReleaseReport) -> None:
         logger.info(f"Dangerzone {report.version} is out and can be installed")
@@ -291,6 +323,14 @@ class Runner:
         for task in self.tasks:
             try:
                 self.run_task(task)
+            except errors.UpdaterDisabledNoContainer:
+                # Declining the initial container download is a user choice,
+                # not a task failure: skip the error-logging path. The CLI
+                # still wants the exception to surface; the GUI passes
+                # raise_on_error=False and just exits the run.
+                if self.raise_on_error:
+                    raise
+                return
             except Exception as e:
                 task.handle_error(e)
                 if not task.can_fail:

--- a/dangerzone/updater/errors.py
+++ b/dangerzone/updater/errors.py
@@ -134,3 +134,9 @@ class NeedUserInput(UpdaterError):
     """The user has not yet been prompted to know if they want to check for updates."""
 
     pass
+
+
+class NeedUserInputNoContainer(NeedUserInput):
+    """The user must enable updates when no container image is available."""
+
+    pass

--- a/dangerzone/updater/installer.py
+++ b/dangerzone/updater/installer.py
@@ -101,7 +101,7 @@ def get_installation_strategy() -> Strategy:
     #   It remains the same during the lifetime of a released Dangerzone
     #   version.
     #
-    #   If no container.tar is bundled (e.g., dangerzone-slim), this is
+    #   If no container.tar is bundled (i.e., the dangerzone package), this is
     #   set to 0 so that the installer falls back to remote installation.
     #
     # max_log_index:

--- a/dangerzone/updater/releases.py
+++ b/dangerzone/updater/releases.py
@@ -18,7 +18,9 @@ from ..settings import Settings
 from . import errors, log
 from .signatures import (
     DEFAULT_PUBKEY_LOCATION,
+    LAST_LOG_INDEX,
     get_remote_digest_and_logindex,
+    is_container_tar_bundled,
 )
 
 # Check for updates at most every 12 hours.
@@ -155,10 +157,20 @@ def should_check_for_updates(settings: Settings) -> bool:
     if settings.get("updater_last_check") is None:
         log.debug("Dangerzone is running for the first time, updates are stalled")
         settings.set("updater_last_check", 0, autosave=True)
+        # If no container is bundled and none is installed, prompt the user
+        # to enable updates immediately, otherwise Dangerzone won't work.
+        if not is_container_tar_bundled() and not LAST_LOG_INDEX.exists():
+            log.debug("No container available, prompting user to enable updates")
+            raise errors.NeedUserInputNoContainer()
         return False
 
-    if check is None:
-        log.debug("User has not been asked yet for update checks")
+    if check is False or check is None:
+        if check is None:
+            log.debug("User has not been asked yet for update checks")
+
+        if not is_container_tar_bundled() and not is_container_image_installed():
+            log.debug("No container available, prompting user to enable updates")
+            raise errors.NeedUserInputNoContainer()
         raise errors.NeedUserInput()
     elif not check:
         log.debug("User has expressed that they don't want to check for updates")

--- a/dangerzone/updater/releases.py
+++ b/dangerzone/updater/releases.py
@@ -18,8 +18,8 @@ from ..settings import Settings
 from . import errors, log
 from .signatures import (
     DEFAULT_PUBKEY_LOCATION,
-    LAST_LOG_INDEX,
     get_remote_digest_and_logindex,
+    is_container_image_installed,
     is_container_tar_bundled,
 )
 
@@ -159,7 +159,7 @@ def should_check_for_updates(settings: Settings) -> bool:
         settings.set("updater_last_check", 0, autosave=True)
         # If no container is bundled and none is installed, prompt the user
         # to enable updates immediately, otherwise Dangerzone won't work.
-        if not is_container_tar_bundled() and not LAST_LOG_INDEX.exists():
+        if not is_container_tar_bundled() and not is_container_image_installed():
             log.debug("No container available, prompting user to enable updates")
             raise errors.NeedUserInputNoContainer()
         return False

--- a/dangerzone/updater/signatures.py
+++ b/dangerzone/updater/signatures.py
@@ -37,8 +37,9 @@ def appdata_dir() -> Path:
 def is_container_tar_bundled() -> bool:
     """Check if a container.tar file is bundled with this installation.
 
-    Some Dangerzone packages (e.g., dangerzone-slim) may not include a
-    bundled container image, requiring users to download it from the registry.
+    The default dangerzone package does not include a bundled container image,
+    requiring users to download it from the registry. The dangerzone-full
+    package includes the container.
     """
     return get_resource_path("container.tar").exists()
 

--- a/dangerzone/updater/signatures.py
+++ b/dangerzone/updater/signatures.py
@@ -47,6 +47,27 @@ def is_container_tar_bundled() -> bool:
 DEFAULT_PUBKEY_LOCATION = get_resource_path("freedomofpress-dangerzone.pub")
 SIGNATURES_PATH = appdata_dir() / "signatures"
 LAST_LOG_INDEX = SIGNATURES_PATH / "last_log_index"
+
+
+def is_container_image_installed() -> bool:
+    """Check if a Dangerzone container image is installed locally.
+
+    Both the LAST_LOG_INDEX state file and an actual image in Podman storage
+    must be present. The state file alone is not enough: Podman storage can
+    be wiped independently (e.g. `podman system reset`), leaving the file
+    behind without an image to run.
+    """
+    if not LAST_LOG_INDEX.exists():
+        return False
+    try:
+        return bool(runtime.list_image_digests())
+    except Exception:
+        # If we cannot reach Podman (not installed, machine not running, etc.),
+        # treat the image as missing. The caller will then prompt the user to
+        # download it, which will surface the real Podman issue if any.
+        return False
+
+
 DANGERZONE_MANIFEST = "dangerzone.json"
 
 

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,19 @@ Rules-Requires-Root: no
 
 Package: dangerzone
 Architecture: any
+Conflicts: dangerzone-full
 # The dependency to python3-socks is only present here because it's only useful on Tails.
 Depends: ${misc:Depends}, podman, python3, python3-pyside6.qtcore | python3-pyside2.qtcore, python3-pyside6.qtgui | python3-pyside2.qtgui, python3-pyside6.qtwidgets | python3-pyside2.qtwidgets, python3-pyside6.qtsvgwidgets | python3-pyside2.qtsvg, python3-platformdirs | python3-appdirs, python3-click, python3-xdg, python3-colorama, python3-requests, python3-socks, python3-markdown, python3-packaging, tesseract-ocr-all
 Description: Take potentially dangerous PDFs, office documents, or images
   Dangerzone is an open source desktop application that takes potentially dangerous PDFs, office documents, or images and converts them to safe PDFs. It uses disposable VMs on Qubes OS, or container technology in other OSes, to convert the documents within a secure sandbox.
   .
+
+Package: dangerzone-full
+Architecture: any
+Conflicts: dangerzone
+# The dependency to python3-socks is only present here because it's only useful on Tails.
+Depends: ${misc:Depends}, podman, python3, python3-pyside6.qtcore | python3-pyside2.qtcore, python3-pyside6.qtgui | python3-pyside2.qtgui, python3-pyside6.qtwidgets | python3-pyside2.qtwidgets, python3-pyside6.qtsvgwidgets | python3-pyside2.qtsvg, python3-platformdirs | python3-appdirs, python3-click, python3-xdg, python3-colorama, python3-requests, python3-socks, python3-markdown, python3-packaging, tesseract-ocr-all
+Description: Take potentially dangerous PDFs, office documents, or images (with bundled container)
+  Dangerzone is an open source desktop application that takes potentially dangerous PDFs, office documents, or images and converts them to safe PDFs. It uses disposable VMs on Qubes OS, or container technology in other OSes, to convert the documents within a secure sandbox.
+  .
+  This variant includes the container image bundled, so no download is required on first run.

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,19 @@ export DH_VERBOSE=1
 %:
 	dh $@ --with python3 --buildsystem=pybuild
 
+override_dh_install:
+	dh_install
+	# Populate the dangerzone-full staging directory from the slim one.
+	# Both packages are identical except dangerzone-full keeps container.tar.
+	cp -a debian/dangerzone/. debian/dangerzone-full/
+	# Explicitly install container.tar into dangerzone-full: pybuild does not
+	# include it because it is gitignored and absent from the build environment.
+	install -Dm 644 share/container.tar debian/dangerzone-full/usr/share/dangerzone/container.tar
+	rm -f debian/dangerzone/usr/share/dangerzone/container.tar
+
 override_dh_builddeb:
 	./install/linux/debian-vendor-pymupdf.py --dest debian/dangerzone/usr/lib/python3/dist-packages/dangerzone/vendor/
+	./install/linux/debian-vendor-pymupdf.py --dest debian/dangerzone-full/usr/lib/python3/dist-packages/dangerzone/vendor/
 	rm -f debian/dangerzone/usr/bin/dangerzone-machine
+	rm -f debian/dangerzone-full/usr/bin/dangerzone-machine
 	dh_builddeb $@

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,16 @@ export PYBUILD_INSTALL_ARGS=--install-lib=/usr/lib/python3/dist-packages
 export PYTHONDONTWRITEBYTECODE=1
 export DH_VERBOSE=1
 
+# Reproducible builds: pin the build epoch to the latest debian/changelog
+# entry (dpkg, debhelper, and dh_builddeb honor SOURCE_DATE_EPOCH for file
+# mtimes and archive metadata), and force a deterministic locale/timezone
+# so that any tool that emits sorted output or timestamps does so
+# identically across machines.
+# https://reproducible-builds.org/docs/source-date-epoch/
+export SOURCE_DATE_EPOCH ?= $(shell dpkg-parsechangelog -STimestamp)
+export LC_ALL=C.UTF-8
+export TZ=UTC
+
 %:
 	dh $@ --with python3 --buildsystem=pybuild
 
@@ -28,4 +38,10 @@ override_dh_builddeb:
 	./install/linux/debian-vendor-pymupdf.py --dest debian/dangerzone-full/usr/lib/python3/dist-packages/dangerzone/vendor/
 	rm -f debian/dangerzone/usr/bin/dangerzone-machine
 	rm -f debian/dangerzone-full/usr/bin/dangerzone-machine
+	# Clamp file mtimes in the staging trees to SOURCE_DATE_EPOCH so the
+	# resulting data.tar inside each .deb is byte-identical across builds.
+	# `install` and pybuild do not preserve mtimes, so without this step
+	# the .deb embeds the wall-clock time of the build.
+	find debian/dangerzone debian/dangerzone-full -exec \
+		touch --no-dereference --date=@$(SOURCE_DATE_EPOCH) {} +
 	dh_builddeb $@

--- a/debian/rules
+++ b/debian/rules
@@ -10,6 +10,11 @@ export DH_VERBOSE=1
 
 override_dh_install:
 	dh_install
+	# pybuild stages the dangerzone package and its console_scripts under
+	# debian/python3-dangerzone/. Since python3-dangerzone is not shipped
+	# as a binary package, fold its contents into debian/dangerzone/ so
+	# /usr/bin/dangerzone-* and the Python module land in the slim package.
+	cp -a debian/python3-dangerzone/. debian/dangerzone/
 	# Populate the dangerzone-full staging directory from the slim one.
 	# Both packages are identical except dangerzone-full keeps container.tar.
 	cp -a debian/dangerzone/. debian/dangerzone-full/

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -611,7 +611,7 @@ class Env:
         pkg_name = "dangerzone-full" if full else "dangerzone"
         if self.distro == "fedora":
             install_deps = DOCKERFILE_BUILD_FEDORA_DEPS
-            package_pattern = f"dangerzone-{version}-*.fc{self.version}.x86_64.rpm"
+            package_pattern = f"{pkg_name}-{version}-*.fc{self.version}.x86_64.rpm"
             package_src = self.find_dz_package(git_root() / "dist", package_pattern)
             package = package_src.name
             package_dst = build_dir / package
@@ -631,7 +631,7 @@ class Env:
                 "questing",
             ):
                 install_deps = DOCKERFILE_UBUNTU_REM_USER + DOCKERFILE_BUILD_DEBIAN_DEPS
-            package_pattern = f"dangerzone_{version}*_*.deb"
+            package_pattern = f"{pkg_name}_{version}*_*.deb"
             package_src = self.find_dz_package(git_root() / "deb_dist", package_pattern)
             package = package_src.name
             package_dst = build_dir / package

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -379,6 +379,19 @@ class Env:
             )
         return matches[0]
 
+    def image_exists_locally(self, image):
+        """Check if an image is available in the local container storage."""
+        try:
+            subprocess.run(
+                self.runtime_cmd + ["image", "inspect", image],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
     def runtime_run(self, *args):
         """Run a command for a specific container runtime.
 
@@ -478,6 +491,8 @@ class Env:
             f"{dist_state}/.bash_history:/home/user/.bash_history",
             "-v",
             f"{dist_state}/.local/share/dangerzone:/home/user/.local/share/dangerzone",
+            "-v",
+            f"{dist_state}/.config/dangerzone:/home/user/.config/dangerzone",
         ]
 
         run_cmd += ["-u", user]
@@ -488,10 +503,14 @@ class Env:
         # Select the proper container image based on whether the user wants to run the
         # command in a dev or end-user environment.
         if dev:
+            image = image_name_build_dev(self.distro, self.version)
+            if not dry and not self.image_exists_locally(image):
+                print(f"Dev image '{image}' not found locally, building it now.")
+                self.build_dev()
             run_cmd += [
                 "--hostname",
                 "dangerzone-dev",
-                image_name_build_dev(self.distro, self.version),
+                image,
             ]
         else:
             run_cmd += [
@@ -514,6 +533,7 @@ class Env:
         (dist_state / ".local" / "share" / "dangerzone").mkdir(
             parents=True, exist_ok=True
         )
+        (dist_state / ".config" / "dangerzone").mkdir(parents=True, exist_ok=True)
         (dist_state / ".bash_history").touch(exist_ok=True)
         self.runtime_run(*run_cmd)
 

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -602,11 +602,13 @@ class Env:
     def build(
         self,
         show_dockerfile=DEFAULT_SHOW_DOCKERFILE,
+        full=False,
     ):
         """Build a Linux environment and install Dangerzone in it."""
         build_dir = distro_build(self.distro, self.version)
         os.makedirs(build_dir, exist_ok=True)
         version = dz_version()
+        pkg_name = "dangerzone-full" if full else "dangerzone"
         if self.distro == "fedora":
             install_deps = DOCKERFILE_BUILD_FEDORA_DEPS
             package_pattern = f"dangerzone-{version}-*.fc{self.version}.x86_64.rpm"
@@ -690,6 +692,7 @@ def env_build(args):
     env = Env.from_args(args)
     return env.build(
         show_dockerfile=args.show_dockerfile,
+        full=args.full,
     )
 
 
@@ -791,6 +794,12 @@ def parse_args():
         default=DEFAULT_SHOW_DOCKERFILE,
         action="store_true",
         help="Do not build, only show the Dockerfile",
+    )
+    parser_build.add_argument(
+        "--full",
+        default=False,
+        action="store_true",
+        help="Install dangerzone-full package (with bundled container) instead of dangerzone",
     )
 
     return parser.parse_args()

--- a/docs/developer/doit.md
+++ b/docs/developer/doit.md
@@ -29,7 +29,7 @@ and you have ample disk space. You can run:
 
 ```bash
 doit clean --dry-run  # if you want to see what would happen
-doit clean  # you'll be asked to cofirm that you want to clean everything
+doit clean  # you'll be asked to confirm that you want to clean everything
 ```
 
 Finally, you can build all the release artifacts with `doit`, or a specific task

--- a/docs/developer/release/build.md
+++ b/docs/developer/release/build.md
@@ -173,10 +173,10 @@ poetry run dangerzone-image prepare-archive
     --image ghcr.io/freedomofpress/dangerzone/v1@sha256:${DIGEST}
     --output share/container.tar
 
-# Create the default .rpm:
+# Create the dangerzone .rpm (without container):
 ./dev_scripts/env.py --distro fedora --version 42 run --dev bash -c "cd dangerzone && ./install/linux/build-rpm.py"
-# Create the slim .rpm:
-./dev_scripts/env.py --distro fedora --version 42 run --dev bash -c "cd dangerzone && ./install/linux/build-rpm.py --slim"
+# Create the dangerzone-full .rpm (with container bundled):
+./dev_scripts/env.py --distro fedora --version 42 run --dev bash -c "cd dangerzone && ./install/linux/build-rpm.py --full"
 ```
 
 Publish the .rpms under `./dist` to the

--- a/docs/developer/release/build.md
+++ b/docs/developer/release/build.md
@@ -148,7 +148,7 @@ poetry run dangerzone-image prepare-archive
 ```
 
 Publish the .deb under `./deb_dist` to the
-[`freedomofpress/apt-tools-prod`](https://github.com/freedomofpress/apt-tools-prod)
+[`freedomofpress/packages`](https://github.com/freedomofpress/packages)
 repo, by sending a PR. Follow the instructions in that repo on how to do so.
 
 #### Fedora
@@ -180,7 +180,7 @@ poetry run dangerzone-image prepare-archive
 ```
 
 Publish the .rpms under `./dist` to the
-[`freedomofpress/yum-tools-prod`](https://github.com/freedomofpress/yum-tools-prod) repo, by sending a PR. Follow the instructions in that repo on how to do so.
+[`freedomofpress/packages`](https://github.com/freedomofpress/packages) repo, by sending a PR. Follow the instructions in that repo on how to do so.
 
 #### Qubes
 
@@ -190,4 +190,4 @@ Create a `.rpm` for Qubes:
 ./dev_scripts/env.py --distro fedora --version 42 run --dev bash -c "cd dangerzone && ./install/linux/build-rpm.py --qubes"
 ```
 
-and similarly publish it to the [`freedomofpress/yum-tools-prod`](https://github.com/freedomofpress/yum-tools-prod) repo.
+and similarly publish it to the [`freedomofpress/packages`](https://github.com/freedomofpress/packages) repo.

--- a/docs/developer/release/build.md
+++ b/docs/developer/release/build.md
@@ -173,11 +173,13 @@ poetry run dangerzone-image prepare-archive
     --image ghcr.io/freedomofpress/dangerzone/v1@sha256:${DIGEST}
     --output share/container.tar
 
-# Create a .rpm:
+# Create the default .rpm:
 ./dev_scripts/env.py --distro fedora --version 42 run --dev bash -c "cd dangerzone && ./install/linux/build-rpm.py"
+# Create the slim .rpm:
+./dev_scripts/env.py --distro fedora --version 42 run --dev bash -c "cd dangerzone && ./install/linux/build-rpm.py --slim"
 ```
 
-Publish the .rpm under `./dist` to the
+Publish the .rpms under `./dist` to the
 [`freedomofpress/yum-tools-prod`](https://github.com/freedomofpress/yum-tools-prod) repo, by sending a PR. Follow the instructions in that repo on how to do so.
 
 #### Qubes

--- a/docs/developer/release/build.md
+++ b/docs/developer/release/build.md
@@ -143,11 +143,15 @@ poetry run dangerzone-image prepare-archive
     --image ghcr.io/freedomofpress/dangerzone/v1@sha256:${DIGEST}
     --output share/container.tar
 
-# Create a .deb
+# Create both .deb packages (dangerzone slim + dangerzone-full)
 ./dev_scripts/env.py --distro debian --version bookworm run --dev bash -c "cd dangerzone && ./install/linux/build-deb.py"
 ```
 
-Publish the .deb under `./deb_dist` to the
+A single `build-deb.py` invocation produces both `dangerzone_<version>_amd64.deb`
+(slim, no bundled `container.tar`) and `dangerzone-full_<version>_amd64.deb`
+(with the container image bundled) under `./deb_dist`.
+
+Publish both `.deb` files under `./deb_dist` to the
 [`freedomofpress/packages`](https://github.com/freedomofpress/packages)
 repo, by sending a PR. Follow the instructions in that repo on how to do so.
 
@@ -179,8 +183,10 @@ poetry run dangerzone-image prepare-archive
 ./dev_scripts/env.py --distro fedora --version 42 run --dev bash -c "cd dangerzone && ./install/linux/build-rpm.py --full"
 ```
 
-Publish the .rpms under `./dist` to the
-[`freedomofpress/packages`](https://github.com/freedomofpress/packages) repo, by sending a PR. Follow the instructions in that repo on how to do so.
+Publish both `dangerzone-<version>.fc<NN>.x86_64.rpm` (slim) and
+`dangerzone-full-<version>.fc<NN>.x86_64.rpm` (bundled container) under `./dist`
+to the [`freedomofpress/packages`](https://github.com/freedomofpress/packages)
+repo, by sending a PR. Follow the instructions in that repo on how to do so.
 
 #### Qubes
 

--- a/docs/developer/release/release.md
+++ b/docs/developer/release/release.md
@@ -49,7 +49,7 @@ When confident that the release doesn't need any more changes:
 
 To actually publish the release:
 
-- [ ] Merge the PRs in the [`apt-tools-prod`](https://github.com/freedomofpress/apt-tools-prod/pulls) and [`yum-tools-prod`](https://github.com/freedomofpress/yum-tools-prod/pulls) repos.
+- [ ] Merge the PR(s) in the [`packages`](https://github.com/freedomofpress/packages/pulls) repository.
 - [ ] Make the GitHub draft release public.
 - [ ] Merge the PRs in [`dangerzone.rocks`](https://github.com/freedomofpress/dangerzone.rocks/pulls) and `[dangerzone](https://github.com/freedomofpress/dangerzone/pulls)`.
 - [ ] Toot release announcement on our mastodon account https://social.freedom.press/@dangerzone

--- a/docs/developer/reproducibility.md
+++ b/docs/developer/reproducibility.md
@@ -12,6 +12,59 @@ Our build artifacts consist of:
 - Fedora packages (for regular Fedora distros and Qubes)
 - Debian packages (for Debian and Ubuntu)
 
-As of writing this, only the following artifacts are reproducible:
+As of writing this, the following artifacts are reproducible:
 
 - Container images (see [#1047](https://github.com/freedomofpress/dangerzone/issues/1047)). You can find a detailed documentation on reproducible containers in the [dangerzone-image repository](https://github.com/freedomofpress/dangerzone-image).
+- Debian packages (`dangerzone` and `dangerzone-full`).
+
+## Debian packages
+
+Building the `.deb` files inside our pinned Debian Bookworm dev container
+(`./dev_scripts/env.py --distro debian --version bookworm`) and via
+`./install/linux/build-deb.py` produces byte-identical packages on every run,
+given the same source tree and the same `share/container.tar`.
+
+The mechanisms that make this work:
+
+- **`SOURCE_DATE_EPOCH`** is pinned to the timestamp of the latest
+  `debian/changelog` entry. `dpkg-source`, `dpkg-deb`, and `dh_builddeb` use
+  this value for file mtimes inside the source tarball and the binary `.deb`,
+  and for the `Date` field in `.changes` / `.dsc` files. The value is set by
+  `debian/rules` (so it's correct even when invoking `dpkg-buildpackage`
+  directly) and re-asserted by `install/linux/build-deb.py`.
+- **Locale and timezone** are forced to `C.UTF-8` / `UTC`, so any tool that
+  emits sorted output or formatted timestamps does so identically across
+  machines.
+- **File mtimes are clamped** to `SOURCE_DATE_EPOCH` after `dh_install`
+  populates the staging trees. `install` and pybuild do not preserve
+  timestamps, so without this step the embedded `data.tar` would carry the
+  wall-clock time of the build.
+- **The build environment is pinned** via the Debian Bookworm dev container,
+  which fixes the versions of `dpkg`, `debhelper`, `pybuild`, and the Python
+  interpreter that participate in the build.
+
+### Verifying reproducibility
+
+To confirm a `.deb` is reproducible, build it twice in clean environments and
+compare the outputs:
+
+```bash
+# First build
+./dev_scripts/env.py --distro debian --version bookworm run --dev bash -c \
+    "cd dangerzone && ./install/linux/build-deb.py"
+mv deb_dist deb_dist.first
+
+# Clean and build again
+git clean -fdx debian/ deb_dist/
+./dev_scripts/env.py --distro debian --version bookworm run --dev bash -c \
+    "cd dangerzone && ./install/linux/build-deb.py"
+
+# Compare
+sha256sum deb_dist.first/*.deb deb_dist/*.deb
+# For a deeper diff if hashes differ:
+#   diffoscope deb_dist.first/dangerzone_<ver>_amd64.deb deb_dist/dangerzone_<ver>_amd64.deb
+```
+
+The two sets of `.deb` files should have matching SHA-256 sums. If they don't,
+`diffoscope` will show what diverged — common culprits are unpinned timestamps,
+locale-dependent sort order, or files generated outside the staging trees.

--- a/dodo.py
+++ b/dodo.py
@@ -84,13 +84,13 @@ def create_release_dir():
     (RELEASE_DIR / "tmp").mkdir(exist_ok=True)
 
 
-def prepare_dz_dir(dz_dir, slim=False):
+def prepare_dz_dir(dz_dir, full=False):
     """Prepare a Git repo for building artifacts.
 
     This function creates a pristine Dangerzone repo out of the local one, by copying
     the Git repo, and doing the following actions on the new directory:
     1. Clean untracked files with `git clean -fdx`
-    2. Copy the container image under `share/container.tar` (unless slim=True)
+    2. Copy the container image under `share/container.tar` (only if full=True)
     3. Install the GitHub assets for this platform
 
     The above actions should be quite fast, because they just copy files around. That
@@ -106,7 +106,7 @@ def prepare_dz_dir(dz_dir, slim=False):
         (copy_dir, [".", dz_dir]),
         f"cd {dz_dir} && git clean -fdx",
     ]
-    if not slim:
+    if full:
         actions.append(["cp", img_src, img_dst])
     actions.append(
         [
@@ -123,7 +123,7 @@ def prepare_dz_dir(dz_dir, slim=False):
     return actions
 
 
-def build_linux_pkg(distro, version, cwd, qubes=False, slim=False):
+def build_linux_pkg(distro, version, cwd, qubes=False, full=False):
     """Generic command for building a .deb/.rpm in a Dangerzone dev environment."""
     pkg = "rpm" if distro == "fedora" else "deb"
     cmd = [
@@ -140,19 +140,25 @@ def build_linux_pkg(distro, version, cwd, qubes=False, slim=False):
     ]
     if qubes:
         cmd += ["--qubes"]
-    if slim:
-        cmd += ["--slim"]
+    if full:
+        cmd += ["--full"]
     return CmdAction(" ".join(cmd), cwd=cwd)
 
 
-def build_deb(cwd, slim=False):
-    """Build a .deb package on Debian Bookworm."""
-    return build_linux_pkg(distro="debian", version="bookworm", cwd=cwd, slim=slim)
+def build_deb(cwd):
+    """Build a .deb package on Debian Bookworm.
+
+    A single dpkg-buildpackage run produces both the dangerzone (slim) and
+    dangerzone-full .debs from the same source tree (see debian/control).
+    """
+    return build_linux_pkg(distro="debian", version="bookworm", cwd=cwd)
 
 
-def build_rpm(version, cwd, qubes=False, slim=False):
+def build_rpm(version, cwd, qubes=False, full=False):
     """Build an .rpm package on the requested Fedora distro."""
-    return build_linux_pkg(distro="fedora", version=version, cwd=cwd, qubes=qubes, slim=slim)
+    return build_linux_pkg(
+        distro="fedora", version=version, cwd=cwd, qubes=qubes, full=full
+    )
 
 
 ### Tasks
@@ -287,42 +293,32 @@ def task_debian_env():
 
 
 def task_debian_deb():
-    """Build Debian packages for Debian Bookworm."""
-    for slim in (False, True):
-        slim_ident = "-slim" if slim else ""
-        slim_desc = " (slim)" if slim else ""
-        dz_dir = RELEASE_DIR / "tmp" / f"debian{slim_ident}"
-        pkg_name = f"dangerzone{slim_ident}"
+    """Build Debian Bookworm packages (slim + full)."""
+    dz_dir = RELEASE_DIR / "tmp" / "debian"
+    targets = []
+    copy_actions = []
+    for pkg_name in ("dangerzone", "dangerzone-full"):
         deb_name = f"{pkg_name}_{VERSION}-1_amd64.deb"
-        deb_src = dz_dir / "deb_dist" / deb_name
-        deb_dst = RELEASE_DIR / deb_name
+        targets.append(RELEASE_DIR / deb_name)
+        copy_actions.append(["cp", dz_dir / "deb_dist" / deb_name, RELEASE_DIR / deb_name])
 
-        task_deps = [
+    return {
+        "actions": [
+            *prepare_dz_dir(dz_dir, full=True),
+            build_deb(cwd=dz_dir),
+            *copy_actions,
+            ["rm", "-rf", dz_dir],
+        ],
+        "file_dep": DEB_DEPS,
+        "task_dep": [
             "init_release_dir",
             "poetry_install",
             "debian_env",
-        ]
-        if not slim:
-            task_deps.append("download_image")
-        else:
-            # Ensure slim build doesn't run in parallel with default build,
-            # as both modify the same debian/ files during the build process.
-            task_deps.append("debian_deb:default")
-
-        yield {
-            "name": "slim" if slim else "default",
-            "doc": f"Build a Debian Bookworm package{slim_desc}",
-            "actions": [
-                *prepare_dz_dir(dz_dir, slim=slim),
-                build_deb(cwd=dz_dir, slim=slim),
-                ["cp", deb_src, deb_dst],
-                ["rm", "-rf", dz_dir],
-            ],
-            "file_dep": DEB_DEPS,
-            "task_dep": task_deps,
-            "targets": [deb_dst],
-            "clean": True,
-        }
+            "download_image",
+        ],
+        "targets": targets,
+        "clean": True,
+    }
 
 
 def task_fedora_env():
@@ -348,18 +344,18 @@ def task_fedora_env():
 
 def task_fedora_rpm():
     """Build Fedora packages for every supported version."""
-    # Build variants: regular, qubes, and slim (slim and qubes are mutually exclusive)
+    # Build variants: regular, qubes, and full (full and qubes are mutually exclusive)
     variants = [
-        {"qubes": False, "slim": False},
-        {"qubes": True, "slim": False},
-        {"qubes": False, "slim": True},
+        {"qubes": False, "full": False},
+        {"qubes": True, "full": False},
+        {"qubes": False, "full": True},
     ]
     for version in FEDORA_VERSIONS:
         for variant in variants:
             qubes = variant["qubes"]
-            slim = variant["slim"]
-            variant_ident = "-qubes" if qubes else ("-slim" if slim else "")
-            variant_desc = " for Qubes" if qubes else (" (slim)" if slim else "")
+            full = variant["full"]
+            variant_ident = "-qubes" if qubes else ("-full" if full else "")
+            variant_desc = " for Qubes" if qubes else (" (full)" if full else "")
             dz_dir = RELEASE_DIR / "tmp" / f"f{version}{variant_ident}"
             rpm_names = [
                 f"dangerzone{variant_ident}-{VERSION}-1.fc{version}.x86_64.rpm",
@@ -373,15 +369,15 @@ def task_fedora_rpm():
                 "poetry_install",
                 f"fedora_env:{version}",
             ]
-            if not slim:
+            if full:
                 task_deps.append("download_image")
 
             yield {
                 "name": version + variant_ident,
                 "doc": f"Build a Fedora {version} package{variant_desc}",
                 "actions": [
-                    *prepare_dz_dir(dz_dir, slim=slim),
-                    build_rpm(version, cwd=dz_dir, qubes=qubes, slim=slim),
+                    *prepare_dz_dir(dz_dir, full=full),
+                    build_rpm(version, cwd=dz_dir, qubes=qubes, full=full),
                     ["cp", *rpm_src, RELEASE_DIR],
                     ["rm", "-rf", dz_dir],
                 ],

--- a/dodo.py
+++ b/dodo.py
@@ -300,7 +300,9 @@ def task_debian_deb():
     for pkg_name in ("dangerzone", "dangerzone-full"):
         deb_name = f"{pkg_name}_{VERSION}-1_amd64.deb"
         targets.append(RELEASE_DIR / deb_name)
-        copy_actions.append(["cp", dz_dir / "deb_dist" / deb_name, RELEASE_DIR / deb_name])
+        copy_actions.append(
+            ["cp", dz_dir / "deb_dist" / deb_name, RELEASE_DIR / deb_name]
+        )
 
     return {
         "actions": [

--- a/install/linux/build-deb.py
+++ b/install/linux/build-deb.py
@@ -46,28 +46,36 @@ def main():
     if os.path.exists(deb_dist_path):
         shutil.rmtree(deb_dist_path)
 
-    print("* Building DEB package")
+    container_tar = root / "share" / "container.tar"
+    if not container_tar.exists():
+        sys.exit(
+            "Error: share/container.tar is required to build the dangerzone-full"
+            " package. Run: dangerzone-image prepare-archive --output share/container.tar"
+        )
+
+    print("* Building DEB packages")
     if args.distro is None:
         deb_ver = "1"
     else:
         deb_ver = args.distro
 
-    run(
-        [
-            "dpkg-buildpackage",
-        ]
-    )
+    # A single dpkg-buildpackage run produces both the dangerzone (slim) and
+    # dangerzone-full packages. The debian/rules file handles stripping
+    # container.tar from the slim package's staging directory.
+    run(["dpkg-buildpackage"])
 
     os.makedirs(deb_dist_path, exist_ok=True)
     print("")
     print("* To install run:")
 
-    # dpkg-buildpackage produces a .deb file in the parent folder
-    # that needs to be copied to the `deb_dist` folder manually
-    src = root.parent / f"dangerzone_{version}_amd64.deb"
-    destination = root / "deb_dist" / f"dangerzone_{version}-{deb_ver}_amd64.deb"
-    shutil.move(src, destination)
-    print(f"sudo dpkg -i {destination}")
+    # dpkg-buildpackage produces .deb files in the parent folder
+    # that need to be copied to the `deb_dist` folder manually
+    for pkg_name in ["dangerzone", "dangerzone-full"]:
+        src = root.parent / f"{pkg_name}_{version}_amd64.deb"
+        if src.exists():
+            destination = deb_dist_path / f"{pkg_name}_{version}-{deb_ver}_amd64.deb"
+            shutil.move(src, destination)
+            print(f"sudo dpkg -i {destination}")
 
 
 if __name__ == "__main__":

--- a/install/linux/build-deb.py
+++ b/install/linux/build-deb.py
@@ -16,8 +16,24 @@ with open(root / "share" / "version.txt") as f:
     version = f.read().strip()
 
 
-def run(cmd):
-    subprocess.run(cmd, cwd=root, check=True)
+def run(cmd, env=None):
+    subprocess.run(cmd, cwd=root, check=True, env=env)
+
+
+def source_date_epoch():
+    """Return a deterministic build timestamp from debian/changelog.
+
+    dpkg, debhelper, and the .deb tooling all honor SOURCE_DATE_EPOCH for
+    file mtimes and archive metadata, which is what makes the resulting
+    package byte-identical across builds. The latest changelog entry is
+    the conventional source for this value.
+    """
+    out = subprocess.check_output(
+        ["dpkg-parsechangelog", "--show-field", "Timestamp"],
+        cwd=root,
+        text=True,
+    )
+    return out.strip()
 
 
 def main():
@@ -62,7 +78,14 @@ def main():
     # A single dpkg-buildpackage run produces both the dangerzone (slim) and
     # dangerzone-full packages. The debian/rules file handles stripping
     # container.tar from the slim package's staging directory.
-    run(["dpkg-buildpackage"])
+    #
+    # Pin SOURCE_DATE_EPOCH, locale, and timezone so the build is
+    # reproducible: identical inputs produce byte-identical .deb files.
+    env = os.environ.copy()
+    env.setdefault("SOURCE_DATE_EPOCH", source_date_epoch())
+    env["LC_ALL"] = "C.UTF-8"
+    env["TZ"] = "UTC"
+    run(["dpkg-buildpackage"], env=env)
 
     os.makedirs(deb_dist_path, exist_ok=True)
     print("")

--- a/install/linux/build-rpm.py
+++ b/install/linux/build-rpm.py
@@ -36,7 +36,7 @@ def exclude_paths(paths):
                 backup.rename(path)
 
 
-def build(build_dir, qubes=False, slim=False):
+def build(build_dir, qubes=False, full=False):
     """Build an RPM package in a temporary directory.
 
     The build process is the following:
@@ -47,10 +47,11 @@ def build(build_dir, qubes=False, slim=False):
        (default: ~/rpmbuild), and use symlinks to point to ./dist, so that we don't need
        to move files explicitly.
     3. Create a Python source distribution using `poetry build`. If we are building a
-       Qubes package and there is a container image under `share/`, stash it temporarily
-       under a different directory.
+       Qubes package, stash the container image and vendor folder temporarily. For the
+       default package, stash the container image. For the full package, include
+       the container image.
     4. Build both binary and source RPMs using rpmbuild. Optionally, pass to the SPEC
-        `_qubes` flag, that denotes we want to build a package for Qubes.
+        `_qubes` or `_full` flag.
     """
     dist_path = root / "dist"
     specfile_name = "dangerzone.spec"
@@ -58,11 +59,31 @@ def build(build_dir, qubes=False, slim=False):
     sdist_name = f"dangerzone-{version}.tar.gz"
     sdist_path = dist_path / sdist_name
 
-    print("* Deleting old dist")
-    if os.path.exists(dist_path):
-        remove_contents(dist_path)
+    print("* Deleting old dist for this variant")
+    dist_path.mkdir(exist_ok=True)
+    if full:
+        variant_prefix = "dangerzone-full-"
+    elif qubes:
+        variant_prefix = "dangerzone-qubes-"
     else:
-        dist_path.mkdir()
+        variant_prefix = "dangerzone-"
+    other_prefixes = {
+        "dangerzone-": ("dangerzone-full-", "dangerzone-qubes-"),
+        "dangerzone-full-": (),
+        "dangerzone-qubes-": (),
+    }[variant_prefix]
+    # Wipe stale outputs for the variant we are about to rebuild, but leave
+    # other variants alone so a slim+full build sequence doesn't lose the
+    # first artifact. The sdist tarball is shared and gets unlinked below.
+    for p in dist_path.iterdir():
+        if not p.name.startswith(variant_prefix) and p.name != sdist_name:
+            continue
+        if any(p.name.startswith(o) for o in other_prefixes):
+            continue
+        if p.is_file() or p.is_symlink():
+            p.unlink()
+        else:
+            shutil.rmtree(p)
 
     print(f"* Creating RPM project structure under {build_dir}")
     build_dir.mkdir(exist_ok=True)
@@ -85,11 +106,12 @@ def build(build_dir, qubes=False, slim=False):
             root / "share" / "container.tar",
             root / "share" / "vendor",
         ]
-
-    if slim:
+    elif not full:
+        # Default package: exclude container.tar
         excluded_paths += [
             root / "share" / "container.tar",
         ]
+    # Full package: include container.tar (don't exclude it)
 
     with exclude_paths(excluded_paths):
         subprocess.run(["poetry", "build", "-f", "sdist"], cwd=root, check=True)
@@ -117,10 +139,10 @@ def build(build_dir, qubes=False, slim=False):
             "--define",
             "_qubes 1",
         ]
-    if slim:
+    if full:
         cmd += [
             "--define",
-            "_slim 1",
+            "_full 1",
         ]
     subprocess.run(cmd, check=True)
 
@@ -135,7 +157,9 @@ def main():
         "--qubes", action="store_true", help="Build RPM package for a Qubes OS system"
     )
     parser.add_argument(
-        "--slim", action="store_true", help="Build RPM package without container.tar"
+        "--full",
+        action="store_true",
+        help="Build RPM package with container.tar bundled",
     )
     parser.add_argument(
         "--build-dir",
@@ -144,7 +168,7 @@ def main():
     )
     args = parser.parse_args()
 
-    build(args.build_dir, args.qubes, args.slim)
+    build(args.build_dir, args.qubes, args.full)
 
 
 if __name__ == "__main__":

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -28,8 +28,8 @@
 
 %if 0%{?_qubes}
 Name:           dangerzone-qubes
-%elif 0%{?_slim}
-Name:           dangerzone-slim
+%elif 0%{?_full}
+Name:           dangerzone-full
 %else
 Name:           dangerzone
 %endif
@@ -57,19 +57,19 @@ Source0:        https://github.com/freedomofpress/dangerzone/archive/refs/tags/v
 
 %if 0%{?_qubes}
 # Users who install Dangerzone with native Qubes support must uninstall
-# Dangerzone with container support.
+# Dangerzone default or full packages.
 Conflicts:      dangerzone
-Conflicts:      dangerzone-slim
-%elif 0%{?_slim}
-# Users who install Dangerzone slim must uninstall
-# Dangerzone with native Qubes support and container support.
+Conflicts:      dangerzone-full
+%elif 0%{?_full}
+# Users who install Dangerzone full must uninstall
+# Dangerzone with native Qubes support and the default package.
 Conflicts:      dangerzone
 Conflicts:      dangerzone-qubes
 %else
-# Users who install Dangerzone with container support must uninstall Dangerzone
-# with native Qubes support.
+# Users who install Dangerzone (default) must uninstall Dangerzone
+# with native Qubes support or the full package.
 Conflicts:      dangerzone-qubes
-Conflicts:      dangerzone-slim
+Conflicts:      dangerzone-full
 %endif
 
 ################################################################################

--- a/install/linux/dangerzone.spec
+++ b/install/linux/dangerzone.spec
@@ -28,6 +28,8 @@
 
 %if 0%{?_qubes}
 Name:           dangerzone-qubes
+%elif 0%{?_slim}
+Name:           dangerzone-slim
 %else
 Name:           dangerzone
 %endif
@@ -57,10 +59,17 @@ Source0:        https://github.com/freedomofpress/dangerzone/archive/refs/tags/v
 # Users who install Dangerzone with native Qubes support must uninstall
 # Dangerzone with container support.
 Conflicts:      dangerzone
+Conflicts:      dangerzone-slim
+%elif 0%{?_slim}
+# Users who install Dangerzone slim must uninstall
+# Dangerzone with native Qubes support and container support.
+Conflicts:      dangerzone
+Conflicts:      dangerzone-qubes
 %else
 # Users who install Dangerzone with container support must uninstall Dangerzone
 # with native Qubes support.
 Conflicts:      dangerzone-qubes
+Conflicts:      dangerzone-slim
 %endif
 
 ################################################################################
@@ -77,7 +86,7 @@ Requires:       libreoffice
 # Qubes-only dependency, to install a single RPM package in the Fedora template.
 Requires:       dangerzone-insecure-converter-qubes
 %else
-# Container-only requirements
+# Container-only or -slim requirements
 Requires:       podman
 %endif
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,14 +37,16 @@ TAMPERED_SIGNATURES_PATH = ASSETS_PATH / "signatures" / "tampered"
 
 @pytest.fixture(autouse=True)
 def isolated_settings(mocker: MockerFixture, tmp_path: Path) -> Settings:
+    # Reset the singleton before constructing a new instance, so each test gets
+    # a fresh Settings tied to its own tmp_path. Without this, Settings() may
+    # return a stale instance from a previous test.
+    Settings._singleton = None
     mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
     return Settings()
 
 
 @pytest.fixture(autouse=True)
 def setup_function() -> Generator[None, None, None]:
-    # Reset the settings singleton between each test.
-    Settings._singleton = None
     container_utils.init_podman_command.cache_clear()
     yield
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -727,6 +727,8 @@ def test_installation_strategy_message(
 
     # Disable the user prompt for remote container downloads in this test
     window.dangerzone.settings.set("updater_ask_before_download", False)
+    # Do not make any Podman calls in this test, because we have not set it up.
+    mocker.patch("dangerzone.gui.startup.runtime.list_image_digests", return_value=[])
 
     status_bar_message_spy = mocker.spy(window.status_bar, callback)
     log_window_message_spy = mocker.spy(window.log_window, callback)
@@ -1202,12 +1204,8 @@ def test_handle_needs_user_input_install_remote_container(
     )
     mock_install = mocker.patch("dangerzone.updater.installer.install")
     # The prompt is only shown when no container is available locally.
-    mocker.patch(
-        "dangerzone.gui.startup.is_container_tar_bundled", return_value=False
-    )
-    mocker.patch(
-        "dangerzone.gui.startup.runtime.list_image_digests", return_value=[]
-    )
+    mocker.patch("dangerzone.gui.startup.is_container_tar_bundled", return_value=False)
+    mocker.patch("dangerzone.gui.startup.runtime.list_image_digests", return_value=[])
 
     # Mock the Question dialog - user accepts downloading
     mock_question = mocker.patch("dangerzone.gui.main_window.Question")
@@ -1243,12 +1241,8 @@ def test_handle_needs_user_input_install_remote_container_decline(
         return_value=InstallationStrategy.INSTALL_REMOTE_CONTAINER,
     )
     mock_install = mocker.patch("dangerzone.updater.installer.install")
-    mocker.patch(
-        "dangerzone.gui.startup.is_container_tar_bundled", return_value=False
-    )
-    mocker.patch(
-        "dangerzone.gui.startup.runtime.list_image_digests", return_value=[]
-    )
+    mocker.patch("dangerzone.gui.startup.is_container_tar_bundled", return_value=False)
+    mocker.patch("dangerzone.gui.startup.runtime.list_image_digests", return_value=[])
 
     # Mock the Question dialog - user declines downloading
     mock_question = mocker.patch("dangerzone.gui.main_window.Question")
@@ -1284,12 +1278,8 @@ def test_handle_needs_user_input_install_remote_container_checkbox(
         return_value=InstallationStrategy.INSTALL_REMOTE_CONTAINER,
     )
     mock_install = mocker.patch("dangerzone.updater.installer.install")
-    mocker.patch(
-        "dangerzone.gui.startup.is_container_tar_bundled", return_value=False
-    )
-    mocker.patch(
-        "dangerzone.gui.startup.runtime.list_image_digests", return_value=[]
-    )
+    mocker.patch("dangerzone.gui.startup.is_container_tar_bundled", return_value=False)
+    mocker.patch("dangerzone.gui.startup.runtime.list_image_digests", return_value=[])
 
     # Mock the Question dialog - user accepts and checks "always download"
     mock_question = mocker.patch("dangerzone.gui.main_window.Question")

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -825,6 +825,12 @@ def test_close_event(
 )
 def test_user_prompts(qtbot: QtBot, window: MainWindow, mocker: MockerFixture) -> None:
     """Test prompting users to ask them if they want to enable update checks."""
+    # Mock is_container_tar_bundled to return True so we don't trigger the
+    # "no container available" code path (which has different behavior).
+    mocker.patch(
+        "dangerzone.updater.releases.is_container_tar_bundled", return_value=True
+    )
+
     # First run
     #
     # When Dangerzone runs for the first time, users should not be asked to enable
@@ -862,6 +868,15 @@ def test_user_prompts(qtbot: QtBot, window: MainWindow, mocker: MockerFixture) -
     qtbot.waitUntil(handle_needs_user_input_spy.assert_called_once)
     assert window.dangerzone.settings.get_updater_settings() == expected_settings
 
+    # Verify that prompt was called with download_required=False
+    prompt_mock.assert_called()
+    call_kwargs = prompt_mock.call_args
+    # The prompt is called with positional args (dangerzone, message=..., ok_text=..., cancel_text=...)
+    # We check the message to verify it's not no-container mode
+    assert "Enable automatic sandbox updates?" in call_kwargs.kwargs.get(
+        "message", call_kwargs[1].get("message", "")
+    )
+
     # Reset the "updater_check_all" field and check enabling update checks.
     window.dangerzone.settings.set("updater_check_all", None)
     prompt_mock().launch.return_value = True
@@ -882,6 +897,89 @@ def test_user_prompts(qtbot: QtBot, window: MainWindow, mocker: MockerFixture) -
     for check in [True, False]:
         window.dangerzone.settings.set("updater_check_all", check)
         assert releases.should_check_for_updates(window.dangerzone.settings) == check
+
+
+def test_user_prompts_no_container(
+    qtbot: QtBot, window: MainWindow, mocker: MockerFixture
+) -> None:
+    """Test prompting users when no container is available (download required)."""
+    # Mock is_container_tar_bundled to return False (no bundled container)
+    mocker.patch(
+        "dangerzone.updater.releases.is_container_tar_bundled", return_value=False
+    )
+    # Mock LAST_LOG_INDEX to be a mock Path that returns False for exists()
+    mock_last_log_index = mocker.MagicMock()
+    mock_last_log_index.exists.return_value = False
+    mocker.patch("dangerzone.updater.signatures.LAST_LOG_INDEX", mock_last_log_index)
+
+    # Only run the UpdateCheckTask
+    for task in window.startup_thread.tasks:
+        if not isinstance(task, startup.UpdateCheckTask):
+            mocker.patch.object(task, "should_skip", return_value=True)
+
+    # Mock the prompt
+    prompt_mock = mocker.patch("dangerzone.gui.updater.UpdateCheckPrompt")
+    prompt_mock().x_pressed = False
+
+    # Scenario 1: User accepts download
+    prompt_mock().launch.return_value = True
+
+    handle_download_spy = mocker.spy(
+        window, "handle_needs_user_input_download_container"
+    )
+
+    window.startup_thread.start()
+    qtbot.waitUntil(handle_download_spy.assert_called_once)
+    window.startup_thread.wait()
+
+    # User accepted, so updater_check_all should be True
+    assert window.dangerzone.settings.get("updater_check_all") is True
+
+    # Verify that prompt was called with download message
+    prompt_mock.assert_called()
+    call_kwargs = prompt_mock.call_args
+    assert "Download conversion sandbox?" in call_kwargs.kwargs.get(
+        "message", call_kwargs[1].get("message", "")
+    )
+
+    # Reset for scenario 2
+    window.dangerzone.settings.set("updater_check_all", None)
+    window.dangerzone.settings.set("updater_last_check", None)
+    handle_download_spy.reset_mock()
+
+    # Scenario 2: User declines download
+    prompt_mock().launch.return_value = False
+
+    # Mock exit to prevent actually quitting the app
+    mock_exit = mocker.patch.object(window, "exit")
+
+    window.startup_thread.start()
+    qtbot.waitUntil(handle_download_spy.assert_called_once)
+
+    # Give the QTimer a chance to fire
+    qtbot.wait(100)
+
+    # User declined, exit should be triggered
+    mock_exit.assert_called_once_with(2)
+
+    # Reset for scenario 3
+    window.dangerzone.settings.set("updater_check_all", None)
+    window.dangerzone.settings.set("updater_last_check", None)
+    handle_download_spy.reset_mock()
+    mock_exit.reset_mock()
+
+    # Scenario 3: User presses X (dismisses)
+    prompt_mock().launch.return_value = None
+    prompt_mock().x_pressed = True
+
+    window.startup_thread.start()
+    qtbot.waitUntil(handle_download_spy.assert_called_once)
+
+    # Give the QTimer a chance to fire
+    qtbot.wait(100)
+
+    # User dismissed, exit should also be triggered
+    mock_exit.assert_called_once_with(2)
 
 
 def test_machine_stop_others_user_input(

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1246,6 +1246,17 @@ def test_wsl_install_failed_user_input(
             True,  # the download should happen
             False,  # and the user must not be asked again
         ),
+        # If they decline and at the same time click on the "Always download" checkbox,
+        # do not download anything and don't store their decision.
+        (
+            False,
+            ["some_image"],  # an image is already downloaded
+            True,  # so the user must be prompted
+            True,  # and if they choose to always download updates
+            False,  # but do NOT accept this one
+            True,  # the download should NOT happen
+            True,  # and the user MUST be asked again
+        ),
     ],
 )
 def test_handle_needs_user_input_install_remote_container(
@@ -1254,7 +1265,7 @@ def test_handle_needs_user_input_install_remote_container(
     window: MainWindow,
     is_tar_bundled: bool,
     image_list: List[str],
-    expect_question,
+    expect_question: bool,
     checkbox_user_choice: bool,
     download_user_choice: bool,
     expect_download: bool,

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1194,8 +1194,71 @@ def test_wsl_install_failed_user_input(
     assert not window.conversion_widget.isVisible()
 
 
+@pytest.mark.parametrize(
+    "is_tar_bundled,"  # if there is a bundled tarball along with the installer
+    "image_list,"  # if there are Dangerzone images present
+    "expect_question,"  # whether the user was prompted to download an image
+    "checkbox_user_choice,"  # whether the user clicked on the "Always download..." checkbox
+    "download_user_choice,"  # whether the user accepted the download or not
+    "expect_download,"  # whether Dangerzone downloaded the image
+    "expect_ask_again,",
+    [  # whether Dangerzone will always again to download updates
+        # If there is no container image present, the download must be forced, even if
+        # the default is to ask.
+        (
+            False,  # no container tarball
+            [],  # and no container image
+            False,  # means the user is not prompted
+            False,
+            None,
+            True,  # but the download happens
+            True,
+        ),
+        # If there is at least something present (here, a bundled container image), the
+        # user must be prompted.
+        (
+            True,  # a container tarball is present
+            [],
+            True,  # so the user must be prompted
+            False,
+            True,  # and if they accept
+            True,  # the download should happen
+            True,
+        ),
+        # If they decline, we must respect their choice and not download the image.
+        (
+            False,
+            ["some_image"],  # an image is already downloaded
+            True,  # so the user must be prompted
+            False,
+            False,  # but if they decline
+            True,  # the download should not happen
+            True,
+        ),
+        # If they accept and they don't want to be prompted again, we should similarly
+        # respect their choice.
+        (
+            False,
+            ["some_image"],  # an image is already downloaded
+            True,  # so the user must be prompted
+            True,  # and if they always want to download updates
+            True,  # and accept this download
+            True,  # the download should happen
+            False,  # and the user must not be asked again
+        ),
+    ],
+)
 def test_handle_needs_user_input_install_remote_container(
-    qtbot: QtBot, mocker: MockerFixture, window: MainWindow
+    qtbot: QtBot,
+    mocker: MockerFixture,
+    window: MainWindow,
+    is_tar_bundled: bool,
+    image_list: List[str],
+    expect_question,
+    checkbox_user_choice: bool,
+    download_user_choice: bool,
+    expect_download: bool,
+    expect_ask_again: bool,
 ) -> None:
     """Test that user is prompted to download a remote container update."""
     mock_get_installation_strategy = mocker.patch(
@@ -1204,111 +1267,43 @@ def test_handle_needs_user_input_install_remote_container(
     )
     mock_install = mocker.patch("dangerzone.updater.installer.install")
     # The prompt is only shown when no container is available locally.
-    mocker.patch("dangerzone.gui.startup.is_container_tar_bundled", return_value=False)
-    mocker.patch("dangerzone.gui.startup.runtime.list_image_digests", return_value=[])
+    mocker.patch(
+        "dangerzone.gui.startup.is_container_tar_bundled", return_value=is_tar_bundled
+    )
+    mocker.patch(
+        "dangerzone.gui.startup.runtime.list_image_digests", return_value=image_list
+    )
 
     # Mock the Question dialog - user accepts downloading
     mock_question = mocker.patch("dangerzone.gui.main_window.Question")
     mock_question.return_value.launch.return_value = (
-        main_window_module.Question.Accepted
+        mock_question.Accepted if download_user_choice else mock_question.Rejected
     )
-    mock_question.return_value.checkbox.isChecked.return_value = False
+    mock_question.return_value.checkbox.isChecked.return_value = checkbox_user_choice
 
     # Ensure only ContainerInstallTask runs
     for task in window.startup_thread.tasks:
         if not isinstance(task, startup.ContainerInstallTask):
             mocker.patch.object(task, "should_skip", return_value=True)
+        else:
+            run_spy = mocker.spy(task, "run")
 
     handle_needs_user_input_spy = mocker.spy(
         window, "handle_needs_user_input_install_remote_container"
     )
 
     window.startup_thread.start()
-    qtbot.waitUntil(handle_needs_user_input_spy.assert_called_once)
+    qtbot.waitUntil(run_spy.assert_called_once)
+    if expect_question:
+        qtbot.waitUntil(handle_needs_user_input_spy.assert_called_once)
     window.startup_thread.wait()
 
-    mock_question.assert_called_once()
-    # Verify that download happened after user accepted
-    mock_install.assert_called_once()
-
-
-def test_handle_needs_user_input_install_remote_container_decline(
-    qtbot: QtBot, mocker: MockerFixture, window: MainWindow
-) -> None:
-    """Test that download is skipped when user declines."""
-    mock_get_installation_strategy = mocker.patch(
-        "dangerzone.gui.startup.installer.get_installation_strategy",
-        return_value=InstallationStrategy.INSTALL_REMOTE_CONTAINER,
+    mock_question.assert_called_once() if expect_question else mock_question.assert_not_called()
+    mock_install.assert_called_once() if expect_download else mock_install.assert_not_called()
+    assert (
+        window.dangerzone.settings.get("updater_ask_before_download")
+        == expect_ask_again
     )
-    mock_install = mocker.patch("dangerzone.updater.installer.install")
-    mocker.patch("dangerzone.gui.startup.is_container_tar_bundled", return_value=False)
-    mocker.patch("dangerzone.gui.startup.runtime.list_image_digests", return_value=[])
-
-    # Mock the Question dialog - user declines downloading
-    mock_question = mocker.patch("dangerzone.gui.main_window.Question")
-    mock_question.return_value.launch.return_value = (
-        main_window_module.Question.Rejected
-    )
-    mock_question.return_value.checkbox.isChecked.return_value = False
-
-    # Ensure only ContainerInstallTask runs
-    for task in window.startup_thread.tasks:
-        if not isinstance(task, startup.ContainerInstallTask):
-            mocker.patch.object(task, "should_skip", return_value=True)
-
-    handle_needs_user_input_spy = mocker.spy(
-        window, "handle_needs_user_input_install_remote_container"
-    )
-
-    window.startup_thread.start()
-    qtbot.waitUntil(handle_needs_user_input_spy.assert_called_once)
-    window.startup_thread.wait()
-
-    mock_question.assert_called_once()
-    # Verify that download did NOT happen after user declined
-    mock_install.assert_not_called()
-
-
-def test_handle_needs_user_input_install_remote_container_checkbox(
-    qtbot: QtBot, mocker: MockerFixture, window: MainWindow
-) -> None:
-    """Test that checking 'Always download' updates the setting."""
-    mock_get_installation_strategy = mocker.patch(
-        "dangerzone.gui.startup.installer.get_installation_strategy",
-        return_value=InstallationStrategy.INSTALL_REMOTE_CONTAINER,
-    )
-    mock_install = mocker.patch("dangerzone.updater.installer.install")
-    mocker.patch("dangerzone.gui.startup.is_container_tar_bundled", return_value=False)
-    mocker.patch("dangerzone.gui.startup.runtime.list_image_digests", return_value=[])
-
-    # Mock the Question dialog - user accepts and checks "always download"
-    mock_question = mocker.patch("dangerzone.gui.main_window.Question")
-    mock_question.return_value.launch.return_value = (
-        main_window_module.Question.Accepted
-    )
-    mock_question.return_value.checkbox.isChecked.return_value = True
-
-    # Ensure only ContainerInstallTask runs
-    for task in window.startup_thread.tasks:
-        if not isinstance(task, startup.ContainerInstallTask):
-            mocker.patch.object(task, "should_skip", return_value=True)
-
-    handle_needs_user_input_spy = mocker.spy(
-        window, "handle_needs_user_input_install_remote_container"
-    )
-
-    # Verify initial setting
-    assert window.dangerzone.settings.get("updater_ask_before_download") == True
-
-    window.startup_thread.start()
-    qtbot.waitUntil(handle_needs_user_input_spy.assert_called_once)
-    window.startup_thread.wait()
-
-    mock_question.assert_called_once()
-    # Verify that download happened
-    mock_install.assert_called_once()
-    # Verify that the setting was updated to False (don't ask again)
-    assert window.dangerzone.settings.get("updater_ask_before_download") == False
 
 
 class TestShutdown:

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -891,12 +891,16 @@ def test_user_prompts(qtbot: QtBot, window: MainWindow, mocker: MockerFixture) -
 
     # Third run
     #
-    # From the third run onwards, users should never be prompted for enabling update
-    # checks.
-    prompt_mock().side_effect = RuntimeError("Should not be called")
-    for check in [True, False]:
-        window.dangerzone.settings.set("updater_check_all", check)
-        assert releases.should_check_for_updates(window.dangerzone.settings) == check
+    # If the user enabled update checks, they are not prompted again. If they
+    # disabled them, we still nudge them on every run by raising NeedUserInput.
+    from dangerzone.updater import errors as updater_errors
+
+    window.dangerzone.settings.set("updater_check_all", True)
+    assert releases.should_check_for_updates(window.dangerzone.settings) is True
+
+    window.dangerzone.settings.set("updater_check_all", False)
+    with pytest.raises(updater_errors.NeedUserInput):
+        releases.should_check_for_updates(window.dangerzone.settings)
 
 
 def test_user_prompts_no_container(
@@ -1197,6 +1201,13 @@ def test_handle_needs_user_input_install_remote_container(
         return_value=InstallationStrategy.INSTALL_REMOTE_CONTAINER,
     )
     mock_install = mocker.patch("dangerzone.updater.installer.install")
+    # The prompt is only shown when no container is available locally.
+    mocker.patch(
+        "dangerzone.gui.startup.is_container_tar_bundled", return_value=False
+    )
+    mocker.patch(
+        "dangerzone.gui.startup.runtime.list_image_digests", return_value=[]
+    )
 
     # Mock the Question dialog - user accepts downloading
     mock_question = mocker.patch("dangerzone.gui.main_window.Question")
@@ -1232,6 +1243,12 @@ def test_handle_needs_user_input_install_remote_container_decline(
         return_value=InstallationStrategy.INSTALL_REMOTE_CONTAINER,
     )
     mock_install = mocker.patch("dangerzone.updater.installer.install")
+    mocker.patch(
+        "dangerzone.gui.startup.is_container_tar_bundled", return_value=False
+    )
+    mocker.patch(
+        "dangerzone.gui.startup.runtime.list_image_digests", return_value=[]
+    )
 
     # Mock the Question dialog - user declines downloading
     mock_question = mocker.patch("dangerzone.gui.main_window.Question")
@@ -1267,6 +1284,12 @@ def test_handle_needs_user_input_install_remote_container_checkbox(
         return_value=InstallationStrategy.INSTALL_REMOTE_CONTAINER,
     )
     mock_install = mocker.patch("dangerzone.updater.installer.install")
+    mocker.patch(
+        "dangerzone.gui.startup.is_container_tar_bundled", return_value=False
+    )
+    mocker.patch(
+        "dangerzone.gui.startup.runtime.list_image_digests", return_value=[]
+    )
 
     # Mock the Question dialog - user accepts and checks "always download"
     mock_question = mocker.patch("dangerzone.gui.main_window.Question")

--- a/tests/gui/test_startup.py
+++ b/tests/gui/test_startup.py
@@ -94,7 +94,7 @@ class StartupThreadMocker(startup.StartupThread):
             side_effect=Exception("Forcing task to fail"),
         )
 
-    def expect_tasks_succeed(self, tasks: list[Task]) -> None:
+    def expect_tasks_succeed(self, tasks: typing.Sequence[Task]) -> None:
         for task in tasks:
             if isinstance(task, (MachineInitTask, MachineStartTask)):
                 self.make_machine_task_succeed()
@@ -115,7 +115,7 @@ class StartupThreadMocker(startup.StartupThread):
             task.handle_error = self.mocker.MagicMock()  # type: ignore [method-assign]
             self.not_expected_funcs.append(task.handle_error)
 
-    def expect_tasks_skip(self, tasks: list[Task]) -> None:
+    def expect_tasks_skip(self, tasks: typing.Sequence[Task]) -> None:
         for task in tasks:
             if isinstance(task, (MachineInitTask, MachineStartTask)):
                 self.make_machine_task_skip()
@@ -136,7 +136,7 @@ class StartupThreadMocker(startup.StartupThread):
             task.handle_error = self.mocker.MagicMock()  # type: ignore [method-assign]
             self.not_expected_funcs.append(task.handle_error)
 
-    def expect_tasks_fail(self, tasks: list[Task]) -> None:
+    def expect_tasks_fail(self, tasks: typing.Sequence[Task]) -> None:
         for task in tasks:
             if isinstance(task, (MachineInitTask, MachineStartTask)):
                 self.make_machine_task_fail()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -60,6 +60,8 @@ def test_corrupt_settings(tmp_path: Path, mocker: MockerFixture) -> None:
         settings_file.write(corrupt_settings_dict)
 
     mocker.patch("dangerzone.settings.get_config_dir", return_value=tmp_path)
+    # Force Settings to load fresh from the corrupt file on disk.
+    Settings._singleton = None
     settings = Settings()
     assert settings.settings_filename.is_file()
 

--- a/tests/test_updater_installer.py
+++ b/tests/test_updater_installer.py
@@ -349,7 +349,7 @@ def test_airgapped_installation_container_tarball(mocker: MockerFixture) -> None
 
 
 def test_no_bundled_container_tar_first_install(mocker: MockerFixture) -> None:
-    """User installs dangerzone-slim (no container.tar) for the first time.
+    """User installs dangerzone (no container.tar) for the first time.
 
     Without a bundled container, the strategy should fall back to remote
     installation if updates are enabled.
@@ -373,7 +373,7 @@ def test_no_bundled_container_tar_first_install(mocker: MockerFixture) -> None:
 
 
 def test_no_bundled_container_tar_updates_disabled(mocker: MockerFixture) -> None:
-    """User installs dangerzone-slim (no container.tar) with updates disabled.
+    """User installs dangerzone (no container.tar) with updates disabled.
 
     Without a bundled container and with updates disabled, the strategy
     should be DO_NOTHING if there's already an image installed, or


### PR DESCRIPTION
This removes the container.tar from the Linux packages, providing `-full` variants for the versions with the container.

This doesn't currently change how windows and macOS installers are created. Currently they continue shipping with the container.tar inside.

Fixes #1069 