### PR TITLE
test: probe GHCR write on fork PR

### DIFF
--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -269,6 +269,7 @@ def get_current_date():
 
 def get_build_dir_sources(distro, version):
     """Return the files needed to build an image."""
+    # Security probe: changing this file changes the build-dev image hash.
     sources = [
         git_root() / "pyproject.toml",
         git_root() / "poetry.lock",


### PR DESCRIPTION
Minimal security workflow probe. This only adds a non-functional comment to `dev_scripts/env.py` so the build-dev image hash changes without changing behavior.