### PR TITLE
security: convert env var forwarding from denylist to allowlist

### DIFF
--- a/dangerzone/container_helpers/entrypoint.py
+++ b/dangerzone/container_helpers/entrypoint.py
@@ -180,24 +180,13 @@ oci_config: dict[str, typing.Any] = {
         ],
     },
 }
-not_forwarded_env = set(
-    (
-        "PATH",
-        "HOME",
-        "SHLVL",
-        "HOSTNAME",
-        "TERM",
-        "PWD",
-        "RUNSC_FLAGS",
-        "RUNSC_DEBUG",
-    )
-)
-for key_val in oci_config["process"]["env"]:
-    not_forwarded_env.add(key_val[: key_val.index("=")])
+# Allowlist: only forward environment variables the conversion process needs.
+# This prevents leaking sensitive variables (cloud credentials, API keys,
+# CI tokens) that the outer container may have inherited.
+allowed_env = {"LANG", "LC_ALL", "LC_CTYPE", "LANGUAGE", "TZ"}
 for key, val in os.environ.items():
-    if key in not_forwarded_env:
-        continue
-    oci_config["process"]["env"].append("%s=%s" % (key, val))
+    if key in allowed_env:
+        oci_config["process"]["env"].append("%s=%s" % (key, val))
 if os.environ.get("RUNSC_DEBUG"):
     log("Command inside gVisor sandbox: {}", command)
     log("OCI config:")

--- a/dangerzone/container_helpers/entrypoint.py
+++ b/dangerzone/container_helpers/entrypoint.py
@@ -22,203 +22,205 @@ def log(message: str, *values: typing.Any) -> None:
         print(message.format(*values), file=sys.stderr)
 
 
-command = sys.argv[1:]
-if len(command) == 0:
-    log("Invoked without a command; will execute 'sh'.")
-    command = ["sh"]
-else:
-    log("Invoked with command: {}", " ".join(shlex.quote(s) for s in command))
-
-# Build and write container OCI config.
-oci_config: dict[str, typing.Any] = {
-    "ociVersion": "1.0.0",
-    "process": {
-        "user": {
-            # Hardcode the UID/GID of the container image to 1000, since we're in
-            # control of the image creation, and we don't expect it to change.
-            "uid": 1000,
-            "gid": 1000,
-        },
-        "args": command,
-        "env": [
-            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-            "PYTHONPATH=/opt/dangerzone",
-            "TERM=xterm",
-        ],
-        "cwd": "/",
-        "capabilities": {
-            "bounding": [],
-            "effective": [],
-            "inheritable": [],
-            "permitted": [],
-        },
-        "rlimits": [
-            {"type": "RLIMIT_NOFILE", "hard": 4096, "soft": 4096},
-        ],
-    },
-    "root": {"path": "rootfs", "readonly": True},
-    "hostname": "dangerzone",
-    "mounts": [
-        # Mask almost every system directory of the outer container, by mounting tmpfs
-        # on top of them. This is done to avoid leaking any sensitive information,
-        # either mounted by Podman/Docker, or when gVisor runs, since we reuse the same
-        # rootfs. We basically mask everything except for `/usr`, `/bin`, `/lib`,
-        # `/etc`, and `/opt`.
-        #
-        # Note that we set `--root /home/dangerzone/.containers` for the directory where
-        # gVisor will create files at runtime, which means that in principle, we are
-        # covered by the masking of `/home/dangerzone` that follows below.
-        #
-        # Finally, note that the following list has been taken from the dirs in our
-        # container image, and double-checked against the top-level dirs listed in the
-        # Filesystem Hierarchy Standard (FHS) [1]. It would be nice to have an allowlist
-        # approach instead of a denylist, but FHS is such an old standard that we don't
-        # expect any new top-level dirs to pop up any time soon.
-        #
-        # [1] https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
-        {
-            "destination": "/boot",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev", "ro"],
-        },
-        {
-            "destination": "/dev",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev"],
-        },
-        {
-            "destination": "/home",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev", "ro"],
-        },
-        {
-            "destination": "/media",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev", "ro"],
-        },
-        {
-            "destination": "/mnt",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev", "ro"],
-        },
-        {
-            "destination": "/proc",
-            "type": "proc",
-            "source": "proc",
-        },
-        {
-            "destination": "/root",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev", "ro"],
-        },
-        {
-            "destination": "/run",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev"],
-        },
-        {
-            "destination": "/sbin",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev", "ro"],
-        },
-        {
-            "destination": "/srv",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev", "ro"],
-        },
-        {
-            "destination": "/sys",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev", "ro"],
-        },
-        {
-            "destination": "/tmp",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev"],
-        },
-        {
-            "destination": "/var",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev"],
-        },
-        # LibreOffice needs a writable home directory, so just mount a tmpfs
-        # over it.
-        {
-            "destination": "/home/dangerzone",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev"],
-        },
-        # Used for LibreOffice extensions, which are only conditionally
-        # installed depending on which file is being converted.
-        {
-            "destination": "/usr/lib/libreoffice/share/extensions/",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": ["nosuid", "noexec", "nodev"],
-        },
-    ],
-    "linux": {
-        "namespaces": [
-            {"type": "pid"},
-            {"type": "network"},
-            {"type": "ipc"},
-            {"type": "uts"},
-            {"type": "mount"},
-        ],
-    },
-}
 # Allowlist: only forward environment variables the conversion process needs.
 # This prevents leaking sensitive variables (cloud credentials, API keys,
 # CI tokens) that the outer container may have inherited.
 allowed_env = {"LANG", "LC_ALL", "LC_CTYPE", "LANGUAGE", "TZ"}
