### PR TITLE
Queue new documents, when added during a conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 - Dangerzone is able to function without a bundled `container.tar` file
   ([#1400](https://github.com/freedomofpress/dangerzone/pull/1400))
 - Look for desktop entries in `XDG_DATA_DIRS` paths on Linux ([#1413](https://github.com/freedomofpress/dangerzone/issues/1413))
-- It is now possible to convert another set of documents after a first batch ([#549](https://github.com/freedomofpress/dangerzone/issues/549))
+- It is now possible to convert another set of documents after a first batch
+  ([#549](https://github.com/freedomofpress/dangerzone/issues/549)),
+  or add more documents to an ongoing conversion
+  ([#1464](https://github.com/freedomofpress/dangerzone/pull/1464))
 - OCR tasks are now queued, resulting in up to x6 speedup
   ([#1329](https://github.com/freedomofpress/dangerzone/issues/1329))
 

--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -1013,14 +1013,6 @@ class ConversionWidget(QtWidgets.QWidget):
         QtCore.QTimer.singleShot(3000, self.enqueued_widget.hide)
 
     def documents_selected(self, docs: List[Document]) -> None:
-        if self.conversion_started:
-            self.dialog = Alert(
-                self.dangerzone,
-                message="Dangerzone does not support adding documents after the conversion has started.",
-                has_cancel=False,
-            ).launch()
-            return
-
         # Ensure all files in batch are in the same directory
         dirnames = {os.path.dirname(doc.input_filename) for doc in docs}
         if len(dirnames) > 1:
@@ -1030,6 +1022,24 @@ class ConversionWidget(QtWidgets.QWidget):
                 has_cancel=False,
             ).launch()
             return
+
+        if self.conversion_started and not self._all_conversions_done():
+            # A conversion is in progress: queue the new documents so they
+            # join the ongoing run. Settings chosen before the conversion
+            # started apply to the newly added documents too.
+            for doc in docs:
+                self.dangerzone.add_document(doc)
+                self.settings_widget.configure_document(doc)
+
+            if len(docs) > 0:
+                self.documents_added.emit(docs)
+                self.documents_list.start_conversion()
+            return
+
+        # No conversion is running. If a previous conversion has finished,
+        # reset the UI to start a fresh roundtrip through the settings.
+        if self.conversion_started:
+            self.reset_for_new_conversion()
 
         # Clear previously selected documents
         self.dangerzone.clear_documents()
@@ -1048,6 +1058,12 @@ class ConversionWidget(QtWidgets.QWidget):
 
         if len(docs) > 0:
             self.documents_added.emit(docs)
+
+    def _all_conversions_done(self) -> bool:
+        docs = self.documents_list.docs_list
+        if not docs:
+            return True
+        return all(doc.is_safe() or doc.is_failed() for doc in docs)
 
     def reset_for_new_conversion(self) -> None:
         self.dangerzone.clear_documents()
@@ -1516,22 +1532,20 @@ class SettingsWidget(QtWidgets.QWidget):
                     "output_dir", str(selected_dir), autosave=True
                 )
 
+    def configure_document(self, document: Document) -> None:
+        if self.save_checkbox.isChecked():
+            document.suffix = self.safe_extension.text()
+            if self.radio_move_untrusted.isChecked():
+                document.archive_after_conversion = True
+            elif self.radio_save_to.isChecked():
+                document.set_output_dir(self.dangerzone.output_dir)
+        else:
+            (_, tmp) = tempfile.mkstemp(suffix=".pdf", prefix="dangerzone_")
+            document.output_filename = tmp
+
     def start_button_clicked(self) -> None:
         for document in self.dangerzone.get_unconverted_documents():
-            if self.save_checkbox.isChecked():
-                # If we're saving the document, set the suffix that the user chose. Then
-                # check if we should to store the document in the same directory, and
-                # move the original document to an 'unsafe' subdirectory, or save the
-                # document to another directory.
-                document.suffix = self.safe_extension.text()
-                if self.radio_move_untrusted.isChecked():
-                    document.archive_after_conversion = True
-                elif self.radio_save_to.isChecked():
-                    document.set_output_dir(self.dangerzone.output_dir)
-            else:
-                # If not saving, then save it to a temp file instead
-                (_, tmp) = tempfile.mkstemp(suffix=".pdf", prefix="dangerzone_")
-                document.output_filename = tmp
+            self.configure_document(document)
 
         # Update settings
         self.dangerzone.settings.set(
@@ -1593,6 +1607,7 @@ class DocumentsListWidget(QtWidgets.QListWidget):
         self.dangerzone = dangerzone
         self.docs_list: List[Document] = []
         self.docs_list_widget_map: dict[Document, DocumentWidget] = {}
+        self.submitted_docs: set[Document] = set()
         self.conversion_pending = False
 
         # Initialize thread_pool only on the first conversion
@@ -1602,6 +1617,7 @@ class DocumentsListWidget(QtWidgets.QListWidget):
     def clear(self) -> None:
         self.docs_list = []
         self.docs_list_widget_map = {}
+        self.submitted_docs = set()
         super().clear()
 
     def documents_added(self, docs: List[Document]) -> None:
@@ -1630,6 +1646,9 @@ class DocumentsListWidget(QtWidgets.QListWidget):
             self.thread_pool_initized = True
 
         for doc in self.docs_list:
+            if doc in self.submitted_docs:
+                continue
+            self.submitted_docs.add(doc)
             task = ConvertTask(self.dangerzone, doc, self.get_ocr_lang())
             doc_widget = self.docs_list_widget_map[doc]
             task.update.connect(doc_widget.update_progress)

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1312,3 +1312,95 @@ class TestRestartConversion:
 
         assert len(conversion_widget.dangerzone.get_unconverted_documents()) == 1
         assert not conversion_widget.settings_widget.isHidden()
+
+
+class TestQueueDuringConversion:
+    @staticmethod
+    def _copy_doc(src: str, dest_dir: pathlib.Path, name: str) -> Document:
+        dest = dest_dir / name
+        shutil.copy(src, dest)
+        return Document(str(dest))
+
+    def _simulate_running_conversion(
+        self,
+        conversion_widget: ConversionWidget,
+        mock_pool: MagicMock,
+        initial_doc: Document,
+    ) -> None:
+        """Put the widget in the state it would be in while doc is being converted."""
+        conversion_widget.documents_selected([initial_doc])
+        conversion_widget.conversion_started = True
+        conversion_widget.settings_widget.hide()
+        conversion_widget.documents_list.show()
+        initial_doc.state = Document.STATE_CONVERTING
+        conversion_widget.documents_list.submitted_docs.add(initial_doc)
+        conversion_widget.documents_list.thread_pool = mock_pool
+        conversion_widget.documents_list.thread_pool_initized = True
+        conversion_widget.dangerzone.is_waiting_finished = True
+
+    def test_queueing_adds_new_doc_to_running_conversion(
+        self,
+        conversion_widget: ConversionWidget,
+        mocker: MockerFixture,
+        sample_pdf: str,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """Docs passed while a conversion is running are queued and submitted."""
+        doc1 = self._copy_doc(sample_pdf, tmp_path, "doc1.pdf")
+        mock_pool = mocker.MagicMock()
+        self._simulate_running_conversion(conversion_widget, mock_pool, doc1)
+
+        doc2 = self._copy_doc(sample_pdf, tmp_path, "doc2.pdf")
+        conversion_widget.documents_selected([doc2])
+
+        assert doc2 in conversion_widget.documents_list.docs_list
+        assert doc2 in conversion_widget.documents_list.submitted_docs
+        # doc1 is already in submitted_docs and must not be re-queued.
+        assert mock_pool.apply_async.call_count == 1
+        # Conversion view stays: the settings widget should not reappear.
+        assert conversion_widget.settings_widget.isHidden()
+        assert not conversion_widget.documents_list.isHidden()
+
+    def test_queueing_applies_settings_to_new_doc(
+        self,
+        conversion_widget: ConversionWidget,
+        mocker: MockerFixture,
+        sample_pdf: str,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """Queued docs go through configure_document so chosen settings apply to them."""
+        doc1 = self._copy_doc(sample_pdf, tmp_path, "doc1.pdf")
+        mock_pool = mocker.MagicMock()
+        self._simulate_running_conversion(conversion_widget, mock_pool, doc1)
+
+        spy = mocker.spy(conversion_widget.settings_widget, "configure_document")
+
+        doc2 = self._copy_doc(sample_pdf, tmp_path, "doc2.pdf")
+        conversion_widget.documents_selected([doc2])
+
+        spy.assert_called_once_with(doc2)
+
+    def test_adding_doc_after_all_done_resets_to_settings(
+        self,
+        conversion_widget: ConversionWidget,
+        sample_pdf: str,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """When every doc has finished, a new selection resets to the settings flow."""
+        doc1 = self._copy_doc(sample_pdf, tmp_path, "doc1.pdf")
+        conversion_widget.documents_selected([doc1])
+        conversion_widget.conversion_started = True
+        conversion_widget.settings_widget.hide()
+        conversion_widget.documents_list.show()
+        conversion_widget.restart_button.show()
+        doc1.state = Document.STATE_SAFE
+
+        doc2 = self._copy_doc(sample_pdf, tmp_path, "doc2.pdf")
+        conversion_widget.documents_selected([doc2])
+
+        assert conversion_widget.conversion_started is False
+        assert not conversion_widget.settings_widget.isHidden()
+        assert conversion_widget.restart_button.isHidden()
+        unconverted = conversion_widget.dangerzone.get_unconverted_documents()
+        assert len(unconverted) == 1
+        assert unconverted[0].input_filename == doc2.input_filename


### PR DESCRIPTION
When a document is added during a conversion, queue it. When a document is added after a conversion is finished, start afresh and display the settings pane.

This is a sequel to #549, and especially helpful on macOS, where — if Dangerzone is the default app to open PDFs — it will show a warning with the current implementation.