### PR TITLE
Bump last known logindex

### DIFF
--- a/dangerzone/updater/log_index.py
+++ b/dangerzone/updater/log_index.py
@@ -1,3 +1,3 @@
 # RELEASE: Bump this value to the log index of the latest signature
 # to ensure the software can't upgrade to container images that predates it.
-LAST_KNOWN_LOG_INDEX = 732661252
+LAST_KNOWN_LOG_INDEX = 1825518632


### PR DESCRIPTION
When doing 0.11.0 QA, I found out that the last known log-index wasn't bumped properly. As a result, the remote image was always preferred to the local embedded one. 