### PR TITLE
dev_scripts: Fix a key confusion error in DZ envs

### DIFF
--- a/dev_scripts/env.py
+++ b/dev_scripts/env.py
@@ -689,9 +689,18 @@ class Env:
             install_deps = DOCKERFILE_BUILD_FEDORA_DEPS
         else:
             install_deps = DOCKERFILE_BUILD_DEBIAN_DEPS
-            if self.distro == "ubuntu" and self.version in ("22.04", "jammy"):
+            if (
+                self.distro == "ubuntu"
+                and self.version in ("22.04", "jammy")
+                and not "freedom.press/apt-tools-prod" in dz_install_cmd
+            ):
                 # Ubuntu Jammy requires a more up-to-date conmon
-                # package (see https://github.com/freedomofpress/dangerzone/issues/685)
+                # package (see https://github.com/freedomofpress/dangerzone/issues/685).
+                #
+                # NOTE: If we install Dangerzone from our prod/QA repos, we
+                # shouldn't use this workaround, as these repos should contain the
+                # proper conmon version. Moreover, we confuse the APT command this way,
+                # which sees the same source with different keys (inline vs downloaded).
                 install_deps = DOCKERFILE_CONMON_UPDATE + DOCKERFILE_BUILD_DEBIAN_DEPS
             elif self.distro == "ubuntu" and self.version not in ("22.04", "jammy"):
                 install_deps = DOCKERFILE_UBUNTU_REM_USER + DOCKERFILE_BUILD_DEBIAN_DEPS


### PR DESCRIPTION
Do not add the Jammy workaround for `conmon` if `dev_scripts/env.py` is asked to build a Dangerzone env using the prod or QA repos. This is wrong for two reasons:

