### PR TITLE
Fix inverted comment in check_suspicious_options

### DIFF
--- a/dangerzone/args.py
+++ b/dangerzone/args.py
@@ -73,7 +73,7 @@ def check_suspicious_options(args: list[str]) -> None:
     try:
         files = set(os.listdir())
     except OSError:
-        # If we can list files in the current working directory, this means that
+        # If we cannot list files in the current working directory, this means that
         # we're probably in an unlinked directory. Dangerzone should still work in
         # this case, so we should return here.
         return


### PR DESCRIPTION
The comment in `check_suspicious_options` sits inside the `except OSError`
branch, so the case it describes is that we *cannot* list the files in the
current directory - which is what makes us conclude we are probably in an
unlinked directory. It currently reads "If we can list files ...", which
says the opposite of the code it explains.

One-line comment change, no behaviour difference.

A note on CI: the changelog check will fail on this PR because
`CHANGELOG.md` is untouched. There is nothing user-visible here to write
up, so I left it alone rather than add a changelog line for a comment
typo - happy to add one if you would rather keep the check green.
