### PR TITLE
fix: add timeout to registry HTTP requests

### DIFF
--- a/dangerzone/updater/registry.py
+++ b/dangerzone/updater/registry.py
@@ -98,6 +98,7 @@ def _get_auth_header(image: Image) -> Dict[str, str]:
             "scope": f"repository:{image.namespace}/{image.image_name}:pull",
         },
         proxies=get_proxies(),
+        timeout=30,
     )
     response.raise_for_status()
     token = response.json()["token"]
@@ -120,7 +121,9 @@ def get_manifest(image_str: str) -> requests.Response:
     }
     headers.update(_get_auth_header(image))
 
-    response = requests.get(manifest_url, headers=headers, proxies=get_proxies())
+    response = requests.get(
+        manifest_url, headers=headers, proxies=get_proxies(), timeout=30
+    )
     response.raise_for_status()
     return response
 
@@ -152,6 +155,7 @@ def get_blob(image: Image, digest: str) -> requests.Response:
         f"{_url(image)}/blobs/{digest}",
         headers=_get_auth_header(image),
         proxies=get_proxies(),
+        timeout=30,
     )
     response.raise_for_status()
     return response

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -9,6 +9,7 @@ from dangerzone.updater.registry import (
     Image,
     _get_auth_header,
     _url,
+    get_blob,
     get_manifest,
     get_manifest_digest,
     parse_image_location,
@@ -157,6 +158,41 @@ def test_get_manifest_digest() -> None:
 
     # Verify the result
     assert digest == expected_digest
+
+
+def test_requests_get_includes_timeout(mocker: MockerFixture) -> None:
+    """Test that all requests.get() calls in registry.py pass a timeout kwarg."""
+    image_str = "ghcr.io/freedomofpress/dangerzone:v0.4.2"
+
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"token": "dummy_token"}
+    mock_response.raise_for_status.return_value = None
+    mock_response.content = b"{}"
+    mock_response.status_code = 200
+
+    mock_get = mocker.patch("requests.get", return_value=mock_response)
+    mocker.patch("dangerzone.updater.registry.get_proxies", return_value={})
+
+    # Exercise _get_auth_header (first requests.get call)
+    _get_auth_header(parse_image_location(image_str))
+    assert mock_get.call_args_list[-1].kwargs.get("timeout") == 30
+
+    # Exercise get_manifest (second requests.get call, plus auth call)
+    mock_get.reset_mock()
+    get_manifest(image_str)
+    for call in mock_get.call_args_list:
+        assert call.kwargs.get("timeout") == 30, (
+            f"requests.get() missing timeout for URL: {call.args[0]}"
+        )
+
+    # Exercise get_blob (third requests.get call, plus auth call)
+    mock_get.reset_mock()
+    image = parse_image_location(image_str)
+    get_blob(image, "sha256:abc123")
+    for call in mock_get.call_args_list:
+        assert call.kwargs.get("timeout") == 30, (
+            f"requests.get() missing timeout for URL: {call.args[0]}"
+        )
 
 
 def test_get_manifest_digest_from_registry(mocker: MockerFixture) -> None:


### PR DESCRIPTION
Superseded by #1454 which combines this timeout fix with the env var allowlist hardening.