### PR TITLE
Improve our security scan actions

### DIFF
--- a/.github/actions/scan-app/action.yml
+++ b/.github/actions/scan-app/action.yml
@@ -1,0 +1,41 @@
+name: Scan Application
+description: Scans the Dangerzone application code for vulnerabilities
+inputs:
+  path:
+    description: Path to scan
+    required: true
+    default: "."
+  severity-cutoff:
+    description: Severity cutoff for the scan
+    required: false
+    default: critical
+  upload-sarif:
+    description: Whether to upload the SARIF report
+    required: false
+    default: false
+  sarif-category:
+    description: Category for the SARIF report
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Scan application
+      uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+      id: scan
+      with:
+        path: ${{ inputs.path }}
+        fail-build: true
+        only-fixed: false
+        severity-cutoff: ${{ inputs.severity-cutoff }}
+
+    - name: Upload application scan report
+      if: ${{ inputs.upload-sarif && !cancelled() }}
+      uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif }}
+        category: ${{ inputs.sarif-category }}
+
+    - name: Inspect application scan report
+      if: always()
+      shell: bash
+      run: cat ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,9 +1,5 @@
 name: Scan nightly app
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   schedule:
     - cron: "0 0 * * *" # Run every day at 00:00 UTC.
   workflow_dispatch:
@@ -19,22 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      # NOTE: Scan first without failing, else we won't be able to read the scan
-      # report.
-      - name: Scan application (no fail)
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        id: scan_app
-        with:
-          path: "."
-          fail-build: false
-          only-fixed: false
-          severity-cutoff: critical
-      - name: Inspect application scan report
-        run: cat ${{ steps.scan_app.outputs.sarif }}
       - name: Scan application
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        uses: ./.github/actions/scan-app
         with:
-          path: "."
-          fail-build: true
-          only-fixed: false
           severity-cutoff: critical
+          upload-sarif: false

--- a/.github/workflows/scan_released.yml
+++ b/.github/workflows/scan_released.yml
@@ -4,6 +4,11 @@ on:
     - cron: '0 0 * * *' # Run every day at 00:00 UTC.
   workflow_dispatch:
 
+env:
+  # Severity cutoff is 'critical' by default, except for the 5th and 20th of
+  # month (i.e., biweekly), where we turn it to 'high'.
+  SEVERITY_CUTOFF: ${{ github.event_name == 'schedule' && (github.triggering_actor == 'schedule' && (format('{0}', github.event.schedule) == '0 0 5 * *' || format('{0}', github.event.schedule) == '0 0 20 * *')) && 'high' || 'critical' }}
+
 jobs:
   security-scan-app:
     strategy:
@@ -21,31 +26,18 @@ jobs:
         run: |
           # Grab the latest Grype ignore list before git checkout overwrites it.
           cp .grype.yaml .grype.yaml.new
+          # Grab the scan code for the GitHub action.
+          cp -r .github/actions/scan-app .github/actions/scan-app.new
           VERSION=$(curl https://api.github.com/repos/freedomofpress/dangerzone/releases/latest | jq -r '.tag_name')
           git checkout $VERSION
           # Restore the newest Grype ignore list.
           mv .grype.yaml.new .grype.yaml
-      # NOTE: Scan first without failing, else we won't be able to read the scan
-      # report.
-      - name: Scan application (no fail)
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        id: scan_app
-        with:
-          path: "."
-          fail-build: false
-          only-fixed: false
-          severity-cutoff: critical
-      - name: Upload application scan report
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
-        with:
-          sarif_file: ${{ steps.scan_app.outputs.sarif }}
-          category: app
-      - name: Inspect application scan report
-        run: cat ${{ steps.scan_app.outputs.sarif }}
+          # Restore the GHA action.
+          mv .github/actions/scan-app.new .github/actions/scan-app
+
       - name: Scan application
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        uses: ./.github/actions/scan-app
         with:
-          path: "."
-          fail-build: true
-          only-fixed: false
-          severity-cutoff: critical
+          severity-cutoff: ${{ env.SEVERITY_CUTOFF }}
+          upload-sarif: true
+          sarif-category: app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 - Add a security policy for our project
   ([#1278](https://github.com/freedomofpress/dangerzone/issues/1278))
+- Set the severity cutoff of our code scans from Critical to High, on a
+  biweekly basis
+  ([#1438](https://github.com/freedomofpress/dangerzone/pull/1438))
 
 ## [0.11.0](https://github.com/freedomofpress/dangerzone/releases/tag/v0.11.0)
 


### PR DESCRIPTION
The `scan.yml` and `scan_released.yml` actions share some common logic. Factor it out into separate actions, and provide the variables via inputs.

Moreover:
1. Change a bit the scanning logic so that we scan only once, instead of scanning twice (once without failures and then with failures).
2. Every two weeks, specifically on the 5th and 20th of each month, set the severity cutoff to High, instead of critical.

Closes #1395

_(Note, this PR is repurposed from https://github.com/freedomofpress/dangerzone/pull/1438, to decouple it from the changes required for the `SECURITY.md` file)_