1. This workaround is not necessary for these repos, and may even hide a bug.
2. APT may get confused if it sees two different keys for the same APT repo:

       E: Conflicting values set for option Signed-By regarding source https://packages.freedom.press/apt-tools-prod/ jammy: -----BEGIN PGP PUBLIC KEY BLOCK-----
          Comment: DE28 AB24 1FA4 8260 FAC9  B8BA A7C9 B385 2260 4281
          Comment: Dangerzone Release Key <dangerzone-release-key@freedom.
          xsFNBGP2Ey4BEADSudGS33NCAeuUcHqrgNAet4bX6jAPVTNXgOGLK7DYuBNJ0aSR
          1wv+PHaM8la/U2YGD31nKsEsLulzyzrdod8AlbyYPkygaYAJIa7NK7IuOtO6/52R
          unpGkPFzA1oDhmOjUbkNthe3GTqDq6a5U04GRhtbY0U9j0+OREzy18IiTQVTnBRX
          kP8h2H+MaQwI/J2hB7ZF4rRHbzrzfZByWZmxpjxRR56Zfdl8xgp35WDt4ohyo9n6
          LrQZ6Va70EwWRFW2c+SuAF1V3HDdyfkk/NHbD7FWhNByExNCoHiFP1ZMUgqYlQVs
          gAsoW9IEMGayPowMlB1IjhYa65ihyH511nsKP6l8M2cRAfVJTtV3P84JqrWJd9TE
          3koSUa/yi8AO36omUWHHX9rjnj8CHLhk0GEf0c53E7Izad/DTcsVnIs6NT2e7t5u
          O1FUQPFL5gHi0iWI+2jzRGNa/YvGF6amVav5dtus0bObfgPBdBo9UhqgimidX1+N
          T/g25CTKhoUMz4dDycBcJQgeOOpbyPI7W7tpyBNyD3/JCga1+Kj5E+gw+MAFl+KB
          gqaapbXfuIa69WSutOTKINjXVV+Wqn04uMjgcPZP+LCQWN49oS3dCflKEd/mmg63
          8WMuzweDm5gYNCuGHprj3rNUjruVqHzSDwhfDuKtbDjgZ48V9CnwzNe2/wARAQAB
          zT1EYW5nZXJ6b25lIFJlbGVhc2UgS2V5IDxkYW5nZXJ6b25lLXJlbGVhc2Uta2V5
          QGZyZWVkb20ucHJlc3M+wsGRBBMBCAA7FiEE3iirJB+kgmD6ybi6p8mzhSJgQoEF
          AmP2Ey4CGwMFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQp8mzhSJgQoH6
          BhAAkpD8fb4rJVAZuOpxWSNM0EzTjm08aFt9XZqyCxN+j+2737okhjzX5hkTbNgR
          Opn2pAtBEBMXGYzyw/XIg8PKEhY9L0dE5+i0rZwodvdPWMPQ6kHizJQokSc2rWV4
          bjFJrMyS3zXioh8W1zgoHLxvKTBncmdCPRX53Wf4TwZHqgimn03CHHHF9BJBix9d
          8OXJbVBdjB3zRT3VuLxeq73YzNSgUYBjrNf1IYJQKnZzXO9FhfHtaxUnSde2wv9E
          fhTa7fYDQz42zE2GPCcSVFUXmYB/FyHDswJAp7YtTNr8xYZ7ZkV6W1QIEWK9FVC3
          ABcTrMnAGG5OFeNE5C2w5yVM+5f6sJ8H47y9fO8AvEyKRMzsD3c+AOpOgdy+4/6U
          qN0lDB9mP7CXqU5lp7z42QofJtXvUAbzQquZoRZCdEK4N9G0TzUwTkWeeZ+tYgnB
          FkM464DoaF1aZCGIaw3+J7XyweV2TkG9kS95khyszps1iHRUOGYzy0n8twFNWsbe
          /qLZkDtYI28cnKkedHKNAysmtyNIzab+Elc3vni0BEz8d+rn5rG20kjLBDQCZnf9
          UyrXTQ6ahl5UexaJC/3I46g6obHRU6F9+C+JmpRxJxIqJw3jduVB0acTttg8n3F4
          DCUE5Lj/vsE8nlhFi4inU2SMtHBspR5UkKNN5sRDuqac3ovOwU0EY/YT8AEQAM1N
          O3WVV41Ac1SI/fc/NjtKX2wD7GfZERbkPEWFG5n9cY/yoPbYiALKyWhRv7BWFg8e
          j7eEKKuZV6U4zqsnQNTC41LPG3Umq1oWsheeOXS/q7d26nwveL0b2OekUMpjAUkX
          Xboq73UxPyfq9AEzrN2P8AJ6+KBfUx1Croa9Sy49z/94IG1DuJbq5X/9WjNJ6n2d
          zWF0rEnsEKP4bcympi2+hJFOJm3h+GrevOPm5nf3/6N7pRNS3BdW7UsgPfAYOhYL
          2vswNGQu9rDyum11TLzEnTctWDfcnTmvU/cmMup6jx6j8PLotfhT82Ua3DhBiTfC
          RWEEL/vvoiFVmcqOxCX5d7KrSlPUcJR3/438/Rw8W0PlrSW1DT+eMD86uynH4kMs
          FIXGQMZ5OyrPkSQf9RMj93fp6zuh+eqAwOmR460wA/S6q74i0ZD+hTDjz3X178nH
          4CLsl3mGTGu3qlM6wY+gaObzdJFhQsQ014lZ1DuLGRaQY9GVkFftyIUJiDnIJVP2
          Zw8i/3j197cBh4NxAyHRU1m1gP2rhIAh2vT1iA1cXSpf7TZNMFZvYR4IgdWac78Y
          pFuIzFkuFLRYl2oCRp9Q4eS4J/VkoKSe4jGNiPBl+brubsUye7PsWIrUm0ZT2rXa
          cIy/W59zJT6pP2J2yM4TjCsXCyxyrwD3ultOhpNnABEBAAHCw6wEGAEIACAWIQTe
          KKskH6SCYPrJuLqnybOFImBCgQUCY/YT8AIbAgJACRCnybOFImBCgcF0IAQZAQgA
          HRYhBATKvrXddrrPK9Q9L/Osxg9i6lHLBQJj9hPwAAoJEPOsxg9i6lHLrokP/2Mf
          M+z3xy7eT06saDMvJ4X/jkP7c8OwjHcJW6nfwVrxDua/MwZrnNbBvs0uolBbljuG
          B873tCiE5Hx19lUr+o1FUxcMFb6zisSZNZv7FleSYfuyZ2jMMysNrCdATqMJojpj
          XURgr/6LAG/ZEV6egOL7SWQdAw33JBiPLXsRgUeR9QhZjYV+dNDYYzkVlctK7g1h
          mgjKbz7Qu0K4d/nDIUpJlWnNGsmZEObcEQq79GzP6QoUGF86jHurTtJyJYhliyJz
          J+5Ph8hzHSK5H0Z36i+H4LwOL/p4kVJWMRZLLCFXU2IeJk6oDQMkH9fC74b6RB1C
          BbM4AvzxxvgnLdKHBLQ10yum3Iztty7uAg5OMRK+OoZfZpZrcK0uZK1UWjAoHnrr
          h8SqceXwc195ujdnYW+G4Pk3F6OHN7N0Rfp2LN23F/Hbwsz+RKTucCXb8E4cgS14
          4l2O8vaM0VnhKprO5GDk7IY6Q+A7eRnveIMlBitX1Snzgd1+oA5bkCHzEUmQMNUs
          Cqm6iQEqGjEVyRxbCyC+xv+YbpawPm64QSBcR6t0pR3Py9l4HVzVqtN5AHgSN5yp
          NEXEyvhDJT4WEOkJlGwxfGtVzMx01qiWMOjsTzg21qWWvg0+acnU6yMpVxHbG9hb
          Lfz9p42Cc91dUULDg2kVHpOA0+VBkmtKUgNV59rLko8P/jm6JgnJIzNS3a3Zt4HM
          2zGy6r6OpLvgTB4WMRPT/tcxMhky+m/RqNXA3J9U83potE28bc10ZOpCwL/RBt+S
          631Bq2ISFmKCMqVSvlOCGmW4DA52kO82V20E+ijuTMe/bAiarTxeXWkFAptq8Xo1
          6TJdcy4uluhTz23iXeRF09S6Cs6v+RmOTXcRR9FbeLtJhp8h+vhHlqN9JS/k+1dn
          54dRk6ioQO+rrneWSMIqf/Vz9W8YnKMuSP8pCzagGnBsUcZCgDKol01QETgwbUvk
          QTxMsJPT+q/JDBKYuPr073iblJl5S+/so+Ia8NHDJfp5I4q4hKCRMYns4Aur3csU
          kGJiSa+YVx5dkh6FSYBri1yWdu2BMIPVBwR/q4lGv80c64U04PWiVp6Z8SR56PS0
          PJOZYKtgpZ0GJ7ghrv+74HitYYBXBsYc8uP1mfKtuN7AQk7iO8+sttFAAdx5QhQJ
          nn2wsXzbeFDtis3kSH5rjrjRsunTcPzbcf/YfQeBw+rCgAARNKSQTQCu7la161cA
          OJ0bdOpSwHRZdMu4sqpjSUnim54i+6WQi10J3EFiULTRWkT1QLsXL+y/QO7jKWJa
          MaBowvhD9Z4dqreMzFLCpBioJjX5acJhNWeReop3OFjiO2DI/T6sK57Lacqi5PBK
          cFA7AhXOOSdymipReu4BHt/y
          =bwyT
          -----END PGP PUBLIC KEY BLOCK-----
           != /etc/apt/keyrings/fpf-apt-tools-archive-keyring.gpg
       E: The list of sources could not be read.