### PR TITLE
Bump last known log index

### DIFF
--- a/dangerzone/updater/log_index.py
+++ b/dangerzone/updater/log_index.py
@@ -1,3 +1,3 @@
 # RELEASE: Bump this value to the log index of the latest signature
 # to ensure the software can't upgrade to container images that predates it.
-LAST_KNOWN_LOG_INDEX = 1825518632
+LAST_KNOWN_LOG_INDEX = 2023689270


### PR DESCRIPTION
Use the smallest log index for the 2026-06-30 image, as reported in https://github.com/freedomofpress/ghcr-signer/pull/38/changes#diff-989d7f6e9851701f14798e107c0e295a75414be28fbc4ea4840b69cd5225d074.