### PR TITLE
feat(qubes): Build Qubes packages more easily

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -264,32 +264,16 @@ test it.
    `poetry run mazette install`.
 
 
-2. Clone the Dangerzone image repo, which holds the server-side conversion
-   component:
+2. Build the Dangerzone RPM packages for Qubes:
 
    ```sh
-   cd ~
-   git clone https://github.com/freedomofpress/dangerzone-image
+   ./install/linux/build-rpm.py --qubes
    ```
 
-3. Install some extra build dependencies:
+3. Copy the produced `.rpm` files into `fedora-43-dz`:
 
    ```sh
-   sudo dnf install -y python3-uv-build python3-pymupdf python3-magic
-   ```
-
-4. Build the Dangerzone RPM packages for Qubes:
-
-   ```sh
-   ./dangerzone/install/linux/build-rpm.py --qubes
-   ./dangerzone-image/qubes/build-rpm.sh
-   ```
-
-5. Copy the produced `.rpm` files into `fedora-43-dz`:
-
-   ```sh
-   qvm-copy ./dangerzone/dist/*.x86_64.rpm \
-       ./dangerzone-image/qubes/dist/*.noarch.rpm
+   qvm-copy ./dist/*.rpm
    ```
 
 #### In the `fedora-43-dz` template

--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -107,9 +107,13 @@ RUN apt-get update \
 """
 
 # FIXME: Install Poetry on Fedora via package manager.
+# The pyproject-rpm-macros / python3-uv-build / python3-pymupdf / python3-magic
+# packages are needed for building the dangerzone-insecure-converter-qubes RPM
+# from the dangerzone-image repo (https://github.com/freedomofpress/dangerzone-image).
 DOCKERFILE_BUILD_DEV_FEDORA_DEPS = r"""
 RUN dnf install -y git rpm-build podman python3 python3-devel python3-poetry-core \
-    pipx make qt6-qtbase-gui gcc gcc-c++\
+    pipx make qt6-qtbase-gui gcc gcc-c++ \
+    pyproject-rpm-macros python3-uv-build python3-pymupdf python3-magic \
     && dnf clean all
 
 # FIXME: Drop this fix after it's resolved upstream.

--- a/install/linux/build-rpm.py
+++ b/install/linux/build-rpm.py
@@ -4,6 +4,7 @@ import contextlib
 import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 root = Path(__file__).parent.parent.parent
@@ -33,6 +34,39 @@ def exclude_paths(paths):
         for path, backup in zip(paths, backup_paths):
             if backup.exists():
                 backup.rename(path)
+
+
+def build_insecure_converter_rpm(dist_path):
+    print("* Building dangerzone-insecure-converter-qubes package")
+    with tempfile.TemporaryDirectory(prefix="dangerzone-image.") as tmpdir:
+        clone_dir = Path(tmpdir) / "dangerzone-image"
+
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "https://github.com/freedomofpress/dangerzone-image.git",
+                str(clone_dir),
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        subprocess.run(
+            ["./qubes/build-rpm.sh"],
+            check=True,
+            cwd=clone_dir,
+        )
+
+        converter_dist = clone_dir / "qubes" / "dist"
+        for p in converter_dist.iterdir():
+            shutil.copy2(p, dist_path)
+
+        print("* dangerzone-insecure-converter-qubes package(s) copied to dist/")
+        for p in converter_dist.iterdir():
+            print(f"  {p.name}")
 
 
 def build(build_dir, qubes=False, full=False):
@@ -144,6 +178,9 @@ def build(build_dir, qubes=False, full=False):
             "_full 1",
         ]
     subprocess.run(cmd, check=True)
+
+    if qubes:
+        build_insecure_converter_rpm(dist_path)
 
     print()
     print("The following files have been created:")

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -903,6 +903,9 @@ def test_user_prompts(qtbot: QtBot, window: MainWindow, mocker: MockerFixture) -
         releases.should_check_for_updates(window.dangerzone.settings)
 
 
+@pytest.mark.skipif(
+    is_qubes_native_conversion(), reason="Qubes native conversion is enabled"
+)
 def test_user_prompts_no_container(
     qtbot: QtBot, window: MainWindow, mocker: MockerFixture
 ) -> None:
@@ -1257,7 +1260,7 @@ def test_wsl_install_failed_user_input(
         ),
     ],
 )
-def test_handle_needs_user_input_install_remote_container(
+def test_install_task_handle_user_input(
     qtbot: QtBot,
     mocker: MockerFixture,
     window: MainWindow,


### PR DESCRIPTION
Instead of cloning the freedomofpress/dangerzone-image repo separately and install build dependencies manually, incorporate this in the `build-rpm.py --qubes` script. This makes it easier to build the extra `dangerzone-insecure-converter-qubes` package either in the host, or in a container (as the `doit` script does already).

This PR depends on https://github.com/freedomofpress/dangerzone-image/pull/34.