### PR TITLE
Make `dangerzone-image prepare-archive` work with new buildkit versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ since 0.4.1, and this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased](https://github.com/freedomofpress/dangerzone/compare/v0.11.0...HEAD)
 
+### Fixed
+
+- Accept OCI image indexes as multi-arch container images, in addition to Docker manifest lists. BuildKit 0.31.0 and later pushes OCI image indexes by default, which made `dangerzone-image prepare-archive` fail with `InvalidMutliArchImage` against newly published images ([#1534](https://github.com/freedomofpress/dangerzone/pulls/1534)).
+
 ### Development changes
 
 - Add a security policy for our project
   ([#1278](https://github.com/freedomofpress/dangerzone/issues/1278))
+
 
 ## [0.11.0](https://github.com/freedomofpress/dangerzone/releases/tag/v0.11.0)
 

--- a/dangerzone/updater/errors.py
+++ b/dangerzone/updater/errors.py
@@ -28,7 +28,7 @@ class RegistryError(UpdaterError):
     """(Base class) An error was found while interacting with the Container Registry"""
 
 
-class InvalidMutliArchImage(RegistryError):
+class InvalidMultiArchImage(RegistryError):
     """The queried image is not a multi-arch image"""
 
 

--- a/dangerzone/updater/registry.py
+++ b/dangerzone/updater/registry.py
@@ -124,8 +124,8 @@ def get_digest_for_arch(image_str: str, architecture: str) -> str:
     """Return the digest of the matching architecture, for the specified image, without the sha256: prefix"""
     manifest = get_manifest(image_str).json()
 
-    if manifest.get("mediaType") != IMAGE_LIST_MEDIA_TYPE:
-        raise errors.InvalidMutliArchImage()
+    if manifest.get("mediaType") not in (IMAGE_LIST_MEDIA_TYPE, IMAGE_INDEX_MEDIA_TYPE):
+        raise errors.InvalidMultiArchImage()
 
     arch_manifests = [
         m["digest"].replace("sha256:", "")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,8 +4,12 @@ from typing import Any
 import pytest
 from pytest_mock import MockerFixture
 
+from dangerzone.updater import errors
 from dangerzone.updater.registry import (
+    IMAGE_INDEX_MEDIA_TYPE,
+    IMAGE_LIST_MEDIA_TYPE,
     Image,
+    get_digest_for_arch,
     get_manifest,
     get_manifest_digest,
     parse_image_location,
@@ -137,6 +141,66 @@ def test_get_manifest(mocker: MockerFixture) -> None:
     # Verify the result
     assert response.status_code == 200
     assert response.json() == manifest_content
+
+
+def _mock_multiarch_manifest(mocker: MockerFixture, media_type: str) -> None:
+    manifest = {
+        "schemaVersion": 2,
+        "mediaType": media_type,
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:amd64digest",
+                "platform": {"architecture": "amd64", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:arm64digest",
+                "platform": {"architecture": "arm64", "os": "linux"},
+            },
+        ],
+    }
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = manifest
+    mocker.patch("dangerzone.updater.registry.get_manifest", return_value=mock_response)
+
+
+@pytest.mark.parametrize("media_type", [IMAGE_LIST_MEDIA_TYPE, IMAGE_INDEX_MEDIA_TYPE])
+def test_get_digest_for_arch(mocker: MockerFixture, media_type: str) -> None:
+    """Both Docker manifest lists and OCI image indexes are valid multi-arch images.
+
+    BuildKit >= 0.31.0 pushes OCI image indexes by default, so we must accept
+    them alongside the legacy Docker manifest list media type.
+    """
+    _mock_multiarch_manifest(mocker, media_type)
+
+    assert get_digest_for_arch("ghcr.io/freedomofpress/dangerzone/v1", "amd64") == (
+        "amd64digest"
+    )
+    assert get_digest_for_arch("ghcr.io/freedomofpress/dangerzone/v1", "arm64") == (
+        "arm64digest"
+    )
+
+
+def test_get_digest_for_arch_not_multiarch(mocker: MockerFixture) -> None:
+    """A single-arch image manifest is not a valid multi-arch image."""
+    manifest = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    }
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = manifest
+    mocker.patch("dangerzone.updater.registry.get_manifest", return_value=mock_response)
+
+    with pytest.raises(errors.InvalidMultiArchImage):
+        get_digest_for_arch("ghcr.io/freedomofpress/dangerzone/v1", "amd64")
+
+
+def test_get_digest_for_arch_missing_arch(mocker: MockerFixture) -> None:
+    _mock_multiarch_manifest(mocker, IMAGE_INDEX_MEDIA_TYPE)
+
+    with pytest.raises(errors.ArchitectureNotFound):
+        get_digest_for_arch("ghcr.io/freedomofpress/dangerzone/v1", "riscv64")
 
 
 def test_get_manifest_digest() -> None:


### PR DESCRIPTION
Accept OCI image indexes as multi-arch container images In addition to Docker manifest lists.

BuildKit 0.31.0 and later pushes OCI image indexes by default, which made `dangerzone-image prepare-archive` fail with `InvalidMutliArchImage` against newly published images.