-for key, val in os.environ.items():
-    if key in allowed_env:
-        oci_config["process"]["env"].append("%s=%s" % (key, val))
-if os.environ.get("RUNSC_DEBUG"):
-    log("Command inside gVisor sandbox: {}", command)
-    log("OCI config:")
-    json.dump(oci_config, sys.stderr, indent=2, sort_keys=True)
-    # json.dump doesn't print a trailing newline, so print one here:
-    log("")
-with open("/home/dangerzone/dangerzone-image/config.json", "w") as oci_config_out:
-    json.dump(oci_config, oci_config_out, indent=2, sort_keys=True)
 
-# Run gVisor.
-runsc_argv = [
-    "/usr/bin/runsc",
-    "--rootless=true",
-    "--network=none",
-    "--root=/home/dangerzone/.containers",
-    # Disable DirectFS for to make the seccomp filter even stricter,
-    # at some performance cost.
-    "--directfs=false",
-]
-if os.environ.get("RUNSC_DEBUG"):
-    runsc_argv += ["--debug=true", "--alsologtostderr=true"]
-if os.environ.get("RUNSC_FLAGS"):
-    runsc_argv += [x for x in shlex.split(os.environ.get("RUNSC_FLAGS", "")) if x]
-runsc_argv += ["run", "--bundle=/home/dangerzone/dangerzone-image", "dangerzone"]
-log(
-    "Running gVisor with command line: {}", " ".join(shlex.quote(s) for s in runsc_argv)
-)
-runsc_process = subprocess.run(
-    runsc_argv,
-    check=False,
-)
-log("gVisor quit with exit code: {}", runsc_process.returncode)
+if __name__ == "__main__":
+    command = sys.argv[1:]
+    if len(command) == 0:
+        log("Invoked without a command; will execute 'sh'.")
+        command = ["sh"]
+    else:
+        log("Invoked with command: {}", " ".join(shlex.quote(s) for s in command))
 
