### PR TITLE
gui: elide long filenames with tooltip in document list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 - Update the theme correctly on dark/light mode changes
   ([#1238](https://github.com/freedomofpress/dangerzone/issues/1238))
 - Update Linux .desktop file with missing MIME types for HWP and ODF formats ([#646](https://github.com/freedomofpress/dangerzone/issues/646))
+- Elide long filenames in the filename label to prevent UI elements from being pushed off-screen ([#143](https://github.com/freedomofpress/dangerzone/issues/143))
 
 ### Added
 

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -1667,9 +1667,14 @@ class DocumentWidget(QtWidgets.QWidget):
         self.dangerous_doc_label.setAlignment(
             QtCore.Qt.AlignVCenter | QtCore.Qt.AlignLeft
         )
-        self.dangerous_doc_label.setText(os.path.basename(self.document.input_filename))
+        doc_name = os.path.basename(self.document.input_filename)
+        self.dangerous_doc_label.setToolTip(doc_name)
         self.dangerous_doc_label.setMinimumWidth(200)
         self.dangerous_doc_label.setMaximumWidth(200)
+        # Elide text with '...' when the filename is too long for the label width
+        metrics = self.dangerous_doc_label.fontMetrics()
+        elided = metrics.elidedText(doc_name, QtCore.Qt.ElideMiddle, 200)
+        self.dangerous_doc_label.setText(elided)
 
         # Conversion status images
         self.img_status_unconverted = self.load_status_image("status_unconverted.png")


### PR DESCRIPTION
When a file with a very long name is selected, the application window would resize awkwardly or push elements out of the viewport.

For example (_on Fedora Linux_), without this fix, the **"Start another conversion"** button gets pushed completely off-screen when selecting a file with a long filename, making it impossible for the user to trigger another conversion. See the "Before" image below.

This PR improves the UI by:

1. Using `QFontMetrics.elidedText()` with `ElideMiddle` to shorten the displayed filename if it exceeds the available width.
2. Adding a tooltip to the filename label so that the full path is still visible on hover.

Fixes #143

**Before**

<img width="1452" height="982" alt="image" src="https://github.com/user-attachments/assets/0c5cc35c-735e-4dbd-815b-02121f2d075d" />

**After**

<img width="1244" height="980" alt="image" src="https://github.com/user-attachments/assets/a6080f75-3c58-459c-9b3e-02bf53a07293" />
