### PR TITLE
gui: Respect disabling update checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 ### Fixed
 
 - Accept OCI image indexes as multi-arch container images, in addition to Docker manifest lists. BuildKit 0.31.0 and later pushes OCI image indexes by default, which made `dangerzone-image prepare-archive` fail with `InvalidMutliArchImage` against newly published images ([#1534](https://github.com/freedomofpress/dangerzone/pulls/1534)).
+- Respect's user choice to disable update checks ([#1517](https://github.com/freedomofpress/dangerzone/issues/1517))
 
 ### Development changes
 
 - Add a security policy for our project
   ([#1278](https://github.com/freedomofpress/dangerzone/issues/1278))
-
 
 ## [0.11.0](https://github.com/freedomofpress/dangerzone/releases/tag/v0.11.0)
 

--- a/dangerzone/updater/releases.py
+++ b/dangerzone/updater/releases.py
@@ -138,34 +138,33 @@ def fetch_github_release_info() -> tuple[str, str]:
 def should_check_for_updates(settings: Settings) -> bool:
     """Determine if we can check for release updates based on settings and user prefs.
 
-    Note that this method only checks if the user has expressed an interest for
-    learning about new updates, and not whether we should actually make an update
-    check. Those two things are distinct, actually. For example:
+    This method checks if the user has expressed an interest for learning about new
+    updates, or if updates are mandatory. Then, it either returns:
+    * True: if the user has explicitly requested to check for updates
+    * False: if the user has explicitly requested to **not** check for updates (or if
+      it's the first time that Dangerzone runs)
+    * raise errors.NeedUserInputNoContainer: if the user **must** enable updates
+      (e.g., because there is no bundled container image).
+    * raise errors.NeedUserInput: if the user has not been asked before to enable
+      updates.
 
-    * A user may have expressed that they want to learn about new updates.
-    * A previous update check may have found out that there's a new version out.
-    * Thus we will always show to the user the cached info about the new version,
-      and won't make a new update check.
+    This method is advisory and does not perform the underlying update check.
     """
-    check = settings.get("updater_check_all")
+
+    if not is_container_tar_bundled() and not is_container_image_installed():
+        # Updates are required if there is neither a downloaded Dangerzone image on the
+        # host, nor a container image bundled in the installer.
+        log.debug("No container available, prompting user to enable updates")
+        raise errors.NeedUserInputNoContainer()
 
     if settings.get("updater_last_check") is None:
         log.debug("Dangerzone is running for the first time, updates are stalled")
         settings.set("updater_last_check", 0, autosave=True)
-        # If no container is bundled and none is installed, prompt the user
-        # to enable updates immediately, otherwise Dangerzone won't work.
-        if not is_container_tar_bundled() and not is_container_image_installed():
-            log.debug("No container available, prompting user to enable updates")
-            raise errors.NeedUserInputNoContainer()
         return False
 
-    if check is False or check is None:
-        if check is None:
-            log.debug("User has not been asked yet for update checks")
-
-        if not is_container_tar_bundled() and not is_container_image_installed():
-            log.debug("No container available, prompting user to enable updates")
-            raise errors.NeedUserInputNoContainer()
+    check = settings.get("updater_check_all")
+    if check is None:
+        log.debug("User has not been asked yet for update checks")
         raise errors.NeedUserInput()
     elif not check:
         log.debug("User has expressed that they don't want to check for updates")

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -891,16 +891,12 @@ def test_user_prompts(qtbot: QtBot, window: MainWindow, mocker: MockerFixture) -
 
     # Third run
     #
-    # If the user enabled update checks, they are not prompted again. If they
-    # disabled them, we still nudge them on every run by raising NeedUserInput.
-    from dangerzone.updater import errors as updater_errors
-
-    window.dangerzone.settings.set("updater_check_all", True)
-    assert releases.should_check_for_updates(window.dangerzone.settings) is True
-
-    window.dangerzone.settings.set("updater_check_all", False)
-    with pytest.raises(updater_errors.NeedUserInput):
-        releases.should_check_for_updates(window.dangerzone.settings)
+    # From the third run onwards, users should never be prompted for enabling update
+    # checks.
+    prompt_mock().side_effect = RuntimeError("Should not be called")
+    for check in [True, False]:
+        window.dangerzone.settings.set("updater_check_all", check)
+        assert releases.should_check_for_updates(window.dangerzone.settings) == check
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
If the user decides to disable update checks, we should respect their choice. The only exception should be in cases where there is no container image locally, or not bundled within Dangerzone. The current behavior is to always ask the user to enable update checks, but that is not helpful in airgapped installations.

This commit basically reinstates the v0.10.0 behavior in the `should_check_for_updates` function and `test_user_prompts` test.

Fixes #1517