### PR TITLE
Add support for Ubuntu 26.04 "Resolute Raccoon"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
-            version: "25.04"
+            version: "26.04"
           - distro: ubuntu
             version: "25.10"
           - distro: debian

--- a/.github/workflows/check_repos.yml
+++ b/.github/workflows/check_repos.yml
@@ -21,7 +21,7 @@ jobs:
           - distro: ubuntu
             version: "25.10"  # questing
           - distro: ubuntu
-            version: "25.04"  # plucky
+            version: "26.04"  # resolute
           - distro: ubuntu
             version: "24.04"  # noble
           - distro: ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
-            version: "25.04"
+            version: "26.04"
           - distro: ubuntu
             version: "25.10"
           - distro: debian
@@ -263,7 +263,7 @@ jobs:
           - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
-            version: "25.04"
+            version: "26.04"
           - distro: ubuntu
             version: "25.10"
           - distro: debian
@@ -415,7 +415,7 @@ jobs:
           - distro: ubuntu
             version: "24.04"
           - distro: ubuntu
-            version: "25.04"
+            version: "26.04"
           - distro: ubuntu
             version: "25.10"
           - distro: debian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ### Platform changes
 
+- Add support for Ubuntu 26.04 (Resolute Raccoon)
+  ([#1467](https://github.com/freedomofpress/dangerzone/issues/1467))
+- Drop support for Ubuntu 25.04 as it has reached end of life
+  ([#1468](https://github.com/freedomofpress/dangerzone/issues/1468))
 - Add a deprecation warning for Windows 10
   ([#1357](https://github.com/freedomofpress/dangerzone/issues/1357))
 - Add support for Fedora 44

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,7 +71,7 @@ Podman [sets the bottom line](https://github.com/containers/podman/blob/v5.8.1/d
 Dangerzone is available for:
 
 - Ubuntu 25.10 (questing)
-- Ubuntu 25.04 (plucky)
+- Ubuntu 26.04 (resolute)
 - Ubuntu 24.04 (noble)
 - Ubuntu 22.04 (jammy)
 - Debian 14 (forky)

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -574,8 +574,8 @@ class Env:
             elif self.distro == "ubuntu" and self.version in (
                 "24.04",
                 "noble",
-                "25.04",
-                "plucky",
+                "26.04",
+                "resolute",
                 "25.10",
                 "questing",
             ):
@@ -639,8 +639,8 @@ class Env:
             elif self.distro == "ubuntu" and self.version in (
                 "24.04",
                 "noble",
-                "25.04",
-                "plucky",
+                "26.04",
+                "resolute",
                 "25.10",
                 "questing",
             ):

--- a/dev_scripts/qa.py
+++ b/dev_scripts/qa.py
@@ -969,9 +969,9 @@ class QAUbuntu2404(QADebianBased):
     VERSION = "24.04"
 
 
-class QAUbuntu2504(QADebianBased):
+class QAUbuntu2604(QADebianBased):
     DISTRO = "ubuntu"
-    VERSION = "25.04"
+    VERSION = "26.04"
 
 
 class QAUbuntu2510(QADebianBased):


### PR DESCRIPTION
At the same time, drop support for Ubuntu 25.04, since it's EOL.

Closes #1467
Closes #1468