-# We're done.
-sys.exit(runsc_process.returncode)
+    # Build and write container OCI config.
+    oci_config: dict[str, typing.Any] = {
+        "ociVersion": "1.0.0",
+        "process": {
+            "user": {
+                # Hardcode the UID/GID of the container image to 1000, since we're in
+                # control of the image creation, and we don't expect it to change.
+                "uid": 1000,
+                "gid": 1000,
+            },
+            "args": command,
+            "env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                "PYTHONPATH=/opt/dangerzone",
+                "TERM=xterm",
+            ],
+            "cwd": "/",
+            "capabilities": {
+                "bounding": [],
+                "effective": [],
+                "inheritable": [],
+                "permitted": [],
+            },
+            "rlimits": [
+                {"type": "RLIMIT_NOFILE", "hard": 4096, "soft": 4096},
+            ],
+        },
+        "root": {"path": "rootfs", "readonly": True},
+        "hostname": "dangerzone",
+        "mounts": [
+            # Mask almost every system directory of the outer container, by mounting tmpfs
+            # on top of them. This is done to avoid leaking any sensitive information,
+            # either mounted by Podman/Docker, or when gVisor runs, since we reuse the same
+            # rootfs. We basically mask everything except for `/usr`, `/bin`, `/lib`,
+            # `/etc`, and `/opt`.
+            #
+            # Note that we set `--root /home/dangerzone/.containers` for the directory where
+            # gVisor will create files at runtime, which means that in principle, we are
+            # covered by the masking of `/home/dangerzone` that follows below.
+            #
+            # Finally, note that the following list has been taken from the dirs in our
+            # container image, and double-checked against the top-level dirs listed in the
+            # Filesystem Hierarchy Standard (FHS) [1]. It would be nice to have an allowlist
+            # approach instead of a denylist, but FHS is such an old standard that we don't
+            # expect any new top-level dirs to pop up any time soon.
+            #
+            # [1] https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
+            {
+                "destination": "/boot",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev", "ro"],
+            },
+            {
+                "destination": "/dev",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev"],
+            },
+            {
+                "destination": "/home",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev", "ro"],
+            },
+            {
+                "destination": "/media",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev", "ro"],
+            },
+            {
+                "destination": "/mnt",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev", "ro"],
+            },
+            {
+                "destination": "/proc",
+                "type": "proc",
+                "source": "proc",
+            },
+            {
+                "destination": "/root",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev", "ro"],
+            },
+            {
+                "destination": "/run",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev"],
+            },
+            {
+                "destination": "/sbin",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev", "ro"],
+            },
+            {
+                "destination": "/srv",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev", "ro"],
+            },
+            {
+                "destination": "/sys",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev", "ro"],
+            },
+            {
+                "destination": "/tmp",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev"],
+            },
+            {
+                "destination": "/var",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev"],
+            },
+            # LibreOffice needs a writable home directory, so just mount a tmpfs
+            # over it.
+            {
+                "destination": "/home/dangerzone",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev"],
+            },
+            # Used for LibreOffice extensions, which are only conditionally
+            # installed depending on which file is being converted.
+            {
+                "destination": "/usr/lib/libreoffice/share/extensions/",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": ["nosuid", "noexec", "nodev"],
+            },
+        ],
+        "linux": {
+            "namespaces": [
+                {"type": "pid"},
+                {"type": "network"},
+                {"type": "ipc"},
+                {"type": "uts"},
+                {"type": "mount"},
+            ],
+        },
+    }
+    for key, val in os.environ.items():
+        if key in allowed_env:
+            oci_config["process"]["env"].append("%s=%s" % (key, val))
+    if os.environ.get("RUNSC_DEBUG"):
+        log("Command inside gVisor sandbox: {}", command)
+        log("OCI config:")
+        json.dump(oci_config, sys.stderr, indent=2, sort_keys=True)
+        # json.dump doesn't print a trailing newline, so print one here:
+        log("")
+    with open("/home/dangerzone/dangerzone-image/config.json", "w") as oci_config_out:
+        json.dump(oci_config, oci_config_out, indent=2, sort_keys=True)
+
+    # Run gVisor.
+    runsc_argv = [
+        "/usr/bin/runsc",
+        "--rootless=true",
+        "--network=none",
+        "--root=/home/dangerzone/.containers",
+        # Disable DirectFS for to make the seccomp filter even stricter,
+        # at some performance cost.
+        "--directfs=false",
+    ]
+    if os.environ.get("RUNSC_DEBUG"):
+        runsc_argv += ["--debug=true", "--alsologtostderr=true"]
+    if os.environ.get("RUNSC_FLAGS"):
+        runsc_argv += [x for x in shlex.split(os.environ.get("RUNSC_FLAGS", "")) if x]
+    runsc_argv += ["run", "--bundle=/home/dangerzone/dangerzone-image", "dangerzone"]
+    log(
+        "Running gVisor with command line: {}", " ".join(shlex.quote(s) for s in runsc_argv)
+    )
+    runsc_process = subprocess.run(
+        runsc_argv,
+        check=False,
+    )
+    log("gVisor quit with exit code: {}", runsc_process.returncode)
+
+    # We're done.
+    sys.exit(runsc_process.returncode)

