### PR TITLE
Default to the production apt repository

### DIFF
--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -199,7 +199,7 @@ RUN gpg --keyserver hkps://keys.openpgp.org \
     --recv-keys DE28AB241FA48260FAC9B8BAA7C9B38522604281
 RUN chmod +r /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
 RUN . /etc/os-release && echo "deb [signed-by=/etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg] \
-    https://packages-qa.freedom.press/apt-tools-prod ${{VERSION_CODENAME?}} main" \
+    https://packages{qa}.freedom.press/apt-tools-prod ${{VERSION_CODENAME?}} main" \
     | tee /etc/apt/sources.list.d/fpf-apt-tools.list
 
 RUN apt-get update


### PR DESCRIPTION
Before this change, `env.py` is always and only referring to the QA packages.