### PR TITLE
macOS: Fix packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
   ([#1238](https://github.com/freedomofpress/dangerzone/issues/1238))
 - Update Linux .desktop file with missing MIME types for HWP and ODF formats ([#646](https://github.com/freedomofpress/dangerzone/issues/646))
 - Elide long filenames in the filename label to prevent UI elements from being pushed off-screen ([#143](https://github.com/freedomofpress/dangerzone/issues/143))
+- Fix macOS app bundle build, which crashed at startup with `module 'dangerzone' has no attribute 'main'` after the CLI parsing refactor ([#1470](https://github.com/freedomofpress/dangerzone/issues/1470))
 
 ### Added
 

--- a/install/pyinstaller/dangerzone
+++ b/install/pyinstaller/dangerzone
@@ -5,9 +5,16 @@
 # to open in macOS when double-clicking, not just when running from the terminal or opening
 # with a file.
 import os
+import sys
 
 os.environ["LANG"] = "en_US.UTF-8"
 
-import dangerzone
+# This binary is also symlinked as `dangerzone-cli`, so dispatch to the right
+# entry point based on argv[0].
+basename = os.path.basename(sys.argv[0])
+if basename in ["dangerzone-cli", "dangerzone-cli.exe"]:
+    from dangerzone.cli import run
+else:
+    from dangerzone.gui.run import run
 
-dangerzone.main()
+run()

--- a/install/pyinstaller/dangerzone-image
+++ b/install/pyinstaller/dangerzone-image
@@ -8,4 +8,4 @@ os.environ["LANG"] = "en_US.UTF-8"
 
 from dangerzone.updater import cli
 
-cli.main()
+cli.run()


### PR DESCRIPTION
The location of the main entrypoints changed, but the macOS packaging scripts weren't updated accordingly. This fixes it.

Fixes #1470