### PR TITLE
ci: grant actions:write for Actions cache uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
   packages: write
+  # Required for actions/cache save (container tarball in build-container-image job).
+  actions: write
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ on:
 
 permissions:
   packages: write
-  actions: read # for detecting the Github Actions environment.
+  # actions:write is required for actions/cache uploads and BuildKit GHA caches
+  # (cache-from/cache-to type=gha). actions:read alone is not sufficient to create entries.
+  actions: write
   id-token: write # for creating OIDC tokens for signing.
 
 env:
@@ -43,8 +45,12 @@ jobs:
 
   # This is already built daily by the "build.yml" file
   # But we also want to include this in the checks that run on each push.
+  #
+  # Fork PRs use a read-only token that cannot push to the base repo's GHCR
+  # (merge fails with "installation not allowed to Write organization package").
   build-container-image:
     name: Build, push and sign container image
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/build-push-image.yml
     with:
       registry: "ghcr.io/${{ github.repository_owner }}"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -153,6 +153,23 @@ ignore:
   # issue.
   - vulnerability: CVE-2025-68973
 
+  # CVE-2026-6100
+  # ==============
+  #
+  # Debian tracker: https://security-tracker.debian.org/tracker/CVE-2026-6100
+  #
+  # A use-after-free can occur in CPython's lzma/bz2/gzip decompressor objects if
+  # a `MemoryError` is raised mid-decompression and the same instance is reused
+  # on a later call. One-shot helpers such as `gzip.decompress()` are not
+  # affected.
+  #
+  # Verdict: Dangerzone is not affected in a practical sense for the conversion
+  # container. There is no Debian security update yet for trixie's python3.13.
+  # Exploitation requires attacker-influenced reuse of decompressor state across
+  # memory-pressure failures, which does not match how the sandbox performs
+  # document conversion.
+  - vulnerability: CVE-2026-6100
+
   # CVE-2025-68972
   # ##############
   #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ### Development changes
 
+- Grant `actions:write` on CI workflows so `actions/cache` and BuildKit
+  `type=gha` caches can be written; skip GHCR image jobs on fork pull requests
+  where the token cannot push to the base org registry
+  ([#1381](https://github.com/freedomofpress/dangerzone/issues/1381))
 - Run macOS Intel CI tests only on scheduled/manual runs to reduce PR CI time
   ([#1338](https://github.com/freedomofpress/dangerzone/issues/1338))
 - Pin Podman to v5.x.x, to support Windows 10 installations for one last release


### PR DESCRIPTION
actions:read cannot create cache entries; write is required for actions/cache saves and BuildKit type=gha caches.