### PR TITLE
Mention Winget in the Windows installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,6 +53,8 @@ You can also install Dangerzone for Mac using [Homebrew](https://brew.sh/): `bre
 > [!TIP]
 > We generally support Windows releases that are still within [Microsoft’s servicing timeline](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet).
 
+You can also install Dangerzone for Windows using [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/): `winget install FreedomofthePressFoundation.Dangerzone`
+
 Podman [sets the bottom line](https://github.com/containers/podman/blob/v5.8.1/docs/tutorials/podman-for-windows.md#prerequisites):
 
 > Since Podman uses WSL, you need a recent release of Windows 10 or Windows 11. On x64, WSL requires build 18362 or later, and 19041 or later is required for arm64 systems. Internally, WSL uses virtualization, so your system must support and have hardware virtualization enabled. If you are running Windows on a VM, you must have a VM that supports nested virtualization.


### PR DESCRIPTION
Fixes #1498.

The Windows section of INSTALL.md only points at the release page, while the macOS section right above it already offers Homebrew as an alternative. This adds the equivalent line for Winget, in the same shape as the Homebrew one.

I checked that `FreedomofthePressFoundation.Dangerzone` is the current package identifier in winget-pkgs and that its latest manifest is 0.11.0, matching the current release.

No CHANGELOG entry: this documents an installation route that already exists rather than changing anything, so I read it as falling under the `no changelog` label. Happy to add an entry instead if you would rather have one.
