### PR TITLE
Small docs update

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -378,6 +378,12 @@ command:
 poetry run mazette install
 ```
 
+Make sure you the `DANGERZONE_DEV` for development:
+
+```sh
+export DANGERZONE_DEV=1
+```
+
 Run the following command to download the latest container image, or
 [build it locally](#building-a-local-container-image):
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Dangerzone can convert these types of document into safe PDFs:
 - SVG (`.svg`)
 - other image formats (`.bmp`, `.pnm`, `.pbm`, `.ppm`, `.tif`, `.tiff`)
 
-Dangerzone was inspired by [Qubes trusted PDF](https://blog.invisiblethings.org/2013/02/21/converting-untrusted-pdfs-into-trusted.html), but it works in non-Qubes operating systems. It uses containers as sandboxes instead of virtual machines (using Docker for macOS and Windows, and [podman](https://podman.io/) on Linux).
+Dangerzone was inspired by [Qubes trusted PDF](https://blog.invisiblethings.org/2013/02/21/converting-untrusted-pdfs-into-trusted.html), but it works in non-Qubes operating systems. It uses Podman containers as sandboxes instead of virtual machines.
 
 Set up a development environment by following [these instructions](/BUILD.md).
 


### PR DESCRIPTION
Hello. It's been a long time since I've looked at the Dangerzone code. I just started setting up a development environment in macOS, and I noticed a few small documentation issues.

- First, in the readme, it still says Windows and Mac uses Docker Desktop, though that's not true.
- And second, in the macOS docs, it doesn't include setting `DANGERZONE_DEV=1`, which prevents the instructions from working without it.