### PR TITLE
Accept files from stdin, write safe PDFs to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased](https://github.com/freedomofpress/dangerzone/compare/v0.11.0...HEAD)
 
+### Added
+
+- Accept documents from stdin via `-` or implicit piping, and write safe PDFs to stdout, enabling standard Unix pipe workflows like `cat file.pdf | dangerzone > safe.pdf`
+  ([#1522](https://github.com/freedomofpress/dangerzone/issues/1522))
+
 ## [0.11.0](https://github.com/freedomofpress/dangerzone/releases/tag/v0.11.0)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ### Added
 
-- Accept documents from stdin via `-` or implicit piping, and write safe PDFs to stdout, enabling standard Unix pipe workflows like `cat file.pdf | dangerzone > safe.pdf`
+- Accept documents from stdin, and write safe PDFs to stdout, by passing `-` as the input filename and `--output-filename -` for the output, enabling standard Unix pipe workflows like `cat file.pdf | dangerzone-cli - -o - > safe.pdf`
   ([#1522](https://github.com/freedomofpress/dangerzone/issues/1522))
 
 ## [0.11.0](https://github.com/freedomofpress/dangerzone/releases/tag/v0.11.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased](https://github.com/freedomofpress/dangerzone/compare/v0.11.0...HEAD)
 
+### Added
+
+- Accept documents from stdin, and write safe PDFs to stdout, by passing `-` as the input filename and `--output-filename -` for the output, enabling standard Unix pipe workflows like `cat file.pdf | dangerzone-cli - -o - > safe.pdf`
+  ([#1522](https://github.com/freedomofpress/dangerzone/issues/1522))
+
 ### Fixed
 
 - Accept OCI image indexes as multi-arch container images, in addition to Docker manifest lists. BuildKit 0.31.0 and later pushes OCI image indexes by default, which made `dangerzone-image prepare-archive` fail with `InvalidMutliArchImage` against newly published images ([#1534](https://github.com/freedomofpress/dangerzone/pulls/1534)).

--- a/dangerzone/args.py
+++ b/dangerzone/args.py
@@ -7,6 +7,8 @@ import click
 from . import errors
 from .document import Document
 
+STDIO_DESCRIPTOR = "-"
+
 
 @errors.handle_document_errors
 def validate_input_filenames(
@@ -14,8 +16,9 @@ def validate_input_filenames(
 ) -> list[str]:
     normalized_filenames = []
     for filename in value:
-        filename = Document.normalize_filename(filename)
-        Document.validate_input_filename(filename)
+        if filename != STDIO_DESCRIPTOR:
+            filename = Document.normalize_filename(filename)
+            Document.validate_input_filename(filename)
         normalized_filenames.append(filename)
     return normalized_filenames
 

--- a/dangerzone/args.py
+++ b/dangerzone/args.py
@@ -9,18 +9,7 @@ from .document import Document
 
 
 @errors.handle_document_errors
-def _validate_input_filename(
-    ctx: click.Context, param: str, value: str | None
-) -> str | None:
-    if value is None:
-        return None
-    filename = Document.normalize_filename(value)
-    Document.validate_input_filename(filename)
-    return filename
-
-
-@errors.handle_document_errors
-def _validate_input_filenames(
+def validate_input_filenames(
     ctx: click.Context, param: list[str], value: tuple[str]
 ) -> list[str]:
     normalized_filenames = []
@@ -32,7 +21,7 @@ def _validate_input_filenames(
 
 
 @errors.handle_document_errors
-def _validate_output_filename(
+def validate_output_filename(
     ctx: click.Context, param: str, value: str | None
 ) -> str | None:
     if value is None:
@@ -40,32 +29,6 @@ def _validate_output_filename(
     filename = Document.normalize_filename(value)
     Document.validate_output_filename(filename)
     return filename
-
-
-# XXX: Click versions 7.x and below inspect the number of arguments that the
-# callback handler supports. Unfortunately, common Python decorators (such as
-# `handle_document_errors()`) mask this number, so we need to reinstate it
-# somehow [1]. The simplest way to do so is using a wrapper function.
-#
-# Once we stop supporting Click 7.x, we can remove the wrappers below.
-#
-# [1]: https://github.com/freedomofpress/dangerzone/issues/206#issuecomment-1297336863
-def validate_input_filename(
-    ctx: click.Context, param: str, value: str | None
-) -> str | None:
-    return _validate_input_filename(ctx, param, value)
-
-
-def validate_input_filenames(
-    ctx: click.Context, param: list[str], value: tuple[str]
-) -> list[str]:
-    return _validate_input_filenames(ctx, param, value)
-
-
-def validate_output_filename(
-    ctx: click.Context, param: str, value: str | None
-) -> str | None:
-    return _validate_output_filename(ctx, param, value)
 
 
 def check_suspicious_options(args: list[str]) -> None:

--- a/dangerzone/args.py
+++ b/dangerzone/args.py
@@ -29,6 +29,10 @@ def validate_output_filename(
 ) -> str | None:
     if value is None:
         return None
+    if value == STDIO_DESCRIPTOR:
+        # Writing the safe PDF to stdout. There is no filename to normalize or
+        # validate in this case.
+        return value
     filename = Document.normalize_filename(value)
     Document.validate_output_filename(filename)
     return filename

--- a/dangerzone/args.py
+++ b/dangerzone/args.py
@@ -7,6 +7,8 @@ import click
 from . import errors
 from .document import Document
 
+STDIO_DESCRIPTOR = "-"
+
 
 @errors.handle_document_errors
 def validate_input_filenames(
@@ -14,8 +16,9 @@ def validate_input_filenames(
 ) -> list[str]:
     normalized_filenames = []
     for filename in value:
-        filename = Document.normalize_filename(filename)
-        Document.validate_input_filename(filename)
+        if filename != STDIO_DESCRIPTOR:
+            filename = Document.normalize_filename(filename)
+            Document.validate_input_filename(filename)
         normalized_filenames.append(filename)
     return normalized_filenames
 
@@ -26,6 +29,10 @@ def validate_output_filename(
 ) -> str | None:
     if value is None:
         return None
+    if value == STDIO_DESCRIPTOR:
+        # Writing the safe PDF to stdout. There is no filename to normalize or
+        # validate in this case.
+        return value
     filename = Document.normalize_filename(value)
     Document.validate_output_filename(filename)
     return filename

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -15,8 +15,8 @@ from .util import get_version, replace_control_chars
 
 
 def print_header(s: str) -> None:
-    click.echo("")
-    click.echo(Style.BRIGHT + s)
+    click.echo("", err=True)
+    click.echo(Style.BRIGHT + s, err=True)
 
 
 @click.command()
@@ -88,13 +88,16 @@ def run(
         if set_container_runtime == "default":
             settings.unset_custom_runtime()
             click.echo(
-                "Instructed Dangerzone to use the default container runtime for this OS"
+                "Instructed Dangerzone to use the default container runtime for this OS",
+                err=True,
             )
         else:
             container_runtime = settings.set_custom_runtime(
                 set_container_runtime, autosave=True
             )
-            click.echo(f"Set the settings container_runtime to {container_runtime}")
+            click.echo(
+                f"Set the settings container_runtime to {container_runtime}", err=True
+            )
         sys.exit(0)
     elif not filenames:
         raise click.UsageError("Missing argument 'FILENAMES...'")
@@ -123,9 +126,9 @@ def run(
                 valid = True
                 break
         if not valid:
-            click.echo("Invalid OCR language code. Valid language codes:")
+            click.echo("Invalid OCR language code. Valid language codes:", err=True)
             for lang in dangerzone.ocr_languages:
-                click.echo(f"{dangerzone.ocr_languages[lang]}: {lang}")
+                click.echo(f"{dangerzone.ocr_languages[lang]}: {lang}", err=True)
             sys.exit(1)
 
     tasks = []
@@ -150,7 +153,8 @@ def run(
                 + "No container image found."
                 + Style.RESET_ALL
                 + " Please initialize Dangerzone by running:\n\n"
-                "    dangerzone-image upgrade\n"
+                "    dangerzone-image upgrade\n",
+                err=True,
             )
             sys.exit(1)
         print_header("Converting document(s) to safe PDF")
@@ -178,7 +182,7 @@ def run(
     if documents_failed != []:
         print_header("Failed to convert document(s)")
         for document in documents_failed:
-            click.echo(replace_control_chars(document.input_filename))
+            click.echo(replace_control_chars(str(document)), err=True)
         sys.exit(1)
     sys.exit(0)
 

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -231,7 +231,10 @@ def display_banner() -> None:
     ╰──────────────────────────╯
     """
 
-    print(Back.BLACK + Fore.YELLOW + Style.DIM + "╭──────────────────────────╮")
+    print(
+        Back.BLACK + Fore.YELLOW + Style.DIM + "╭──────────────────────────╮",
+        file=sys.stderr,
+    )
     print(
         Back.BLACK
         + Fore.YELLOW
@@ -242,7 +245,8 @@ def display_banner() -> None:
         + "           ▄██▄           "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -254,7 +258,8 @@ def display_banner() -> None:
         + "          ██████          "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -266,7 +271,8 @@ def display_banner() -> None:
         + "         ███▀▀▀██         "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -278,7 +284,8 @@ def display_banner() -> None:
         + "        ███   ████        "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -290,7 +297,8 @@ def display_banner() -> None:
         + "       ███   ██████       "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -302,7 +310,8 @@ def display_banner() -> None:
         + "      ███   ▀▀▀▀████      "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -314,7 +323,8 @@ def display_banner() -> None:
         + "     ███████  ▄██████     "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -326,7 +336,8 @@ def display_banner() -> None:
         + "    ███████ ▄█████████    "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -338,7 +349,8 @@ def display_banner() -> None:
         + "   ████████████████████   "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -350,9 +362,13 @@ def display_banner() -> None:
         + "    ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀    "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
-    print(Back.BLACK + Fore.YELLOW + Style.DIM + "│                          │")
+    print(
+        Back.BLACK + Fore.YELLOW + Style.DIM + "│                          │",
+        file=sys.stderr,
+    )
     left_spaces = (15 - len(get_version()) - 1) // 2
     right_spaces = left_spaces
     if left_spaces + len(get_version()) + 1 + right_spaces < 15:
@@ -369,7 +385,8 @@ def display_banner() -> None:
         + f"{' ' * left_spaces}Dangerzone v{get_version()}{' ' * right_spaces}"
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
@@ -382,12 +399,14 @@ def display_banner() -> None:
         + " https://dangerzone.rocks "
         + Fore.YELLOW
         + Style.DIM
-        + "│"
+        + "│",
+        file=sys.stderr,
     )
     print(
         Back.BLACK
         + Fore.YELLOW
         + Style.DIM
         + "╰──────────────────────────╯"
-        + Style.RESET_ALL
+        + Style.RESET_ALL,
+        file=sys.stderr,
     )

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -68,10 +68,19 @@ def _initialize_documents(
         "are neutralized. You can also use OCR to add a searchable text layer\n"
         "to the safe PDF, via the --ocr-lang option.\n\n"
         f"Pass one or more file paths as arguments, or use '{args.STDIO_DESCRIPTOR}'\n"
-        f"to read a document from standard input. When reading from stdin, write\n"
-        f"the safe PDF to a file with --output-filename, or to standard output\n"
-        f"with --output-filename {args.STDIO_DESCRIPTOR}. All status messages are\n"
-        "printed to standard error."
+        "to read a document from standard input. For single-document conversions, you\n"
+        "can write the safe PDF to a file with -o <file>, or to standard output\n"
+        f"with -o {args.STDIO_DESCRIPTOR}.\n\n"
+        "Examples:\n\n"
+        "\b\n"
+        "    dangerzone-cli evidence.odt                      # create evidence-safe.pdf\n"
+        "    dangerzone-cli doc1.pdf doc2.docx                # create doc1-safe.pdf and doc2-safe.pdf\n"
+        "    dangerzone-cli --archive report.docx             # create report-safe.pdf and move the original under 'unsafe/'\n"
+        "    dangerzone-cli --ocr-lang eng scan.pdf           # add a searchable text layer\n"
+        "    dangerzone-cli -o safe.pdf evidence.odt          # create safe.pdf\n"
+        f"    dangerzone-cli -o {args.STDIO_DESCRIPTOR} evidence.odt > safe.pdf      # write the safe PDF to stdout\n"
+        f"    cat evidence.pdf | dangerzone-cli {args.STDIO_DESCRIPTOR} -o safe.pdf  # read from stdin and write to safe.pdf\n"
+        f"    cat in.pdf | dangerzone-cli {args.STDIO_DESCRIPTOR} -o {args.STDIO_DESCRIPTOR} > out.pdf     # read from stdin to write to stdout\n"
     )
 )
 @click.option(

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -19,7 +19,52 @@ def print_header(s: str) -> None:
     click.echo(Style.BRIGHT + s, err=True)
 
 
-@click.command()
+def _initialize_documents(
+    dangerzone: DangerzoneCore,
+    filenames: list[str] | None,
+    archive: bool,
+    output_filename: str | None,
+) -> None:
+    """Validate that options are compatible with stdin input."""
+    if filenames is not None and len(filenames) > 1:
+        if args.STDIO_DESCRIPTOR in filenames:
+            raise click.BadArgumentUsage(
+                "Cannot mix input from stdin with other documents"
+            )
+        if output_filename:
+            raise click.BadOptionUsage(
+                option_name="--output-filename",
+                message="--output-filename can only be used with one input file",
+            )
+
+    if filenames == [args.STDIO_DESCRIPTOR] or not filenames:
+        # We are reading a single document from stdin.
+        if archive:
+            raise click.UsageError("--archive cannot be used with input from stdin")
+        if sys.stdin.isatty():
+            raise click.UsageError("No files were provided and cannot read from stdin")
+        if output_filename is None and sys.stdout.isatty():
+            raise click.UsageError(
+                "Cowardly refusing to write to a terminal.\n"
+                "Use --output-filename to specify an output file, or redirect "
+                "stdout to a file/pipe."
+            )
+        dangerzone.add_document_from_stdin(output_filename)
+        return
+
+    for filename in filenames:
+        dangerzone.add_document_from_filename(filename, output_filename, archive)
+
+
+@click.command(
+    help=(
+        "Convert potentially dangerous documents to safe PDFs.\n\n"
+        "Accepts file paths as arguments, or reads from stdin when no\n"
+        "files are given (or when '{args.STDIO_DESCRIPTOR}' is passed as a filename).\n"
+        "When reading from stdin, the safe PDF is written to stdout unless\n"
+        "--output-filename is specified. All status output goes to stderr."
+    )
+)
 @click.option(
     "--output-filename",
     callback=args.validate_output_filename,
@@ -99,8 +144,6 @@ def run(
                 f"Set the settings container_runtime to {container_runtime}", err=True
             )
         sys.exit(0)
-    elif not filenames:
-        raise click.UsageError("Missing argument 'FILENAMES...'")
 
     if getattr(sys, "dangerzone_dev", False) and dummy_conversion:
         dangerzone = DangerzoneCore(Dummy())
@@ -109,14 +152,7 @@ def run(
     else:
         dangerzone = DangerzoneCore(Container(debug=debug))
 
-    if len(filenames) == 1 and output_filename:
-        dangerzone.add_document_from_filename(filenames[0], output_filename, archive)
-    elif len(filenames) > 1 and output_filename:
-        click.echo("--output-filename can only be used with one input file.")
-        sys.exit(1)
-    else:
-        for filename in filenames:
-            dangerzone.add_document_from_filename(filename, archive=archive)
+    _initialize_documents(dangerzone, filenames, archive, output_filename)
 
     # Validate OCR language
     if ocr_lang:
@@ -172,7 +208,10 @@ def run(
     if documents_safe != []:
         print_header("Safe PDF(s) created successfully")
         for document in documents_safe:
-            click.echo(replace_control_chars(document.output_filename))
+            # When writing to stdout (data-based doc, no output filename),
+            # skip printing the filename — the PDF is already on stdout.
+            if document._data is None or document._output_filename is not None:
+                click.echo(replace_control_chars(document.output_filename), err=True)
 
         if archive:
             print_header(

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -5,7 +5,7 @@ import click
 from colorama import Back, Fore, Style
 
 from . import args, errors, shutdown, startup
-from .document import ARCHIVE_SUBDIR, SAFE_EXTENSION
+from .document import ARCHIVE_SUBDIR, SAFE_EXTENSION, Document
 from .isolation_provider.container import Container
 from .isolation_provider.dummy import Dummy
 from .isolation_provider.qubes import Qubes, is_qubes_native_conversion
@@ -25,8 +25,11 @@ def _initialize_documents(
     archive: bool,
     output_filename: str | None,
 ) -> None:
-    """Validate that options are compatible with stdin input."""
-    if filenames is not None and len(filenames) > 1:
+    """Create the Document objects based on the provided CLI arguments."""
+    if not filenames:
+        raise click.UsageError("Missing argument 'FILENAMES...'")
+
+    if len(filenames) > 1:
         if args.STDIO_DESCRIPTOR in filenames:
             raise click.BadArgumentUsage(
                 "Cannot mix input from stdin with other documents"
@@ -37,38 +40,49 @@ def _initialize_documents(
                 message="--output-filename can only be used with one input file",
             )
 
-    if filenames == [args.STDIO_DESCRIPTOR] or not filenames:
+    if filenames == [args.STDIO_DESCRIPTOR]:
         # We are reading a single document from stdin.
         if archive:
             raise click.UsageError("--archive cannot be used with input from stdin")
-        if sys.stdin.isatty():
-            raise click.UsageError("No files were provided and cannot read from stdin")
-        if output_filename is None and sys.stdout.isatty():
+        if output_filename is None:
             raise click.UsageError(
-                "Cowardly refusing to write to a terminal.\n"
-                "Use --output-filename to specify an output file, or redirect "
-                "stdout to a file/pipe."
+                "No output file specified for the input from stdin.\n"
+                "Use --output-filename <file> to write to a file, or "
+                "--output-filename - to write to stdout."
             )
-        dangerzone.add_document_from_stdin(output_filename)
+        # A data-based document with no output filename is written to stdout,
+        # so treat '-' as "no output filename".
+        if output_filename == args.STDIO_DESCRIPTOR:
+            output_filename = None
+        dangerzone.add_document(Document.from_stdin(output_filename))
         return
 
     for filename in filenames:
-        dangerzone.add_document_from_filename(filename, output_filename, archive)
+        dangerzone.add_document(Document(filename, output_filename, archive=archive))
 
 
 @click.command(
     help=(
         "Convert potentially dangerous documents to safe PDFs.\n\n"
-        "Accepts file paths as arguments, or reads from stdin when no\n"
-        "files are given (or when '{args.STDIO_DESCRIPTOR}' is passed as a filename).\n"
-        "When reading from stdin, the safe PDF is written to stdout unless\n"
-        "--output-filename is specified. All status output goes to stderr."
+        "Documents are converted inside a sandbox, so that any embedded threats\n"
+        "are neutralized. You can also use OCR to add a searchable text layer\n"
+        "to the safe PDF, via the --ocr-lang option.\n\n"
+        f"Pass one or more file paths as arguments, or use '{args.STDIO_DESCRIPTOR}'\n"
+        f"to read a document from standard input. When reading from stdin, write\n"
+        f"the safe PDF to a file with --output-filename, or to standard output\n"
+        f"with --output-filename {args.STDIO_DESCRIPTOR}. All status messages are\n"
+        "printed to standard error."
     )
 )
 @click.option(
     "--output-filename",
+    "-o",
     callback=args.validate_output_filename,
-    help=f"Default is filename ending with {SAFE_EXTENSION}",
+    help=(
+        f"Output filename for the safe PDF. Default is the input filename with"
+        f" '{SAFE_EXTENSION}' appended. Alternatively, use '{args.STDIO_DESCRIPTOR}' to"
+        " write the safe PDF to standard output."
+    ),
 )
 @click.option("--ocr-lang", help="Language to OCR, defaults to none")
 @click.option(
@@ -206,11 +220,11 @@ def run(
     documents_failed = dangerzone.get_failed_documents()
 
     if documents_safe != []:
-        print_header("Safe PDF(s) created successfully")
-        for document in documents_safe:
-            # When writing to stdout (data-based doc, no output filename),
-            # skip printing the filename — the PDF is already on stdout.
-            if document._data is None or document._output_filename is not None:
+        if len(documents_safe) == 1 and documents_safe[0]._output_filename is None:
+            print_header("Safe PDF written successfully to stdout")
+        else:
+            print_header("Safe PDF(s) created successfully")
+            for document in documents_safe:
                 click.echo(replace_control_chars(document.output_filename), err=True)
 
         if archive:

--- a/dangerzone/cli.py
+++ b/dangerzone/cli.py
@@ -5,7 +5,7 @@ import click
 from colorama import Back, Fore, Style
 
 from . import args, errors, shutdown, startup
-from .document import ARCHIVE_SUBDIR, SAFE_EXTENSION
+from .document import ARCHIVE_SUBDIR, SAFE_EXTENSION, Document
 from .isolation_provider.container import Container
 from .isolation_provider.dummy import Dummy
 from .isolation_provider.qubes import Qubes, is_qubes_native_conversion
@@ -19,11 +19,58 @@ def print_header(s: str) -> None:
     click.echo(Style.BRIGHT + s, err=True)
 
 
+def _initialize_documents(
+    dangerzone: DangerzoneCore,
+    filenames: list[str] | None,
+    archive: bool,
+    output_filename: str | None,
+) -> None:
+    """Create the Document objects based on the provided CLI arguments."""
+    if not filenames:
+        raise click.UsageError("Missing argument 'FILENAMES...'")
+
+    if len(filenames) > 1:
+        if args.STDIO_DESCRIPTOR in filenames:
+            raise click.BadArgumentUsage(
+                "Cannot mix input from stdin with other documents"
+            )
+        if output_filename:
+            raise click.BadOptionUsage(
+                option_name="--output-filename",
+                message="--output-filename can only be used with one input file",
+            )
+
+    if filenames == [args.STDIO_DESCRIPTOR]:
+        # We are reading a single document from stdin.
+        if archive:
+            raise click.UsageError("--archive cannot be used with input from stdin")
+        if output_filename is None:
+            raise click.UsageError(
+                "No output file specified for the input from stdin.\n"
+                "Use --output-filename <file> to write to a file, or "
+                "--output-filename - to write to stdout."
+            )
+        # A data-based document with no output filename is written to stdout,
+        # so treat '-' as "no output filename".
+        if output_filename == args.STDIO_DESCRIPTOR:
+            output_filename = None
+        dangerzone.add_document(Document.from_stdin(output_filename))
+        return
+
+    for filename in filenames:
+        dangerzone.add_document(Document(filename, output_filename, archive=archive))
+
+
 @click.command()
 @click.option(
     "--output-filename",
+    "-o",
     callback=args.validate_output_filename,
-    help=f"Default is filename ending with {SAFE_EXTENSION}",
+    help=(
+        f"Output filename for the safe PDF. Default is the input filename with"
+        f" '{SAFE_EXTENSION}' appended. Alternatively, use '{args.STDIO_DESCRIPTOR}' to"
+        " write the safe PDF to standard output."
+    ),
 )
 @click.option("--ocr-lang", help="Language to OCR, defaults to none")
 @click.option(
@@ -81,6 +128,28 @@ def run(
     set_container_runtime: str | None = None,
     linger: bool = False,
 ) -> None:
+    """Convert potentially dangerous documents to safe PDFs.
+
+    Documents are converted inside a sandbox, so that any embedded threats
+    are neutralized. You can also use OCR to add a searchable text layer
+    to the safe PDF, via the --ocr-lang option.
+
+    Pass one or more file paths as arguments, or use '-' to read a document from
+    standard input. For single-document conversions, you can write the safe PDF to a
+    file with '-o <file>', or to standard output with '-o -'.
+
+    Examples:
+
+    \b
+        dangerzone-cli evidence.odt                  # convert to 'evidence-safe.pdf'
+        dangerzone-cli doc1.pdf doc2.docx            # convert to 'doc1-safe.pdf' and 'doc2-safe.pdf'
+        dangerzone-cli --archive report.docx         # convert to 'report-safe.pdf' and move the original under './unsafe/'
+        dangerzone-cli --ocr-lang eng scan.pdf       # add a searchable text layer in English
+        dangerzone-cli -o out.pdf in.pdf             # write to 'out.pdf'
+        dangerzone-cli -o - in.pdf > out.pdf         # write to stdout and pipe to 'out.pdf'
+        dangerzone-cli - -o out.pdf < in.pdf         # read from stdin and write to 'out.pdf'
+        dangerzone-cli - -o - < in.pdf > out.pdf     # read from stdin, write to stdout and pipe to 'out.pdf'
+    """
     setup_logging()
     display_banner()
     settings = Settings(debug=debug)
@@ -99,8 +168,6 @@ def run(
                 f"Set the settings container_runtime to {container_runtime}", err=True
             )
         sys.exit(0)
-    elif not filenames:
-        raise click.UsageError("Missing argument 'FILENAMES...'")
 
     if getattr(sys, "dangerzone_dev", False) and dummy_conversion:
         dangerzone = DangerzoneCore(Dummy())
@@ -109,14 +176,7 @@ def run(
     else:
         dangerzone = DangerzoneCore(Container(debug=debug))
 
-    if len(filenames) == 1 and output_filename:
-        dangerzone.add_document_from_filename(filenames[0], output_filename, archive)
-    elif len(filenames) > 1 and output_filename:
-        click.echo("--output-filename can only be used with one input file.")
-        sys.exit(1)
-    else:
-        for filename in filenames:
-            dangerzone.add_document_from_filename(filename, archive=archive)
+    _initialize_documents(dangerzone, filenames, archive, output_filename)
 
     # Validate OCR language
     if ocr_lang:
@@ -170,9 +230,12 @@ def run(
     documents_failed = dangerzone.get_failed_documents()
 
     if documents_safe != []:
-        print_header("Safe PDF(s) created successfully")
-        for document in documents_safe:
-            click.echo(replace_control_chars(document.output_filename))
+        if len(documents_safe) == 1 and documents_safe[0]._output_filename is None:
+            print_header("Safe PDF written successfully to stdout")
+        else:
+            print_header("Safe PDF(s) created successfully")
+            for document in documents_safe:
+                click.echo(replace_control_chars(document.output_filename), err=True)
 
         if archive:
             print_header(

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -4,7 +4,10 @@ import os
 import platform
 import re
 import secrets
+import sys
+from io import BytesIO
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import BinaryIO
 
 from . import errors, util
 
@@ -33,24 +36,39 @@ class Document:
         output_filename: str | None = None,
         suffix: str = SAFE_EXTENSION,
         archive: bool = False,
+        data: bytes | None = None,
     ) -> None:
         # NOTE: See https://github.com/freedomofpress/dangerzone/pull/216#discussion_r1015449418
         self.id = secrets.token_urlsafe(6)[0:6]
 
         self._input_filename: str | None = None
         self._output_filename: str | None = None
+        self._data: bytes | None = None
         self._archive = False
         self._suffix = suffix
 
-        if input_filename:
+        if input_filename and data:
+            raise ValueError("Cannot provide both input_filename and data")
+        elif input_filename:
             self.input_filename = input_filename
+        elif data:
+            self._data = data
+            self.announce_id()
+        else:
+            raise errors.NotSetInputFilenameException()
 
-            if output_filename:
-                self.output_filename = output_filename
+        if output_filename is not None:
+            self.output_filename = output_filename
 
         self.state = Document.STATE_UNCONVERTED
-
         self.archive_after_conversion = archive
+
+    @classmethod
+    def from_stdin(cls, output_filename: str | None = None) -> "Document":
+        data = sys.stdin.buffer.read()
+        if not data:
+            raise ValueError("No data received from stdin")
+        return cls(input_filename=None, output_filename=output_filename, data=data)
 
     @staticmethod
     def normalize_filename(filename: str) -> str:
@@ -97,8 +115,7 @@ class Document:
     def input_filename(self) -> str:
         if self._input_filename is None:
             raise errors.NotSetInputFilenameException()
-        else:
-            return self._input_filename
+        return self._input_filename
 
     @input_filename.setter
     def input_filename(self, filename: str) -> None:
@@ -112,16 +129,18 @@ class Document:
         if self._output_filename is None:
             if self._input_filename is not None:
                 return self.default_output_filename
-            else:
-                raise errors.NotSetOutputFilenameException()
-        else:
-            return self._output_filename
+            raise errors.NotSetOutputFilenameException()
+        return self._output_filename
 
     @output_filename.setter
     def output_filename(self, filename: str) -> None:
         filename = self.normalize_filename(filename)
         self.validate_output_filename(filename)
         self._output_filename = filename
+
+    @property
+    def sanitized_input_filename(self) -> str:
+        return util.replace_control_chars(self.input_filename)
 
     @property
     def sanitized_output_filename(self) -> str:
@@ -173,8 +192,33 @@ class Document:
         return f"{os.path.splitext(self.input_filename)[0]}{self.suffix}"
 
     def announce_id(self) -> None:
-        sanitized_filename = util.replace_control_chars(self.input_filename)
-        log.info(f"Assigning ID '{self.id}' to doc '{sanitized_filename}'")
+        if self._input_filename is not None:
+            log.info(
+                f"Assigning ID '{self.id}' to doc '{self.sanitized_input_filename}'"
+            )
+        else:
+            log.info(f"Assigning ID '{self.id}' to doc from '<stdin>'")
+
+    def open(self) -> BinaryIO:
+        """Return a readable binary stream for this document's content."""
+        if self._input_filename is not None:
+            return open(self._input_filename, "rb")
+        elif self._data is not None:
+            return BytesIO(self._data)
+        else:
+            raise errors.NotSetInputFilenameException()
+
+    def write(self, pdf_data: bytes) -> None:
+        """Write the safe PDF data to the proper destination.
+
+        For data-based documents (from stdin) with no output filename,
+        write to stdout. Otherwise, write to the output filename.
+        """
+        if self._data is not None and self._output_filename is None:
+            sys.stdout.buffer.write(pdf_data)
+        else:
+            with open(self.output_filename, "wb") as f:
+                f.write(pdf_data)
 
     def set_output_dir(self, path: str) -> None:
         # keep the same name
@@ -217,13 +261,19 @@ class Document:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Document):
             return False
-        return (
-            Path(self.input_filename).absolute()
-            == Path(other.input_filename).absolute()
-        )
+        if self._input_filename is not None and other._input_filename is not None:
+            return (
+                Path(self.input_filename).absolute()
+                == Path(other.input_filename).absolute()
+            )
+        return self.id == other.id
 
     def __hash__(self) -> int:
-        return hash(str(Path(self.input_filename).absolute()))
+        if self._input_filename is not None:
+            return hash(str(Path(self.input_filename).absolute()))
+        return hash(self.id)
 
     def __str__(self) -> str:
-        return self.input_filename
+        if self._input_filename is not None:
+            return self.input_filename
+        return "<stdin>"

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -192,12 +192,7 @@ class Document:
         return f"{os.path.splitext(self.input_filename)[0]}{self.suffix}"
 
     def announce_id(self) -> None:
-        if self._input_filename is not None:
-            log.info(
-                f"Assigning ID '{self.id}' to doc '{self.sanitized_input_filename}'"
-            )
-        else:
-            log.info(f"Assigning ID '{self.id}' to doc from '<stdin>'")
+        log.info(f"Assigning ID '{self.id}' to doc '{self!s}'")
 
     def open(self) -> BinaryIO:
         """Return a readable binary stream for this document's content."""

--- a/dangerzone/document.py
+++ b/dangerzone/document.py
@@ -4,7 +4,10 @@ import os
 import platform
 import re
 import secrets
+import sys
+from io import BytesIO
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import BinaryIO
 
 from . import errors, util
 
@@ -33,24 +36,39 @@ class Document:
         output_filename: str | None = None,
         suffix: str = SAFE_EXTENSION,
         archive: bool = False,
+        data: bytes | None = None,
     ) -> None:
         # NOTE: See https://github.com/freedomofpress/dangerzone/pull/216#discussion_r1015449418
         self.id = secrets.token_urlsafe(6)[0:6]
 
         self._input_filename: str | None = None
         self._output_filename: str | None = None
+        self._data: bytes | None = None
         self._archive = False
         self._suffix = suffix
 
-        if input_filename:
+        if input_filename and data:
+            raise ValueError("Cannot provide both input_filename and data")
+        elif input_filename:
             self.input_filename = input_filename
+        elif data:
+            self._data = data
+            self.announce_id()
+        else:
+            raise errors.NotSetInputFilenameException()
 
-            if output_filename:
-                self.output_filename = output_filename
+        if output_filename is not None:
+            self.output_filename = output_filename
 
         self.state = Document.STATE_UNCONVERTED
-
         self.archive_after_conversion = archive
+
+    @classmethod
+    def from_stdin(cls, output_filename: str | None = None) -> "Document":
+        data = sys.stdin.buffer.read()
+        if not data:
+            raise ValueError("No data received from stdin")
+        return cls(input_filename=None, output_filename=output_filename, data=data)
 
     @staticmethod
     def normalize_filename(filename: str) -> str:
@@ -97,8 +115,7 @@ class Document:
     def input_filename(self) -> str:
         if self._input_filename is None:
             raise errors.NotSetInputFilenameException()
-        else:
-            return self._input_filename
+        return self._input_filename
 
     @input_filename.setter
     def input_filename(self, filename: str) -> None:
@@ -112,16 +129,18 @@ class Document:
         if self._output_filename is None:
             if self._input_filename is not None:
                 return self.default_output_filename
-            else:
-                raise errors.NotSetOutputFilenameException()
-        else:
-            return self._output_filename
+            raise errors.NotSetOutputFilenameException()
+        return self._output_filename
 
     @output_filename.setter
     def output_filename(self, filename: str) -> None:
         filename = self.normalize_filename(filename)
         self.validate_output_filename(filename)
         self._output_filename = filename
+
+    @property
+    def sanitized_input_filename(self) -> str:
+        return util.replace_control_chars(self.input_filename)
 
     @property
     def sanitized_output_filename(self) -> str:
@@ -173,8 +192,28 @@ class Document:
         return f"{os.path.splitext(self.input_filename)[0]}{self.suffix}"
 
     def announce_id(self) -> None:
-        sanitized_filename = util.replace_control_chars(self.input_filename)
-        log.info(f"Assigning ID '{self.id}' to doc '{sanitized_filename}'")
+        log.info(f"Assigning ID '{self.id}' to doc '{self!s}'")
+
+    def open(self) -> BinaryIO:
+        """Return a readable binary stream for this document's content."""
+        if self._input_filename is not None:
+            return open(self._input_filename, "rb")
+        elif self._data is not None:
+            return BytesIO(self._data)
+        else:
+            raise errors.NotSetInputFilenameException()
+
+    def write(self, pdf_data: bytes) -> None:
+        """Write the safe PDF data to the proper destination.
+
+        For data-based documents (from stdin) with no output filename,
+        write to stdout. Otherwise, write to the output filename.
+        """
+        if self._data is not None and self._output_filename is None:
+            sys.stdout.buffer.write(pdf_data)
+        else:
+            with open(self.output_filename, "wb") as f:
+                f.write(pdf_data)
 
     def set_output_dir(self, path: str) -> None:
         # keep the same name
@@ -217,13 +256,19 @@ class Document:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Document):
             return False
-        return (
-            Path(self.input_filename).absolute()
-            == Path(other.input_filename).absolute()
-        )
+        if self._input_filename is not None and other._input_filename is not None:
+            return (
+                Path(self.input_filename).absolute()
+                == Path(other.input_filename).absolute()
+            )
+        return self.id == other.id
 
     def __hash__(self) -> int:
-        return hash(str(Path(self.input_filename).absolute()))
+        if self._input_filename is not None:
+            return hash(str(Path(self.input_filename).absolute()))
+        return hash(self.id)
 
     def __str__(self) -> str:
-        return self.input_filename
+        if self._input_filename is not None:
+            return self.input_filename
+        return "<stdin>"

--- a/dangerzone/isolation_provider/base.py
+++ b/dangerzone/isolation_provider/base.py
@@ -189,7 +189,7 @@ class IsolationProvider(ABC):
         percentage = 0.0
         # Write the content of the to-be-converted document to the stdin of
         # the conversion process.
-        with open(document.input_filename, "rb") as f:
+        with document.open() as f:
             try:
                 assert p.stdin is not None
                 p.stdin.write(f.read())
@@ -315,10 +315,8 @@ class IsolationProvider(ABC):
         # Ensure nothing else is read after all bitmaps are obtained
         p.stdout.close()
 
-        # Saving it with a different name first, because PyMuPDF cannot handle
-        # non-Unicode chars.
-        safe_doc.save(document.sanitized_output_filename)
-        os.replace(document.sanitized_output_filename, document.output_filename)
+        # Write the safe PDF to the document's destination.
+        document.write(safe_doc.tobytes())
 
         # TODO handle leftover code input
         text = "Successfully converted document"

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -42,6 +42,10 @@ class DangerzoneCore:
         doc = Document(input_filename, output_filename, archive=archive)
         self.add_document(doc)
 
+    def add_document_from_stdin(self, output_filename: str | None = None) -> None:
+        doc = Document.from_stdin(output_filename=output_filename)
+        self.add_document(doc)
+
     def add_document(self, doc: Document) -> None:
         if doc in self.documents:
             raise errors.AddedDuplicateDocumentException()

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -33,19 +33,6 @@ class DangerzoneCore:
         self.documents: list[Document] = []
         self.isolation_provider = isolation_provider
 
-    def add_document_from_filename(
-        self,
-        input_filename: str,
-        output_filename: str | None = None,
-        archive: bool = False,
-    ) -> None:
-        doc = Document(input_filename, output_filename, archive=archive)
-        self.add_document(doc)
-
-    def add_document_from_stdin(self, output_filename: str | None = None) -> None:
-        doc = Document.from_stdin(output_filename=output_filename)
-        self.add_document(doc)
-
     def add_document(self, doc: Document) -> None:
         if doc in self.documents:
             raise errors.AddedDuplicateDocumentException()

--- a/dangerzone/logic.py
+++ b/dangerzone/logic.py
@@ -33,15 +33,6 @@ class DangerzoneCore:
         self.documents: list[Document] = []
         self.isolation_provider = isolation_provider
 
-    def add_document_from_filename(
-        self,
-        input_filename: str,
-        output_filename: str | None = None,
-        archive: bool = False,
-    ) -> None:
-        doc = Document(input_filename, output_filename, archive=archive)
-        self.add_document(doc)
-
     def add_document(self, doc: Document) -> None:
         if doc in self.documents:
             raise errors.AddedDuplicateDocumentException()

--- a/tests/isolation_provider/base.py
+++ b/tests/isolation_provider/base.py
@@ -75,7 +75,7 @@ class IsolationProviderTermination:
     ) -> None:
         # Check that we don't need to terminate any process, if the conversion completes
         # successfully.
-        doc = Document()
+        doc = Document(data=b"test")
         provider.progress_callback = mocker.MagicMock()
         get_proc_exception_spy = mocker.spy(provider, "get_proc_exception")
         terminate_proc_spy = mocker.spy(provider, "terminate_doc_to_pixels_proc")
@@ -98,7 +98,7 @@ class IsolationProviderTermination:
     ) -> None:
         # Check that successful conversions that linger for a little while are
         # terminated gracefully.
-        doc = Document()
+        doc = Document(data=b"test")
         provider.progress_callback = mocker.MagicMock()
         get_proc_exception_spy = mocker.spy(provider, "get_proc_exception")
         terminate_proc_spy = mocker.spy(provider, "terminate_doc_to_pixels_proc")
@@ -120,7 +120,7 @@ class IsolationProviderTermination:
     ) -> None:
         # Check that successful conversions that cannot be terminated gracefully, are
         # killed forcefully.
-        doc = Document()
+        doc = Document(data=b"test")
         get_proc_exception_spy = mocker.spy(provider, "get_proc_exception")
         # We mock the terminate_doc_to_pixels_proc() method, so that the process must be
         # killed.
@@ -144,7 +144,7 @@ class IsolationProviderTermination:
     ) -> None:
         # Check that if a conversion process cannot be killed, at least it will not
         # block the operation.
-        doc = Document()
+        doc = Document(data=b"test")
         get_proc_exception_spy = mocker.spy(provider, "get_proc_exception")
         # We mock both the terminate_doc_to_pixels_proc() method, and our kill
         # invocation, so that the process will seem as unkillable.
@@ -181,7 +181,7 @@ class IsolationProviderTermination:
     ) -> None:
         # Check that we don't need to terminate any process, if the conversion fails.
         # However, we should be able to get the return code.
-        doc = Document()
+        doc = Document(data=b"test")
         provider.progress_callback = mocker.MagicMock()
         get_proc_exception_spy = mocker.spy(provider, "get_proc_exception")
         terminate_proc_spy = mocker.spy(provider, "terminate_doc_to_pixels_proc")
@@ -214,7 +214,7 @@ class IsolationProviderTermination:
     ) -> None:
         # Check that if the failed process has not exited, the error code that will be
         # returned is UnexpectedExceptionError.
-        doc = Document()
+        doc = Document(data=b"test")
         provider.progress_callback = mocker.MagicMock()
         get_proc_exception_spy = mocker.spy(provider, "get_proc_exception")
         terminate_proc_spy = mocker.spy(provider, "terminate_doc_to_pixels_proc")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,6 @@ import tempfile
 import traceback
 from collections.abc import Sequence
 from pathlib import Path
-from unittest import mock
 
 import pytest
 from click.testing import CliRunner, Result
@@ -461,49 +460,27 @@ class TestCliIO(TestCli):
         return CLIResult.reclass_click_result(result, args)
 
     def test_stdin_dash(self) -> None:
-        """dangerzone - converts from stdin via dummy provider."""
-        result = self.run_cli_stdin(["-"])
+        """dangerzone - -o - converts from stdin via dummy provider."""
+        result = self.run_cli_stdin(["-", "-o", "-"])
         result.assert_success()
 
-    def test_stdin_implicit(self) -> None:
-        """No filenames given, stdin piped -> enters stdin mode."""
-        result = self.run_cli_stdin([])
-        result.assert_success()
+    def test_stdin_dash_no_output(self) -> None:
+        """'-' without an output filename -> error, asks for an output."""
+        result = self.run_cli_stdin(["-"])
+        result.assert_failure(message="No output file specified")
 
     def test_stdin_empty(self) -> None:
         """Empty stdin -> error."""
-        result = self.run_cli_stdin(["-"], input=b"")
+        result = self.run_cli_stdin(["-", "-o", "-"], input=b"")
         result.assert_failure()
         assert "No data received from stdin" == str(result.exception)
-
-    def test_stdin_no_args(self) -> None:
-        """No args, no stdin -> error."""
-        runner = CliRunner()
-        # Mock sys.stdin.isatty to return True so that no files error fires.
-        # We patch dangerzone.cli.sys so the CLI code sees our mock.
-        mock_sys = mock.MagicMock(wraps=sys)
-        mock_sys.stdin.isatty.return_value = True
-        with mock.patch("dangerzone.cli.sys", mock_sys):
-            result = runner.invoke(run, [])
-        assert result.exit_code != 0
-        assert "No files were provided and cannot read from stdin" in result.output
 
     def test_stdin_archive_rejected(self) -> None:
         """--archive with stdin -> error."""
         result = self.run_cli_stdin(["-", "--archive"])
         result.assert_failure(message="--archive cannot be used with input from stdin")
 
-    def test_stdin_cowardly_refusal(self) -> None:
-        """Stdin without --output-filename when stdout is a TTY -> error."""
-        # Mock sys.stdout.isatty to return True so the cowardly refusal fires.
-        # We patch dangerzone.cli.sys so the CLI code sees our mock.
-        mock_sys = mock.MagicMock(wraps=sys)
-        mock_sys.stdout.isatty.return_value = True
-        with mock.patch("dangerzone.cli.sys", mock_sys):
-            result = self.run_cli_stdin(["-"])
-        result.assert_failure(message="Cowardly refusing")
-
-    def test_stdin_output(self, tmp_path: Path, mocker: MockerFixture) -> None:
+    def test_stdin_output(self, tmp_path: Path) -> None:
         """dangerzone - --output-filename writes safe PDF to that file."""
         output_filename = tmp_path / "safe-from-stdin.pdf"
         assert not output_filename.exists()
@@ -513,10 +490,7 @@ class TestCliIO(TestCli):
             data = f.read()
 
         # Try again with stdout as output
-        output_filename_2 = tmp_path / "safe-from-stdin-2.pdf"
-        assert not output_filename_2.exists()
-        result = self.run_cli_stdin(["-"])
+        result = self.run_cli_stdin(["-", "-o", "-"])
         result.assert_success()
-        with output_filename.open() as f:
-            assert len(data) == len(result.stdout_bytes)
-            assert data[:-100] == result.stdout_bytes[:-100]
+        assert len(data) == len(result.stdout_bytes)
+        assert data[:-100] == result.stdout_bytes[:-100]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,8 +172,8 @@ class TestCliBasic(TestCli):
 
     def test_display_banner(self, capfd) -> None:  # type: ignore[no-untyped-def]
         display_banner()  # call the test subject
-        (out, _err) = capfd.readouterr()
-        plain_lines = [strip_ansi(line) for line in out.splitlines()]
+        (_out, err) = capfd.readouterr()
+        plain_lines = [strip_ansi(line) for line in err.splitlines()]
         assert "╭──────────────────────────╮" in plain_lines, "missing top border"
         assert "╰──────────────────────────╯" in plain_lines, "missing bottom border"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import tempfile
 import traceback
 from collections.abc import Sequence
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from click.testing import CliRunner, Result
@@ -443,3 +444,79 @@ class TestCliShutdown(TestCli):
         result.assert_failure()
         mock_container_stop.assert_not_called()
         mock_machine_stop.assert_not_called()
+
+
+class TestCliIO(TestCli):
+    """Tests for stdin/stdout I/O support."""
+
+    def run_cli_stdin(
+        self,
+        args: list[str],
+        input: bytes = b"test data to trigger read from stdin",
+    ) -> CLIResult:
+        """Run the CLI with the given args and feed input_data to stdin."""
+        args.append("--unsafe-dummy-conversion")
+        runner = CliRunner()
+        result = runner.invoke(run, args, input=input)
+        return CLIResult.reclass_click_result(result, args)
+
+    def test_stdin_dash(self) -> None:
+        """dangerzone - converts from stdin via dummy provider."""
+        result = self.run_cli_stdin(["-"])
+        result.assert_success()
+
+    def test_stdin_implicit(self) -> None:
+        """No filenames given, stdin piped -> enters stdin mode."""
+        result = self.run_cli_stdin([])
+        result.assert_success()
+
+    def test_stdin_empty(self) -> None:
+        """Empty stdin -> error."""
+        result = self.run_cli_stdin(["-"], input=b"")
+        result.assert_failure()
+        assert "No data received from stdin" == str(result.exception)
+
+    def test_stdin_no_args(self) -> None:
+        """No args, no stdin -> error."""
+        runner = CliRunner()
+        # Mock sys.stdin.isatty to return True so that no files error fires.
+        # We patch dangerzone.cli.sys so the CLI code sees our mock.
+        mock_sys = mock.MagicMock(wraps=sys)
+        mock_sys.stdin.isatty.return_value = True
+        with mock.patch("dangerzone.cli.sys", mock_sys):
+            result = runner.invoke(run, [])
+        assert result.exit_code != 0
+        assert "No files were provided and cannot read from stdin" in result.output
+
+    def test_stdin_archive_rejected(self) -> None:
+        """--archive with stdin -> error."""
+        result = self.run_cli_stdin(["-", "--archive"])
+        result.assert_failure(message="--archive cannot be used with input from stdin")
+
+    def test_stdin_cowardly_refusal(self) -> None:
+        """Stdin without --output-filename when stdout is a TTY -> error."""
+        # Mock sys.stdout.isatty to return True so the cowardly refusal fires.
+        # We patch dangerzone.cli.sys so the CLI code sees our mock.
+        mock_sys = mock.MagicMock(wraps=sys)
+        mock_sys.stdout.isatty.return_value = True
+        with mock.patch("dangerzone.cli.sys", mock_sys):
+            result = self.run_cli_stdin(["-"])
+        result.assert_failure(message="Cowardly refusing")
+
+    def test_stdin_output(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """dangerzone - --output-filename writes safe PDF to that file."""
+        output_filename = tmp_path / "safe-from-stdin.pdf"
+        assert not output_filename.exists()
+        result = self.run_cli_stdin(["-", "--output-filename", str(output_filename)])
+        result.assert_success()
+        with output_filename.open("rb") as f:
+            data = f.read()
+
+        # Try again with stdout as output
+        output_filename_2 = tmp_path / "safe-from-stdin-2.pdf"
+        assert not output_filename_2.exists()
+        result = self.run_cli_stdin(["-"])
+        result.assert_success()
+        with output_filename.open() as f:
+            assert len(data) == len(result.stdout_bytes)
+            assert data[:-100] == result.stdout_bytes[:-100]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -443,3 +443,54 @@ class TestCliShutdown(TestCli):
         result.assert_failure()
         mock_container_stop.assert_not_called()
         mock_machine_stop.assert_not_called()
+
+
+class TestCliIO(TestCli):
+    """Tests for stdin/stdout I/O support."""
+
+    def run_cli_stdin(
+        self,
+        args: list[str],
+        input: bytes = b"test data to trigger read from stdin",
+    ) -> CLIResult:
+        """Run the CLI with the given args and feed input_data to stdin."""
+        args.append("--unsafe-dummy-conversion")
+        runner = CliRunner()
+        result = runner.invoke(run, args, input=input)
+        return CLIResult.reclass_click_result(result, args)
+
+    def test_stdin_dash(self) -> None:
+        """dangerzone - -o - converts from stdin via dummy provider."""
+        result = self.run_cli_stdin(["-", "-o", "-"])
+        result.assert_success()
+
+    def test_stdin_dash_no_output(self) -> None:
+        """'-' without an output filename -> error, asks for an output."""
+        result = self.run_cli_stdin(["-"])
+        result.assert_failure(message="No output file specified")
+
+    def test_stdin_empty(self) -> None:
+        """Empty stdin -> error."""
+        result = self.run_cli_stdin(["-", "-o", "-"], input=b"")
+        result.assert_failure()
+        assert "No data received from stdin" == str(result.exception)
+
+    def test_stdin_archive_rejected(self) -> None:
+        """--archive with stdin -> error."""
+        result = self.run_cli_stdin(["-", "--archive"])
+        result.assert_failure(message="--archive cannot be used with input from stdin")
+
+    def test_stdin_output(self, tmp_path: Path) -> None:
+        """dangerzone - --output-filename writes safe PDF to that file."""
+        output_filename = tmp_path / "safe-from-stdin.pdf"
+        assert not output_filename.exists()
+        result = self.run_cli_stdin(["-", "--output-filename", str(output_filename)])
+        result.assert_success()
+        with output_filename.open("rb") as f:
+            data = f.read()
+
+        # Try again with stdout as output
+        result = self.run_cli_stdin(["-", "-o", "-"])
+        result.assert_success()
+        assert len(data) == len(result.stdout_bytes)
+        assert data[:-100] == result.stdout_bytes[:-100]

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -17,18 +17,12 @@ def test_input_sample_init_archive(sample_pdf: str) -> None:
     Document(sample_pdf, archive=True)
 
 
-def test_input_sample_after(sample_pdf: str) -> None:
-    d = Document()
-    d.input_filename = sample_pdf
-
-
 def test_input_file_none() -> None:
     """
     Attempts to read a document's filename when no doc has been set
     """
-    d = Document()
     with pytest.raises(errors.NotSetInputFilenameException):
-        _ = d.input_filename
+        _d = Document()
 
 
 def test_input_file_non_existing() -> None:
@@ -55,23 +49,14 @@ def test_output_file_unwriteable_dir(sample_pdf: str, tmp_path: Path) -> None:
 
 
 def test_output(tmp_path: Path) -> None:
-    pdf_file = str(tmp_path.joinpath("document.pdf"))
-    d = Document()
-    d.output_filename = pdf_file
-
-
-def test_output_file_none() -> None:
-    """
-    Attempts to read a document's filename when no doc has been set
-    """
-    d = Document()
-    with pytest.raises(errors.NotSetOutputFilenameException):
-        _ = d.output_filename
+    out_path = str(tmp_path.joinpath("output.pdf"))
+    d = Document(data=b"test")
+    d.output_filename = out_path
 
 
 def test_output_file_not_pdf(tmp_path: Path) -> None:
     docx_file = str(tmp_path / "document.docx")
-    d = Document()
+    d = Document(data=b"test")
 
     with pytest.raises(errors.NonPDFOutputFileException):
         d.output_filename = docx_file
@@ -81,20 +66,18 @@ def test_output_file_not_pdf(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific")
 def test_illegal_output_filename_windows(tmp_path: Path) -> None:
-    d = Document()
-
     for char in '"*:<>?':
         with pytest.raises(errors.IllegalOutputFilenameException):
-            d.output_filename = str(tmp_path / f"illegal{char}name.pdf")
+            Document(
+                data=b"test", output_filename=str(tmp_path / f"illegal{char}name.pdf")
+            )
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="MacOS-specific")
 def test_illegal_output_filename_macos(tmp_path: Path) -> None:
     illegal_name = str(tmp_path / "illegal\\name.pdf")
-    d = Document()
-
     with pytest.raises(errors.IllegalOutputFilenameException):
-        d.output_filename = illegal_name
+        Document(data=b"test", output_filename=illegal_name)
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific")
@@ -200,3 +183,62 @@ def test_mark_as_failed(sample_pdf: str) -> None:
     assert d.is_failed()
     assert not d.is_safe()
     assert not d.is_unconverted()
+
+
+def test_init_with_data(sample_pdf: str) -> None:
+    """Document can be constructed with raw bytes of data."""
+    d = Document(data=b"fake pdf content")
+    assert d._data == b"fake pdf content"
+    with pytest.raises(errors.NotSetInputFilenameException):
+        _ = d.input_filename
+    with pytest.raises(errors.NotSetOutputFilenameException):
+        _ = d.output_filename
+
+    # Providing both input_filename and data raises ValueError.
+    with pytest.raises(ValueError, match="Cannot provide both"):
+        Document(input_filename=sample_pdf, data=b"fake pdf content")
+
+
+def test_open(sample_pdf: str) -> None:
+    """Document.open() always returns a readable file handle."""
+    payload = b"fake pdf content"
+    d = Document(data=payload)
+    with d.open() as f:
+        assert f.read() == payload
+
+    # Document.open() returns a readable file handle when input_filename is set.
+    d = Document(sample_pdf)
+    with d.open() as f:
+        content = f.read()
+        assert len(content) > 0
+
+
+def test_str(sample_pdf: str) -> None:
+    """str() of a document returns the proper representation."""
+    d = Document(data=b"fake pdf content")
+    assert str(d) == "<stdin>"
+
+    d = Document(sample_pdf)
+    assert str(d) == d.input_filename
+
+
+def test_eq(sample_pdf: str) -> None:
+    """A data-based document is never equal to a file-based document."""
+    d1 = Document(data=b"content")
+    d2 = Document(data=b"content")
+    # Different ids (random), so they should NOT be equal
+    assert d1 != d2
+
+    d_file = Document(sample_pdf)
+    assert d_file != d1
+
+    # Two file-based documents pointing to the same file are equal.
+    d_file2 = Document(sample_pdf)
+    assert d_file == d_file2
+
+
+def test_data_output_filename_set(tmp_path: Path) -> None:
+    """Data-based document with output_filename works."""
+    out = str(tmp_path / "safe.pdf")
+    d = Document(data=b"content", output_filename=out)
+    assert d.output_filename == os.path.abspath(out)


### PR DESCRIPTION
Dangerzone CLI now accepts documents via stdin and writes safe PDFs to stdout, following standard Unix pipe conventions:

```
cat file.pdf | dangerzone-cli > safe.pdf
dangerzone-cli - < file.pdf > safe.pdf
dangerzone-cli < file.pdf > safe.pdf
```                                                                                                                                                               

All status output (banner, progress, errors) goes to stderr so stdout stays clean for PDF data. We also take extra care to detect when we can read from stdin and when we can write to stdout, so that we don't mess with the user's TTY.

Fixes #1522
Refs #206
                                                                                                              