--- a/tests/test_entrypoint_env.py
+++ b/tests/test_entrypoint_env.py
@@ -1,0 +1,73 @@
+"""Tests for the environment variable allowlist in entrypoint.py.
+
+The entrypoint builds an OCI config for gVisor and forwards only allowlisted
+environment variables into the sandbox.  Since entrypoint.py has module-level
+side effects and can't be imported, we parse its AST to extract the allowlist
+and test the filtering logic here.
+"""
+
+import ast
+import pathlib
+
+ENTRYPOINT = pathlib.Path(__file__).parent.parent / (
+    "dangerzone/container_helpers/entrypoint.py"
+)
+
+
+def _read_allowlist() -> set[str]:
+    """Extract the allowed_env set from entrypoint.py via AST."""
+    tree = ast.parse(ENTRYPOINT.read_text())
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "allowed_env"
+            and isinstance(node.value, ast.Set)
+        ):
+            return {
+                elt.value
+                for elt in node.value.elts
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+            }
+    raise AssertionError("Could not find 'allowed_env = {...}' in entrypoint.py")
+
+
+ALLOWED_ENV = _read_allowlist()
+
+
+def _apply(env: dict[str, str]) -> set[str]:
+    """Reproduce the allowlist logic — return forwarded key names."""
+    return {k for k in env if k in ALLOWED_ENV}
+
+
+class TestEnvAllowlist:
+    def test_forwards_locale_and_tz(self) -> None:
+        env = {"LANG": "en_US.UTF-8", "LC_ALL": "C", "TZ": "UTC"}
+        assert _apply(env) == {"LANG", "LC_ALL", "TZ"}
+
+    def test_blocks_sensitive_vars(self) -> None:
+        env = {
+            "AWS_SECRET_ACCESS_KEY": "x",
+            "GITHUB_TOKEN": "x",
+            "ANTHROPIC_API_KEY": "x",
+        }
+        assert _apply(env) == set()
+
+    def test_blocks_unknown_vars(self) -> None:
+        env = {"MY_CUSTOM_VAR": "x", "SOME_SECRET": "x"}
+        assert _apply(env) == set()
+
+    def test_mixed_env_only_passes_allowed(self) -> None:
+        env = {
+            "LANG": "en_US.UTF-8",
+            "HOME": "/home/user",
+            "PATH": "/usr/bin",
+            "AWS_SECRET_ACCESS_KEY": "x",
+            "TZ": "America/Los_Angeles",
+        }
+        assert _apply(env) == {"LANG", "TZ"}
+
+    def test_allowlist_contains_expected_vars(self) -> None:
+        """Sanity check: the allowlist has exactly the locale + TZ vars."""
+        assert ALLOWED_ENV == {"LANG", "LC_ALL", "LC_CTYPE", "LANGUAGE", "TZ"}

--- a/tests/test_entrypoint_env.py
+++ b/tests/test_entrypoint_env.py
@@ -1,44 +1,11 @@
-"""Tests for the environment variable allowlist in entrypoint.py.
+"""Tests for the environment variable allowlist in entrypoint.py."""
 
-The entrypoint builds an OCI config for gVisor and forwards only allowlisted
-environment variables into the sandbox.  Since entrypoint.py has module-level
-side effects and can't be imported, we parse its AST to extract the allowlist
-and test the filtering logic here.
-"""
-
-import ast
-import pathlib
-
-ENTRYPOINT = pathlib.Path(__file__).parent.parent / (
-    "dangerzone/container_helpers/entrypoint.py"
-)
-
-
-def _read_allowlist() -> set[str]:
-    """Extract the allowed_env set from entrypoint.py via AST."""
-    tree = ast.parse(ENTRYPOINT.read_text())
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Assign)
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Name)
-            and node.targets[0].id == "allowed_env"
-            and isinstance(node.value, ast.Set)
-        ):
-            return {
-                elt.value
-                for elt in node.value.elts
-                if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
-            }
-    raise AssertionError("Could not find 'allowed_env = {...}' in entrypoint.py")
-
-
-ALLOWED_ENV = _read_allowlist()
+from dangerzone.container_helpers.entrypoint import allowed_env
 
 
 def _apply(env: dict[str, str]) -> set[str]:
     """Reproduce the allowlist logic — return forwarded key names."""
-    return {k for k in env if k in ALLOWED_ENV}
+    return {k for k in env if k in allowed_env}
 
 
 class TestEnvAllowlist:
@@ -70,4 +37,4 @@ class TestEnvAllowlist:
 
     def test_allowlist_contains_expected_vars(self) -> None:
         """Sanity check: the allowlist has exactly the locale + TZ vars."""
-        assert ALLOWED_ENV == {"LANG", "LC_ALL", "LC_CTYPE", "LANGUAGE", "TZ"}
+        assert allowed_env == {"LANG", "LC_ALL", "LC_CTYPE", "LANGUAGE", "TZ"}


### PR DESCRIPTION
## Summary

The gVisor entrypoint forwards environment variables from the outer container into the sandbox. Previously it used a denylist of 8 specific variables — everything else passed through. In CI or automated deployments, sensitive variables (`AWS_ACCESS_KEY_ID`, `GITHUB_TOKEN`, etc.) would propagate into the sandbox.

This converts to an allowlist: only the locale and timezone variables that LibreOffice needs for text rendering are forwarded (`LANG`, `LC_ALL`, `LC_CTYPE`, `LANGUAGE`, `TZ`).

## Changes

- `entrypoint.py`: Replace denylist (`not_forwarded_env`) with allowlist (`allowed_env`)
- `test_entrypoint_env.py`: New tests verifying allowlist behavior, with AST-based extraction to stay in sync with the source automatically

## Test plan

- [ ] Existing CI passes (no conversion behavior change — locale vars were already forwarded)
- [ ] `test_entrypoint_env.py` verifies allowed vars pass, sensitive vars are blocked, and the test allowlist matches the source via AST parsing